### PR TITLE
Check-in inline and no visited links

### DIFF
--- a/app/assets/javascript/main.js
+++ b/app/assets/javascript/main.js
@@ -1,1 +1,47 @@
 // ES6 or Vanilla JavaScript
+
+
+document.addEventListener('DOMContentLoaded', () => {
+
+
+  // Inline check in without requiring page reload
+  const checkInLinks = document.querySelectorAll('.js-check-in-link')
+
+  checkInLinks.forEach(link => {
+    link.addEventListener('click', async (e) => {
+      e.preventDefault()
+      const link = e.currentTarget
+      const clinicId = link.dataset.clinicId
+      const eventId = link.dataset.eventId
+
+      try {
+        const response = await fetch(
+          `/clinics/${clinicId}/check-in/${eventId}`,
+          {
+            method: 'GET',
+            headers: {
+              'Accept': 'application/json'
+            }
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error('Failed to check in participant')
+        }
+
+        // Find the containing element by data attribute
+        const container = document.querySelector(`[data-event-status-container="${eventId}"]`)
+        if (container) {
+          container.innerHTML = `
+            <strong class="nhsuk-tag">
+              Checked in
+            </strong>
+          `
+        }
+      } catch (error) {
+        console.error('Error checking in participant:', error)
+        window.location.href = link.href
+      }
+    })
+  })
+})

--- a/app/assets/javascript/main.js
+++ b/app/assets/javascript/main.js
@@ -44,4 +44,35 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     })
   })
+
+  // Handle clear data link with AJAX
+  const clearDataLinks = document.querySelectorAll('a[href="/clear-data"]')
+  clearDataLinks.forEach(link => {
+    link.addEventListener('click', async (e) => {
+      e.preventDefault()
+      try {
+        const response = await fetch('/clear-data', {
+          method: 'GET',
+          headers: {
+            'Accept': 'application/json'
+          }
+        })
+
+        if (!response.ok) {
+          throw new Error('Failed to clear data')
+        }
+
+        const result = await response.json()
+        if (result.success) {
+          // Refresh the page to reflect the cleared data
+          window.location.reload()
+        } else {
+          throw new Error('Failed to clear data')
+        }
+      } catch (error) {
+        console.error('Error clearing data:', error)
+        window.location.href = link.href
+      }
+    })
+  })
 })

--- a/app/routes/clinics.js
+++ b/app/routes/clinics.js
@@ -216,6 +216,9 @@ module.exports = router => {
     const eventIndex = data.events.findIndex(e => e.id === eventId && e.clinicId === clinicId)
 
     if (eventIndex === -1) {
+      if (req.headers.accept?.includes('application/json')) {
+        return res.status(404).json({ error: 'Event not found' })
+      }
       return res.redirect(`/clinics/${clinicId}/${currentFilter}`)
     }
 
@@ -224,6 +227,9 @@ module.exports = router => {
 
     // Only allow check-in if currently scheduled
     if (event.status !== 'event_scheduled') {
+      if (req.headers.accept?.includes('application/json')) {
+        return res.status(400).json({ error: 'Event cannot be checked in' })
+      }
       return res.redirect(`/clinics/${clinicId}/${currentFilter}`)
     }
 
@@ -243,10 +249,18 @@ module.exports = router => {
     // Save back to session
     req.session.data = data
 
+    // If this was an AJAX request, send JSON response
+    if (req.headers.accept?.includes('application/json')) {
+      return res.json({
+        status: 'success',
+        event: data.events[eventIndex]
+      })
+    }
+
     // If there's a returnTo path, use that, otherwise go back to the filter view
-    const returnTo = req.query.returnTo
-    if (returnTo) {
-      res.redirect(returnTo)
+    const referrer = req.query.referrer
+    if (referrer) {
+      res.redirect(referrer)
     } else {
       res.redirect(`/clinics/${clinicId}/${currentFilter}`)
     }

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -98,10 +98,10 @@ module.exports = router => {
     if (!canBeginScreening) {
       res.redirect(`/clinics/${clinicId}/events/${eventId}`)
     } else if (canBeginScreening === 'yes') {
-      if (req.session.data.events[eventIndex].status !== 'checked_in') {
+      if (req.session.data.events[eventIndex].status !== 'event_checked_in') {
         req.session.data.events[eventIndex] = updateEventStatus(
           req.session.data.events[eventIndex],
-          'checked_in'
+          'event_checked_in'
         )
       }
       res.redirect(`/clinics/${clinicId}/events/${eventId}/medical-background`)

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -15,11 +15,16 @@ module.exports = router => {
     res.redirect('/settings')
   })
 
-  // Handle regenerate data action
+  // Handle clear data action
   router.get('/clear-data', async (req, res) => {
     console.log('Clearing session data')
     req.session.data = {}
     req.flash('success', 'Session data cleared')
+
+    if (req.headers['accept'] === 'application/json') {
+      return res.json({ success: true })
+    }
+
     res.redirect('/settings')
   })
 }

--- a/app/views/_components/event-status/macro.njk
+++ b/app/views/_components/event-status/macro.njk
@@ -1,0 +1,3 @@
+{% macro eventStatus(params) %}
+  {%- include './template.njk' -%}
+{% endmacro %}

--- a/app/views/_components/event-status/template.njk
+++ b/app/views/_components/event-status/template.njk
@@ -1,0 +1,29 @@
+{% from 'tag/macro.njk' import tag %}
+
+{% set tagClasses %}
+  {% if params.event.status | getStatusTagColour %}
+    nhsuk-tag--{{ params.event.status | getStatusTagColour}}
+  {% endif %}
+{% endset %}
+
+<div data-event-status-container="{{ params.event.id }}">
+  {{ tag({
+    text: params.event.status | getStatusText,
+    classes: tagClasses | trim
+  })}}
+
+  {# Build href with optional referrer #}
+  {% set href -%}
+  /clinics/{{ params.clinicId }}/check-in/{{ params.event.id }}
+  {%- if params.referrer %}?referrer={{ params.referrer }}{% endif %}
+  {%- endset %}
+
+  {% if params.event.status === 'event_scheduled' %}
+    <p class="nhsuk-u-margin-top-2">
+      <a href="{{ href | trim }}" class="nhsuk-link nhsuk-link--no-visited-state js-check-in-link" data-clinic-id="{{ params.clinicId }}"
+        data-event-id="{{ params.event.id }}">
+        Check in participant
+      </a>
+    </p>
+  {% endif %}
+</div>

--- a/app/views/_includes/event-header.njk
+++ b/app/views/_includes/event-header.njk
@@ -1,27 +1,18 @@
 {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
 
 {% set statusHtml %}
-  {{ tag({
-    text: event.status | getStatusText,
-    classes: "nhsuk-tag--" + event.status | getStatusTagColour
-  }) }}
-  {% if event.status === 'event_scheduled' %}
-    {% set href -%}
-      /clinics/{{ clinicId }}/check-in/{{ event.id }}?returnTo=/clinics/{{ clinicId }}/events/{{ eventId }}
-    {%- endset %}
-    <p class="nhsuk-u-margin-top-2"><a href="{{href | trim}}">Check in participant</a></p>
-
-  {% endif %}
-  {% if event.status === "event_attended_not_screened" %}
-    <p class="nhsuk-u-margin-top-2">[Reason for not screened here]</p>
-  {% endif %}
+{# Status tag with check-in link #}
+{{ eventStatus({
+  clinicId: clinicId,
+  event: event,
+  referrer: currentUrl
+})}}
 {% endset %}
-
 
 <div class="app-event-header">
   <h1 class="nhsuk-heading-l">
     <span class="nhsuk-caption-l">
-      {{ clinic.clinicType | sentenceCase }} appointment 
+      {{ clinic.clinicType | sentenceCase }} appointment
 
     </span>
     {{ pageHeading }}

--- a/app/views/_includes/screening-cannot-proceed-link.njk
+++ b/app/views/_includes/screening-cannot-proceed-link.njk
@@ -1,0 +1,1 @@
+<p class="nhsuk-u-margin-top-x9"><a class="nhsuk-link nhsuk-link--no-visited-state" href="./attended-not-screened-reason">Screening cannot proceed</a></p>

--- a/app/views/_templates/layout.html
+++ b/app/views/_templates/layout.html
@@ -1,6 +1,6 @@
-<!-- 
+<!--
   This is the main layout where you can:
-    - change the header and footer 
+    - change the header and footer
     - add custom CSS and JavaScript
 -->
 
@@ -9,6 +9,7 @@
 
 {%- from '_components/header/macro.njk' import headerNew %}
 {%- from '_components/count/macro.njk' import appCount %}
+{%- from '_components/event-status/macro.njk' import eventStatus %}
 {%- from '_components/secondary-navigation/macro.njk' import appSecondaryNavigation %}
 
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->

--- a/app/views/clinics/show.html
+++ b/app/views/clinics/show.html
@@ -74,7 +74,7 @@
         {% for event in filteredEvents %}
           {% set participant = data.participants | findById(event.participantId) %}
 
-          <tr>
+          <tr id="event-row-{{event.id}}">
 
             {# Appointment time #}
             <td class="nhsuk-table__cell">{{ event.statusHistory[0].timestamp | formatTime }}</td>
@@ -113,32 +113,15 @@
             {# NHS Number #}
             {# <td class="nhsuk-table__cell">{{ participant.medicalInformation.nhsNumber | formatNhsNumber | noWrap }}</td> #}
 
-            {# Appointment status #}
+            {# Appointment status and check-in #}
             <td class="nhsuk-table__cell">
-              {{ tag({
-                text: event.status | getStatusText,
-                classes: "nhsuk-tag--" + event.status | getStatusTagColour
+              {# Status tag with check-in link #}
+              {{ eventStatus({
+                clinicId: clinicId,
+                event: event,
+                referrer: currentUrl + "#event-row-" + event.id
               })}}
-
-              {% if event.status === 'event_scheduled' %}
-              <div class="nhsuk-u-margin-top-2">
-                {# <br> #}
-                <a href="/clinics/{{ clinicId }}/check-in/{{ event.id }}?currentFilter={{ currentFilter }}" class="nhsuk-link">
-                  {{ "Check in participant" | noWrap }}
-                </a>
-              </div>
-              
-              {% endif %}
             </td>
-
-            {# Check-in action #}
-            {# <td class="nhsuk-table__cell">
-              {% if event.status === 'event_scheduled' %}
-                <a href="/clinics/{{ clinicId }}/check-in/{{ event.id }}?currentFilter={{ currentFilter }}" class="nhsuk-link">
-                  {{ "Check in" | noWrap }}
-                </a>
-              {% endif %}
-            </td> #}
           </tr>
         {% endfor %}
       </tbody>
@@ -146,7 +129,7 @@
   {% endif %}
 
   <h2 class="nhsuk-heading-m">Details</h2>
-  
+
   <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">Location</dt>
@@ -157,17 +140,17 @@
         {% endfor %}
       </dd>
     </div>
-    
+
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">Phone</dt>
       <dd class="nhsuk-summary-list__value">{{ unit.phoneNumber }}</dd>
     </div>
-    
+
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">Date</dt>
       <dd class="nhsuk-summary-list__value">{{ clinic.date | formatDate }}</dd>
     </div>
-    
+
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">Location</dt>
       <dd class="nhsuk-summary-list__value">{{ clinic.locationType | formatWords | sentenceCase }}</dd>
@@ -178,5 +161,9 @@
       <dd class="nhsuk-summary-list__value">{{ clinic.clinicType | sentenceCase }}</dd>
     </div>
   </dl>
+
+{% endblock %}
+
+{% block pageScripts %}
 
 {% endblock %}

--- a/app/views/events/mammography/awaiting-images.html
+++ b/app/views/events/mammography/awaiting-images.html
@@ -28,9 +28,7 @@
   </div>
 
 
-
-
-  <p class="nhsuk-u-margin-top-9"><a href="./attended-not-screened-reason">Screening cannot proceed</a></p>
+  {% include "screening-cannot-proceed-link.njk" %}
 
 {% endblock %}
 

--- a/app/views/events/mammography/medical-background.html
+++ b/app/views/events/mammography/medical-background.html
@@ -48,7 +48,7 @@
     <li>they have noticed any recent changes or symptoms in their breast</li>
     <li>they currently have any other physical or mental health issues</li>
   </ul>
- 
+
   {{ radios({
     idPrefix: "medicalBackgroundQuestion",
     name: "medicalBackgroundQuestion",
@@ -75,7 +75,7 @@
     text: "Continue"
   }) }}
 
-  <p><a href="./attended-not-screened-reason">Screening cannot proceed</a></p>
+  {% include "screening-cannot-proceed-link.njk" %}
 
 {% endblock %}
 

--- a/app/views/events/mammography/medical-details.html
+++ b/app/views/events/mammography/medical-details.html
@@ -20,7 +20,7 @@
 <p>{{params.content}}</p>
 
 <p><a href="#">Provide details</a></p>
-  
+
 {% endmacro %}
 
 
@@ -63,7 +63,7 @@
     {% set valueHtml = "Incomplete" | asHint %}
 
   {% endif %}
-{# 
+{#
 {% set insetHtml %}
 <p>No details recorded. <a href="#">Provide details</a>.</p>
 {% endset %}
@@ -389,7 +389,7 @@
           }
         }
       }) %}
-    
+
   {% endfor %}
 
   {% set medicalInformationCardHtml %}
@@ -443,7 +443,7 @@
     text: "Continue"
   }) }}
 
-  <p><a href="./attended-not-screened-reason">Screening cannot proceed</a></p>
+  {% include "screening-cannot-proceed-link.njk" %}
 
 {% endblock %}
 

--- a/app/views/events/mammography/ready-for-imaging.html
+++ b/app/views/events/mammography/ready-for-imaging.html
@@ -37,8 +37,7 @@
     href: "./awaiting-images"
   }) }}
 
-
-  <p><a href="./attended-not-screened-reason">Screening cannot proceed</a></p>
+  {% include "screening-cannot-proceed-link.njk" %}
 
 {% endblock %}
 

--- a/app/views/events/show.html
+++ b/app/views/events/show.html
@@ -16,6 +16,7 @@
 {% block pageContent %}
 
   {{ participant | log("Participant:") }}
+  {{ event | log("Event:") }}
 
   {% include "event-header.njk" %}
 
@@ -27,17 +28,13 @@
   {% endif %}
 
   {% set statusHtml %}
-    {{ tag({
-      text: event.status | getStatusText,
-      classes: "nhsuk-tag--" + event.status | getStatusTagColour
-    }) }}
-    {% if event.status === 'event_event_scheduled' %}
-      {% set href -%}
-        /clinics/{{ clinicId }}/check-in/{{ event.id }}?returnTo=/clinics/{{ clinicId }}/events/{{ eventId }}
-      {%- endset %}
-      <p class="nhsuk-u-margin-top-2"><a href="{{href | trim}}">Check in participant</a></p>
+    {# Status tag with check-in link #}
+    {{ eventStatus({
+      clinicId: clinicId,
+      event: event,
+      referrer: currentUrl
+    })}}
 
-    {% endif %}
     {% if event.status === "event_attended_not_screened" %}
       <p class="nhsuk-u-margin-top-2">[Reason for not screened here]</p>
     {% endif %}
@@ -47,7 +44,7 @@
   {% set appointmentTimeHtml -%}
     <p>{{ clinic.date | formatDate }} ({{ clinic.date | formatRelativeDate }})</p>
     <p>{{ event.timing.startTime | formatTime }} ({{ event.timing.duration }} minutes)</p>
-    
+
   {% endset %}
 
   {% set specialAppointmentHtml %}
@@ -88,7 +85,7 @@
     {% else %}
      {{ "Not provided" | asHint }}
     {% endif %}
-    
+
   {% endset %}
 
   {% set appointmentHtml %}
@@ -120,7 +117,7 @@
           },
           actions: {
             items: [
-              
+
             ]
           }
         },
@@ -133,7 +130,7 @@
           },
           actions: {
             items: [
-              
+
             ]
           }
         },
@@ -329,7 +326,7 @@ Before you proceed, check the participant’s identity and confirm that their la
       </div>
 
 
-      {# 
+      {#
       ,
           {
             value: "no-identity",

--- a/app/views/participants/index.html
+++ b/app/views/participants/index.html
@@ -43,7 +43,7 @@
 
       <button type="submit" class="nhsuk-button">Search</button>
       {% if search %}
-        <p><a href="/participants">Clear search</a></p>
+        <p><a class="nhsuk-link nhsuk-link--no-visited-state" href="/participants">Clear search</a></p>
       {% endif %}
 
     </form>

--- a/app/views/participants/show.html
+++ b/app/views/participants/show.html
@@ -16,6 +16,7 @@
 {% block pageContent %}
 
   {{ participant | log }}
+  {{ event | log }}
 
   <h1 class="nhsuk-heading-l">
     {{ pageHeading }}
@@ -47,7 +48,7 @@
       rows: [
         {
           key: { text: "Date of last mammogram" },
-          value: { 
+          value: {
             html: lastMammogramDateHtml
           }
         }


### PR DESCRIPTION
## Description
In usability testing a participant was (rightly!) frustrated that when using the 'check in participant' link from the clinic list, the page reloads and your scroll position is lost.

This progressively enhances the function to check in inline where javascript is available.

![manage-inline-check-in](https://github.com/user-attachments/assets/7a5d9a67-e133-489e-9696-0eba66e751fc)

As a fallback it uses an anchor to attempt to scroll to the right place.

Any interesting byproduct is that from the 'scheduled' tab once you've checked in, the participant will stay visible until you refresh the page - this might be quite nice to keep.

I also added an include for the cancel link and set no-visited styles on it.

