### PR TITLE
Reduce amount of generated seed data

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -29,12 +29,12 @@ module.exports = {
     slotDurationMinutes: 8,
 
     // Target percentages
-    targetBookingPercent: 150, // 150% represents overbooking (e.g. 60 bookings for 40 slots)
+    targetBookingPercent: 120, // 150% represents overbooking (e.g. 60 bookings for 40 slots)
     targetAttendancePercent: 100, // 100% of original capacity (not overbooking)
 
     // Date range for generating data
-    daysToGenerate: 7,
-    daysBeforeToday: 3,
+    daysToGenerate: 5,
+    daysBeforeToday: 2,
 
     simulatedTime: '11:30', // 24h format
   },
@@ -57,6 +57,6 @@ module.exports = {
   // Data generation settings
   generation: {
     numberOfParticipants: 1000,
-    bookingProbability: 0.8  // 80% of slots are booked
+    bookingProbability: 0.8, // 80% of slots are booked
   }
 };

--- a/app/lib/generate-seed-data.js
+++ b/app/lib/generate-seed-data.js
@@ -38,8 +38,8 @@ const generateSnapshot = (date, allParticipants, unit) => {
     return age >= 50 && age <= 70;
   });
   
-  // Generate a week of clinics
-  for (let i = 0; i < 7; i++) {
+  // Generate a 5 days of clinics
+  for (let i = 0; i < config.clinics.daysToGenerate; i++) {
     const clinicDate = dayjs(date).add(i, 'day');
     const newClinics = generateClinicsForBSU({
       date: clinicDate.toDate(),
@@ -112,7 +112,7 @@ const generateData = async () => {
     today.subtract(9, 'year').add(3, 'month'),
     today.subtract(6, 'year').add(2, 'month'),
     today.subtract(3, 'year').add(1, 'month'),
-    today.subtract(3, 'days')
+    today.subtract(config.clinics.daysBeforeToday, 'days')
   ];
 
 

--- a/app/lib/generators/clinic-generator.js
+++ b/app/lib/generators/clinic-generator.js
@@ -47,7 +47,9 @@ const generateTimeSlots = (date, sessionTimes, clinicType) => {
       endDateTime: slotEndTime.toISOString(),
       duration: slotDurationMinutes,
       type: clinicType,
-      capacity: clinicType === 'assessment' ? 1 : 2, // Assessment clinics don't double book
+      capacity: 1,
+      // Don't support smart clinics yet
+      // capacity: clinicType === 'assessment' ? 1 : 2, // Assessment clinics don't double book
       bookedCount: 0,
       period: `${sessionTimes.startTime}-${sessionTimes.endTime}`
     });
@@ -124,7 +126,9 @@ const generateClinic = (date, location, breastScreeningUnit, sessionTimes) => {
     targetCapacity: {
       bookingPercent: clinicType === 'assessment' ? 100 : config.clinics.targetBookingPercent,
       attendancePercent: clinicType === 'assessment' ? 95 : config.clinics.targetAttendancePercent,
-      totalSlots: slots.length * (clinicType === 'assessment' ? 1 : 2)
+      totalSlots: slots.length,
+      // not supporting Smart clinics yet
+      // totalSlots: slots.length * (clinicType === 'assessment' ? 1 : 2)
     },
     notes: null,
     sessionTimes,


### PR DESCRIPTION
The prototype has gotten quite laggy on Heroku. I think this is because of too much data being in session data.

As a stopgap I've:
* Reduced number of days of clinics to generate
* Stopped generating smart clinics.
