### PR TITLE
Support test scenarios

### DIFF
--- a/app/data/breast-screening-units.js
+++ b/app/data/breast-screening-units.js
@@ -17,13 +17,13 @@ module.exports = [
     clinicTypes: ['screening', 'assessment'], // Can do both
     // Default operating hours for the BSU
     sessionPatterns: [
-      {
-        name: 'full_day',
-        type: 'single',
-        sessions: [
-          { startTime: '09:00', endTime: '17:00' },
-        ],
-      },
+      // {
+      //   name: 'full_day',
+      //   type: 'single',
+      //   sessions: [
+      //     { startTime: '09:00', endTime: '17:00' },
+      //   ],
+      // },
       {
         name: 'split_day',
         type: 'paired',

--- a/app/data/test-scenarios.js
+++ b/app/data/test-scenarios.js
@@ -1,0 +1,45 @@
+// app/data/test-scenarios.js
+
+/**
+ * Test scenarios define specific participants and events that should always exist
+ * in the generated data. This ensures we have consistent test cases.
+ * 
+ * Only specify what needs to be consistent - any unspecified fields will be randomly generated.
+ * This allows natural variation while maintaining key test conditions.
+ */
+module.exports = [
+  {
+    // The participant data matches our data model
+    participant: {
+      id: 'aab45c3d',
+      demographicInformation: {
+        firstName: 'Susan',
+        lastName: 'Smith',
+        middleName: null,
+        dateOfBirth: '1964-03-15',
+      },
+      extraNeeds: ['Wheelchair user'],
+    },
+    // Scheduling is separate as it relates to clinic/event generation
+    scheduling: {
+      whenRelativeToToday: 0,
+      status: 'checked_in',
+      slotIndex: 20,
+    },
+  },
+  {
+    participant: {
+      id: 'bc724e9f',
+      demographicInformation: {
+        firstName: 'Janet',
+        lastName: 'Williams',
+        dateOfBirth: '1959-07-22',
+      },
+    },
+    scheduling: {
+      whenRelativeToToday: 0,
+      status: 'scheduled', 
+      approximateTime: '10:30',
+    },
+  },
+]

--- a/app/data/test-scenarios.js
+++ b/app/data/test-scenarios.js
@@ -9,37 +9,38 @@
  */
 module.exports = [
   {
-    // The participant data matches our data model
-    participant: {
-      id: 'aab45c3d',
-      demographicInformation: {
-        firstName: 'Susan',
-        lastName: 'Smith',
-        middleName: null,
-        dateOfBirth: '1964-03-15',
-      },
-      extraNeeds: ['Wheelchair user'],
-    },
-    // Scheduling is separate as it relates to clinic/event generation
-    scheduling: {
-      whenRelativeToToday: 0,
-      status: 'checked_in',
-      slotIndex: 20,
-    },
-  },
-  {
     participant: {
       id: 'bc724e9f',
       demographicInformation: {
         firstName: 'Janet',
+        middleName: null,
         lastName: 'Williams',
         dateOfBirth: '1959-07-22',
       },
+      extraNeeds: ['Wheelchair user'],
     },
     scheduling: {
       whenRelativeToToday: 0,
       status: 'scheduled', 
       approximateTime: '10:30',
+    },
+  },
+  {
+    participant: {
+      id: 'aab45c3d',
+      demographicInformation: {
+        firstName: 'Dianna',
+        lastName: 'McIntosh',
+        middleName: 'Rose',
+        dateOfBirth: '1964-03-15',
+      },
+      extraNeeds: null,
+    },
+    scheduling: {
+      whenRelativeToToday: 0,
+      status: 'checked_in',
+      approximateTime: '11:30',
+      // slotIndex: 20,
     },
   },
 ]

--- a/app/lib/generate-seed-data.js
+++ b/app/lib/generate-seed-data.js
@@ -19,7 +19,7 @@ const ethnicities = require('../data/ethnicities')
 // Hardcoded scenarios for user research
 const testScenarios = require('../data/test-scenarios')
 
-// Find a slot  near a target time
+// Find nearest slot at or after the target time
 // Used by test scenarios so we can populate a slot at a given time
 const findNearestSlot = (slots, targetTime) => {
   if (!targetTime) return null
@@ -27,7 +27,17 @@ const findNearestSlot = (slots, targetTime) => {
   const [targetHour, targetMinute] = targetTime.split(':').map(Number)
   const targetMinutes = targetHour * 60 + targetMinute
 
-  return slots.reduce((nearest, slot) => {
+  // Filter to only slots at or after target time
+  const eligibleSlots = slots.filter(slot => {
+    const slotTime = dayjs(slot.dateTime)
+    const slotMinutes = slotTime.hour() * 60 + slotTime.minute()
+    return slotMinutes >= targetMinutes
+  })
+
+  if (eligibleSlots.length === 0) return null
+
+  // Find the nearest from eligible slots
+  return eligibleSlots.reduce((nearest, slot) => {
     const slotTime = dayjs(slot.dateTime)
     const slotMinutes = slotTime.hour() * 60 + slotTime.minute()
     
@@ -40,7 +50,7 @@ const findNearestSlot = (slots, targetTime) => {
     )
 
     return currentDiff < nearestDiff ? slot : nearest
-  }, null)
+  })
 }
 
 const generateClinicsForDay = (date, allParticipants, unit) => {

--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 // List of possible extra needs
 const EXTRA_NEEDS = [
   'Agoraphobia',
-  'Breast implants',
+  // 'Breast implants', // needs consent journey that isn't designed yet
   'Learning difficulties',
   'Physical restriction',
   'Registered disabled',

--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -4,6 +4,7 @@ const { faker } = require('@faker-js/faker')
 const generateId = require('../utils/id-generator')
 const weighted = require('weighted')
 const { generateBSUAppropriateAddress } = require('./address-generator')
+const _ = require('lodash')
 
 // List of possible extra needs
 const EXTRA_NEEDS = [
@@ -184,29 +185,27 @@ const generateParticipant = ({
   ethnicities,
   breastScreeningUnits,
   extraNeedsConfig = { probability: 0.08 },
+  overrides = null,
 }) => {
+
   const id = generateId()
 
-  // Randomly assign to a BSU
-  const assignedBSU = faker.helpers.arrayElement(breastScreeningUnits)
+  // First get or generate BSU
+  const assignedBSU = overrides?.assignedBSU 
+    ? breastScreeningUnits.find(bsu => bsu.id === overrides.assignedBSU)
+    : faker.helpers.arrayElement(breastScreeningUnits)
 
-  // Define ethnicity distributions
-  const ethnicityGroups = Object.keys(ethnicities)
-  const ethnicityWeights = [0.85, 0.08, 0.03, 0.02, 0.02]
+  const ethnicGroup = weighted.select(Object.keys(ethnicities), [0.85, 0.08, 0.03, 0.02, 0.02])
 
-  const ethnicGroup = weighted.select(ethnicityGroups, ethnicityWeights)
-  const ethnicBackground = faker.helpers.arrayElement(ethnicities[ethnicGroup])
-
-  const middleName = Math.random() < 0.3 ? faker.person.firstName('female') : null
-
-  return {
-    id,
-    sxNumber: generateSXNumber(assignedBSU.abbreviation),
+  // Generate base random participant first
+  const baseParticipant = {
+    id: id,
+    sxNumber: generateSXNumber(faker.helpers.arrayElement(breastScreeningUnits).abbreviation),
     assignedBSU: assignedBSU.id,
     extraNeeds: generateExtraNeeds(extraNeedsConfig),
     demographicInformation: {
       firstName: faker.person.firstName('female'),
-      middleName,
+      middleName: Math.random() < 0.3 ? faker.person.firstName('female') : null,
       lastName: faker.person.lastName(),
       dateOfBirth: faker.date.birthdate({
         min: 50,
@@ -217,7 +216,7 @@ const generateParticipant = ({
       phone: generateUKPhoneNumber(),
       email: `${faker.internet.username().toLowerCase()}@example.com`,
       ethnicGroup,
-      ethnicBackground,
+      ethnicBackground: faker.helpers.arrayElement(ethnicities[ethnicGroup]),
     },
     medicalInformation: {
       nhsNumber: generateNHSNumber(),
@@ -234,6 +233,14 @@ const generateParticipant = ({
       medications: generateMedications(),
     },
   }
+
+  if (!overrides) {
+    return baseParticipant
+  }
+
+  // If we have overrides, do a deep merge excluding the scheduling info
+  const { scheduling, ...participantOverrides } = overrides
+  return _.merge({}, baseParticipant, participantOverrides)
 }
 
 // Modified family history generator to add more detail

--- a/app/routes/clinics.js
+++ b/app/routes/clinics.js
@@ -25,12 +25,17 @@ function getClinicData (data, clinicId) {
     }
   })
 
+  // Sort events by appointment time
+  const sortedEvents = [...eventsWithParticipants].sort((a, b) => {
+    return new Date(a.timing.startTime) - new Date(b.timing.startTime)
+  })
+
   // Get screening unit details
   const unit = data.breastScreeningUnits.find(u => u.id === clinic.breastScreeningUnitId)
 
   return {
     clinic,
-    events: eventsWithParticipants,
+    events: sortedEvents,
     unit,
   }
 }

--- a/app/views/clinics/show.html
+++ b/app/views/clinics/show.html
@@ -132,5 +132,4 @@
     </div>
   </dl>
 
-  <a href="/clinics" class="nhsuk-back-link">Back to today's clinics</a>
 {% endblock %}


### PR DESCRIPTION
## Description

* Adds support for test scenarios / hardcoded users for use in usability testing.
* Users can be added in `app/data/test-scenarios/js` and will appear in the first clinic of 'today'. We can set all aspects of a user except their screening history, which is still dynamically generated.
* Hardcodes the first clinic of today to be screening - as that's the scenario we're currently mostly exploring.
* Disables all-day clinics at base - so we'll only get half day clinics at a hospital