### PR TITLE
Generate image data

### DIFF
--- a/app/assets/sass/_misc.scss
+++ b/app/assets/sass/_misc.scss
@@ -1,7 +1,7 @@
 .app-mammogram-image--placeholder {
   background-color: black;
-  width: 150px;
-  height:200px;
+  width: 75px;
+  height:100px;
 
   p {
     color: white;

--- a/app/data/test-scenarios.js
+++ b/app/data/test-scenarios.js
@@ -3,7 +3,7 @@
 /**
  * Test scenarios define specific participants and events that should always exist
  * in the generated data. This ensures we have consistent test cases.
- * 
+ *
  * Only specify what needs to be consistent - any unspecified fields will be randomly generated.
  * This allows natural variation while maintaining key test conditions.
  */
@@ -20,12 +20,15 @@ module.exports = [
         ethnicBackground: null,
       },
       extraNeeds: ['Wheelchair user'],
-      defaultRiskLevel: 'routine',
-    },
-    scheduling: {
-      whenRelativeToToday: 0,
-      status: 'event_scheduled',
-      approximateTime: '10:30',
+      config: {
+        defaultRiskLevel: 'routine',
+        repeatView: 'RMLO',
+        scheduling: {
+          whenRelativeToToday: 0,
+          status: 'event_scheduled',
+          approximateTime: '10:30',
+        },
+      },
     },
   },
   {
@@ -40,13 +43,15 @@ module.exports = [
         ethnicBackground: null,
       },
       extraNeeds: null,
-      defaultRiskLevel: 'routine',
-    },
-    scheduling: {
-      whenRelativeToToday: 0,
-      status: 'event_checked_in',
-      approximateTime: '11:30',
-      // slotIndex: 20,
+      config: {
+        defaultRiskLevel: 'routine',
+        scheduling: {
+          whenRelativeToToday: 0,
+          status: 'event_checked_in',
+          approximateTime: '11:30',
+          // slotIndex: 20,
+        },
+      },
     },
   },
 ]

--- a/app/lib/generators/event-generator.js
+++ b/app/lib/generators/event-generator.js
@@ -141,7 +141,8 @@ const generateEvent = ({ slot, participant, clinic, outcomeWeights, forceStatus 
       // Add mammogram images for completed events
       event.mammogramData = generateMammogramImages({
         startTime: actualStartTime,
-        isSeedData: true
+        isSeedData: true,
+        config: participant.config
       })
     }
 

--- a/app/lib/generators/event-generator.js
+++ b/app/lib/generators/event-generator.js
@@ -5,6 +5,7 @@ const { faker } = require('@faker-js/faker')
 const weighted = require('weighted')
 const dayjs = require('dayjs')
 const config = require('../../config')
+const { generateMammogramImages } = require('./mammogram-generator')
 
 const NOT_SCREENED_REASONS = [
   'Recent mammogram at different facility',
@@ -114,9 +115,6 @@ const generateEvent = ({ slot, participant, clinic, outcomeWeights, forceStatus 
       ...eventBase,
       details: {
         ...eventBase.details,
-        imagesTaken: eventStatus === 'event_complete'
-          ? ['RCC', 'LCC', 'RMLO', 'LMLO']
-          : null,
         notScreenedReason: eventStatus === 'event_attended_not_screened'
           ? faker.helpers.arrayElement(NOT_SCREENED_REASONS)
           : null,
@@ -139,6 +137,12 @@ const generateEvent = ({ slot, participant, clinic, outcomeWeights, forceStatus 
         actualEndTime: actualEndTime.toISOString(),
         actualDuration: actualEndTime.diff(actualStartTime, 'minute'),
       }
+
+      // Add mammogram images for completed events
+      event.mammogramData = generateMammogramImages({
+        startTime: actualStartTime,
+        isSeedData: true
+      })
     }
 
     return event

--- a/app/lib/generators/mammogram-generator.js
+++ b/app/lib/generators/mammogram-generator.js
@@ -16,14 +16,13 @@ const REPEAT_REASONS = [
   'patient movement',
   'positioning issue',
   'exposure issue',
-  'breast not fully imaged',
   'blurred image',
   'technical fault'
 ]
 
 // Probability settings for repeats
 const REPEAT_PROBABILITIES = {
-  needsRepeat: 0.15, // 15% chance of needing any repeat
+  needsRepeat: 0.35, // 15% chance of needing any repeat
   multipleRepeats: 0.2 // 20% chance of needing more than one repeat if already repeating
 }
 
@@ -63,8 +62,8 @@ const generateViewImages = ({ side, view, accessionBase, startIndex, startTime, 
     url: generateImageUrl(side, view, `${accessionBase}/${currentIndex}`)
   })
 
-  // Generate repeats if needed (and if we're in seed mode or randomly need them)
-  if (needsRepeat && isSeedData) {
+  // Generate repeats if needed
+  if (needsRepeat) {
     const repeatCount = Math.random() < REPEAT_PROBABILITIES.multipleRepeats ? 2 : 1
 
     for (let i = 0; i < repeatCount; i++) {
@@ -82,6 +81,8 @@ const generateViewImages = ({ side, view, accessionBase, startIndex, startTime, 
   return {
     side,
     view,
+    viewShort: view === 'mediolateral oblique' ? 'MLO' : 'CC',
+    viewShortWithSide: `${side === 'right' ? 'R' : 'L'}${view === 'mediolateral oblique' ? 'MLO' : 'CC'}`,
     images,
     isRepeat: needsRepeat && isSeedData,
     repeatReason: needsRepeat && isSeedData ? faker.helpers.arrayElement(REPEAT_REASONS) : null

--- a/app/lib/generators/mammogram-generator.js
+++ b/app/lib/generators/mammogram-generator.js
@@ -1,0 +1,145 @@
+// app/lib/generators/mammogram-generator.js
+
+const { faker } = require('@faker-js/faker')
+const generateId = require('../utils/id-generator')
+const dayjs = require('dayjs')
+const weighted = require('weighted')
+
+const STANDARD_VIEWS = [
+  { side: 'right', view: 'mediolateral oblique' },
+  { side: 'right', view: 'craniocaudal' },
+  { side: 'left', view: 'craniocaudal' },
+  { side: 'left', view: 'mediolateral oblique' }
+]
+
+const REPEAT_REASONS = [
+  'patient movement',
+  'positioning issue',
+  'exposure issue',
+  'breast not fully imaged',
+  'blurred image',
+  'technical fault'
+]
+
+// Probability settings for repeats
+const REPEAT_PROBABILITIES = {
+  needsRepeat: 0.15, // 15% chance of needing any repeat
+  multipleRepeats: 0.2 // 20% chance of needing more than one repeat if already repeating
+}
+
+const generateViewKey = (side, view) => {
+  const prefix = side === 'right' ? 'right' : 'left'
+  const viewName = view === 'mediolateral oblique' ? 'MediolateralOblique' : 'Craniocaudal'
+  return `${prefix}${viewName}`
+}
+
+const generateImageUrl = (side, view, accessionNumber) => {
+  const sideCode = side === 'right' ? 'R' : 'L'
+  const viewCode = view === 'mediolateral oblique' ? 'MLO' : 'CC'
+  return `/images/mammograms/${sideCode}-${viewCode}-${accessionNumber.replace('/', '-')}.dcm`
+}
+
+/**
+ * Generate images for a single view
+ * @param {Object} params - Parameters for image generation
+ * @param {string} params.side - Breast side ('right' or 'left')
+ * @param {string} params.view - View type ('mediolateral oblique' or 'craniocaudal')
+ * @param {string} params.accessionBase - Base accession number
+ * @param {number} params.startIndex - Starting index for image numbering
+ * @param {string} params.startTime - Start timestamp
+ * @param {boolean} params.isSeedData - Whether generating seed data or live data
+ * @returns {Object} View data with images
+ */
+const generateViewImages = ({ side, view, accessionBase, startIndex, startTime, isSeedData }) => {
+  let currentIndex = startIndex
+  let currentTime = dayjs(startTime)
+  const images = []
+  const needsRepeat = Math.random() < REPEAT_PROBABILITIES.needsRepeat
+
+  // Generate initial image
+  images.push({
+    timestamp: currentTime.toISOString(),
+    accessionNumber: `${accessionBase}/${currentIndex}`,
+    url: generateImageUrl(side, view, `${accessionBase}/${currentIndex}`)
+  })
+
+  // Generate repeats if needed (and if we're in seed mode or randomly need them)
+  if (needsRepeat && isSeedData) {
+    const repeatCount = Math.random() < REPEAT_PROBABILITIES.multipleRepeats ? 2 : 1
+
+    for (let i = 0; i < repeatCount; i++) {
+      currentIndex++
+      currentTime = currentTime.add(faker.number.int({ min: 25, max: 50 }), 'seconds')
+
+      images.push({
+        timestamp: currentTime.toISOString(),
+        accessionNumber: `${accessionBase}/${currentIndex}`,
+        url: generateImageUrl(side, view, `${accessionBase}/${currentIndex}`)
+      })
+    }
+  }
+
+  return {
+    side,
+    view,
+    images,
+    isRepeat: needsRepeat && isSeedData,
+    repeatReason: needsRepeat && isSeedData ? faker.helpers.arrayElement(REPEAT_REASONS) : null
+  }
+}
+
+/**
+ * Generate a complete set of mammogram images
+ * @param {Object} options - Generation options
+ * @param {Date|string} [options.startTime] - Starting timestamp (defaults to now)
+ * @param {boolean} [options.isSeedData=false] - Whether generating seed data
+ * @returns {Object} Complete mammogram data
+ */
+const generateMammogramImages = ({ startTime = new Date(), isSeedData = false } = {}) => {
+  const accessionBase = faker.number.int({ min: 100000000, max: 999999999 }).toString()
+  let currentIndex = 1
+  let currentTime = dayjs(startTime)
+  const views = {}
+
+  // Generate each standard view
+  STANDARD_VIEWS.forEach(({ side, view }) => {
+    const viewKey = generateViewKey(side, view)
+    const viewData = generateViewImages({
+      side,
+      view,
+      accessionBase,
+      startIndex: currentIndex,
+      startTime: currentTime.toISOString(),
+      isSeedData
+    })
+
+    views[viewKey] = viewData
+
+    // Update counters for next view
+    currentIndex += viewData.images.length
+    currentTime = currentTime.add(faker.number.int({ min: 45, max: 70 }), 'seconds')
+  })
+
+  // Calculate metadata
+  const totalImages = Object.values(views).reduce((sum, view) => sum + view.images.length, 0)
+  const allTimestamps = Object.values(views)
+    .flatMap(view => view.images.map(img => img.timestamp))
+    .sort()
+
+  return {
+    accessionBase,
+    views,
+    metadata: {
+      totalImages,
+      standardViewsCompleted: true,
+      startTime: allTimestamps[0],
+      endTime: allTimestamps[allTimestamps.length - 1]
+    }
+  }
+}
+
+module.exports = {
+  generateMammogramImages,
+  STANDARD_VIEWS,
+  REPEAT_REASONS
+}

--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -47,7 +47,7 @@ const generateEthnicity = (ethnicities) => {
   }
 
   const ethnicGroup = weighted.select(Object.keys(ethnicities), [0.85, 0.08, 0.03, 0.02, 0.02])
-  
+
   // 20% chance of having background set to "Not provided"
   if (Math.random() < 0.2) {
     return {
@@ -262,18 +262,17 @@ const generateParticipant = ({
   const id = generateId()
 
   // Determine risk level first as it affects age generation
-  const participantRiskLevel = overrides?.defaultRiskLevel || riskLevel || pickRiskLevel()
+  const participantRiskLevel = overrides?.config?.defaultRiskLevel || riskLevel || pickRiskLevel()
 
   // const participantRiskLevel = 'moderate'
 
   // First get or generate BSU
-  const assignedBSU = overrides?.assignedBSU 
+  const assignedBSU = overrides?.assignedBSU
     ? breastScreeningUnits.find(bsu => bsu.id === overrides.assignedBSU)
     : faker.helpers.arrayElement(breastScreeningUnits)
 
   // Generate ethnicity data using new function
   const ethnicityData = generateEthnicity(ethnicities)
-  console.log(ethnicityData)
 
   // Generate base random participant first
   const baseParticipant = {

--- a/app/lib/utils/objects.js
+++ b/app/lib/utils/objects.js
@@ -1,0 +1,56 @@
+// app/lib/utils/objects.js
+
+const _ = require('lodash')
+
+/**
+ * Extract all values from an object into a flat array
+ * @param {Object} obj - The object to extract values from
+ * @param {Object} [options] - Options for value extraction
+ * @param {boolean} [options.recursive=false] - Whether to recursively extract values from nested objects
+ * @param {boolean} [options.includeArrays=true] - Whether to include array values
+ * @param {boolean} [options.removeEmpty=false] - Whether to remove null/undefined values
+ * @returns {Array} Array of all values from the object
+ * @example
+ * getObjectValues({ name: 'Jane', age: 30 }) // Returns ['Jane', 30]
+ * getObjectValues({ user: { name: 'Jane' }}, { recursive: true }) // Returns ['Jane']
+ */
+const getObjectValues = (obj, options = {}) => {
+  const {
+    recursive = false,
+    includeArrays = true,
+    removeEmpty = false
+  } = options
+
+  if (!obj || typeof obj !== 'object') {
+    return []
+  }
+
+  // Get initial values
+  let values = Object.values(obj)
+
+  if (recursive) {
+    values = values.reduce((acc, val) => {
+      // If value is an object, recursively get its values
+      if (val && typeof val === 'object' && !Array.isArray(val)) {
+        return [...acc, ...getObjectValues(val, options)]
+      }
+      return [...acc, val]
+    }, [])
+  }
+
+  // Handle arrays based on options
+  if (!includeArrays) {
+    values = values.filter(val => !Array.isArray(val))
+  }
+
+  // Remove empty values if specified
+  if (removeEmpty) {
+    values = values.filter(val => val !== null && val !== undefined)
+  }
+
+  return values
+}
+
+module.exports = {
+  getObjectValues
+}

--- a/app/lib/utils/strings.js
+++ b/app/lib/utils/strings.js
@@ -1,5 +1,8 @@
 // app/lib/utils/strings.js
 
+const pluralizeLib = require('pluralize')
+
+
 /**
  * Convert string to sentence case, removing leading/trailing whitespace
  * @param {string} input - String to convert
@@ -240,6 +243,28 @@ const formatNhsNumber = (input) => {
 // formatNhsNumber(4857773456)   // returns '485 777 3456'
 // formatNhsNumber('485 777 3456') // returns '485 777 3456'
 
+/**
+ * Make a word plural based on a count
+ * @param {string} word - Word to pluralise
+ * @param {...*} args - Additional arguments (e.g. count) passed to pluralise
+ * @returns {string} Pluralized word
+ * @example
+ * pluralise('cat') // returns 'cats'
+ * pluralise('cat', 1) // returns 'cat'
+ * pluralise('cat', '2') // returns 'cats'
+ */
+const pluralise = (word, ...args) => {
+  if (!word) return ''
+  if (typeof word !== 'string') return word
+
+  // Convert first arg to number if it looks like one
+  if (args.length && !isNaN(args[0])) {
+    args[0] = Number(args[0])
+  }
+
+  return pluralizeLib(word, ...args)
+}
+
 module.exports = {
   addIndefiniteArticle,
   formatCurrency,
@@ -260,4 +285,5 @@ module.exports = {
   startsWith,
   stringLiteral,
   formatPhoneNumber,
+  pluralise
 }

--- a/app/routes/clinics.js
+++ b/app/routes/clinics.js
@@ -278,8 +278,20 @@ module.exports = router => {
       return res.redirect('/clinics')
     }
 
+    let defaultFilter = 'remaining'
+    let remainingCount = filterEventsByStatus(clinicData.events, 'remaining').length
+
+    if (clinicData.clinic?.status == 'scheduled') {
+      defaultFilter = 'all'
+    }
+    else if (clinicData.clinic?.status == 'closed' || remainingCount == 0) {
+      defaultFilter = 'complete'
+    }
+
+    console.log(clinicData)
+
     // Check filter from either URL param or query string
-    const filter = req.params.filter || req.query.filter || 'remaining'
+    const filter = req.params.filter || req.query.filter || defaultFilter
 
     // Validate filter
     if (!VALID_FILTERS.includes(filter)) {

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -95,8 +95,6 @@ module.exports = router => {
     const canBeginScreening = data.beginScreening
     delete data.beginScreening
 
-    // console.log({data})
-
     const eventIndex = req.session.data.events.findIndex(e => e.id === eventId)
 
     if (!canBeginScreening) {
@@ -126,8 +124,9 @@ module.exports = router => {
 
   // Specific route for imaging view
   router.get('/clinics/:clinicId/events/:eventId/imaging', (req, res) => {
-    const { eventId } = req.params
+    const { clinicId, eventId } = req.params
     const event = req.session.data.events.find(e => e.id === eventId)
+    const eventData = getEventData(req.session.data, clinicId, eventId)
 
     // If no mammogram data exists, generate it
     if (!event.mammogramData) {
@@ -136,7 +135,8 @@ module.exports = router => {
       const startTime = dayjs().subtract(3, 'minutes').toDate()
       const mammogramData = generateMammogramImages({
         startTime,
-        isSeedData: false
+        isSeedData: false,
+        config: eventData?.participant?.config,
       })
 
       // Update both session data and locals

--- a/app/views/_includes/fake-images.njk
+++ b/app/views/_includes/fake-images.njk
@@ -43,7 +43,7 @@
 {% macro makeImage(params) %}
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-quarter">
-    
+
     <div class="app-mammogram-image--placeholder">
       <img class="nhsuk-image__img {{ 'app-image-flip-horizontal' if params.side == 'Right' }}" src="/images/mammograms/nci-vol-9405-72.jpg" alt="Close-up of a person’s tummy showing a number of creases in the skin under their belly button. Shown on light brown skin.">
       <p>[IMAGE HERE]</p>
@@ -51,89 +51,25 @@
   </div>
   <div class="nhsuk-grid-column-three-quarters">
 
-    {# {
-          key: {
-            text: "Side"
-          },
-          value: {
-            text: params.side
-          },
-          actions: {
-            items: [
-              {
-                href: "#",
-                text: "Change",
-                visuallyHiddenText: "side"
-              }
-            ]
-          }
-        }, #}
+
     {{ summaryList({
       classes: "nhsuk-u-margin-bottom-0",
       rows: [
         {
           key: {
-            text: "View"
+            text: "Captured"
           },
           value: {
             text: params.view
-          },
-          actions: {
-            items: [
-              {
-                href: "#",
-                text: "Change",
-                visuallyHiddenText: "view"
-              }
-            ]
           }
         },
         {
           key: {
-            text: "Is a repeat"
+            text: "Accession"
           },
           value: {
             html: params.repeat or "No"
-          },
-          actions: {
-            items: [
-              {
-                href: "#",
-                text: "Change",
-                visuallyHiddenText: "is a repeat"
-              }
-            ]
           }
-        },
-        {
-          key: {
-            text: "Comment"
-          },
-          value: {
-            text: params.comment or "Not provided"
-          },
-          actions: {
-            items: [
-              {
-                href: "#",
-                text: "Change",
-                visuallyHiddenText: "is a repeat"
-              }
-            ]
-          }
-        },
-        {
-          key: {
-            text: "Details",
-            classes: "foo"
-          },
-          value: {
-            html: params.details or "Not provided"
-          },
-          actions: {
-            items: []
-          },
-          classes: "nhsuk-summary-list--no-border"
         }
       ]
     }) }}
@@ -169,10 +105,10 @@
         {% set detailsHtml -%}
         Captured:
         {{ timeNow | formatDate("D MMMM YYYY HH:mm:ss")}}
-        Accession: 
+        Accession:
         9583011-14/{{loop.index}}
         {%- endset %}
-        
+
 
         {% set params = {
           view: image.view,
@@ -192,16 +128,144 @@
       {% endfor %}
     {% endset %}
 
-    {{ card({
+    {# {{ card({
       heading: heading,
       headingLevel: "2",
       feature: true,
       descriptionHtml: imageSideHtml
-    }) }}
-    
+    }) }} #}
+
   {% endfor %}
 
-  
+  {# Convert object to an array of views #}
+  {% set mammogramViews = event.mammogramData.views | getObjectValues %}
+
+  {# Group views by view name so we get MLO or CC only #}
+  {% set groupedViews = mammogramViews | groupby("viewShort") %}
+
+  {# Iterate through each view - they should be in a set / known order #}
+  {# Todo: this won't handle cases where entire views are missing - should we iterate
+  through a hardcoded list and show gaps where there are any? #}
+  {% for viewName, view in groupedViews %}
+
+    {# General view name - "MLO views" #}
+    {% set viewNameString %}
+      {{ viewName }} views
+    {% endset %}
+
+    {# Capture html for entire view #}
+    {% set viewCardHtml %}
+
+      {# Left then right #}
+      {% for side in view %}
+        <div class="{{ 'nhsuk-u-margin-bottom-3' if not loop.last }}">
+          <h2>
+            {{ side.images | length }} {{ side.viewShortWithSide }} {{ "images" | pluralise(side.images | length) }}
+          </h2>
+
+          {# Loop through each image for each side #}
+          {% for image in side.images %}
+            <div class="nhsuk-grid-row {{ 'nhsuk-u-margin-bottom-3' if not loop.last }}">
+              <div class="nhsuk-grid-column-three-quarters">
+                {{ summaryList({
+                  classes: "nhsuk-u-margin-bottom-0",
+                  rows: [
+                    {
+                      key: {
+                        text: "Captured"
+                      },
+                      value: {
+                        text: image.timestamp | formatDateTime
+                      }
+                    },
+                    {
+                      key: {
+                        text: "Accession"
+                      },
+                      value: {
+                        html: image.accessionNumber
+                      }
+                    }
+                  ]
+                }) }}
+              </div>
+              {# Small graphic of mammogram #}
+              <div class="nhsuk-grid-column-one-quarter">
+                <div class="app-mammogram-image--placeholder">
+                  <img class="nhsuk-image__img {{ 'app-image-flip-horizontal' if side.side == 'right' }}" src="/images/mammograms/nci-vol-9405-72.jpg" alt="Mammogram image">
+                  <p>[IMAGE HERE]</p>
+                </div>
+              </div>
+            </div>
+
+          {# If there are no images, show inset text - likely partial mammography #}
+          {% else %}
+            {% set insetHtml %}
+              <p>There are no {{ side.viewShortWithSide }} images</p>
+            {% endset %}
+            {{ insetText({
+              html: insetHtml
+            }) }}
+          {% endfor %}
+
+          {# If there are repeats, show repeat ui #}
+          {% if side.images | length > 1 %}
+
+            <div class="nhsuk-grid-row">
+              <div class="nhsuk-grid-column-two-thirds nhsuk-u-margin-top-3">
+                {% set repeatReasonHtml %}
+                  {{ input({
+                    label: {
+                      text: "Repeat reason"
+                    },
+                    id: "repeatReason",
+                    name: "repeatReason" + side.viewShortWithSide,
+                    value: side.repeatReason
+                  }) }}
+                {% endset %}
+
+                {{ radios({
+                  idPrefix: "isRepeatQuestion-" + side.viewShortWithSide,
+                  name: "isRepeatQuestion-" + side.viewShortWithSide,
+                  fieldset: {
+                    legend: {
+                      text: "Why are there multiple " + side.viewShortWithSide + " images?",
+                      classes: "nhsuk-fieldset__legend--s",
+                      isPageHeading: false
+                    }
+                  },
+                  items: [
+                    {
+                      value: "isRepeat",
+                      text: "A repeat was needed",
+                      checked: true,
+                      conditional: {
+                        html: repeatReasonHtml
+                      }
+                    },
+                    {
+                      value: "extraImages",
+                      text: "Additional images were required to capture complete view"
+                    }
+                  ]
+                }) }}
+              </div>
+            </div>
+
+          {% endif %}
+        </div>
+
+      {% endfor %}
+
+    {% endset %}
+
+    {{ card({
+      heading: viewNameString | sentenceCase,
+      headingLevel: "2",
+      feature: true,
+      descriptionHtml: viewCardHtml
+    }) }}
+  {% endfor %}
 </div>
 
 
@@ -216,12 +280,12 @@
         // Hide spinner after initial delay
         setTimeout(() => {
           loadingSpinner.classList.add('app-hidden')
-          
+
           // Show each image sequentially
           imageCards.forEach((card, index) => {
             // Increased time between images to 2 seconds
             const loadTime = 1000 + (index * 2000)
-            
+
             setTimeout(() => {
               card.classList.remove('app-hidden')
               card.style.opacity = 0

--- a/app/views/clinics/show.html
+++ b/app/views/clinics/show.html
@@ -13,7 +13,7 @@
   {# {% set events = data.events | getClinicEvents(clinicId) %} #}
   {% set events = allEvents %}
 
-  {{ clinic | log }}
+  {{ clinic | log("Clinic") }}
 
   {% set clinicRiskType %}
     {% if clinic.riskLevels | length == 1 %}
@@ -44,13 +44,27 @@
 
   {% set secondaryNavItems = [] %}
 
-  {#     { id: 'scheduled', label: 'Scheduled' }, #}
-  {% for filter in [
+  {% set tabItems = [
     { id: 'remaining', label: 'Remaining' },
     { id: 'checked-in', label: 'Checked in' },
     { id: 'complete', label: 'Complete' },
     { id: 'all', label: 'All' }
   ] %}
+
+  {% set remainingCount = events | filterEventsByStatus(filter.id) | length %}
+
+  {% if clinic.status == 'closed' or remainingCount == 0 %}
+    {% set tabItems = [
+      { id: 'complete', label: 'Complete' },
+      { id: 'all', label: 'All' }
+    ] %}
+  {% elseif clinic.status == "scheduled" %}
+    {% set tabItems = [
+      { id: 'all', label: 'All' }
+    ] %}
+  {% endif %}
+
+  {% for filter in tabItems %}
     {% set href -%}
       /clinics/{{ clinicId }}/{{ filter.id if filter.id !== 'remaining' }}
     {% endset %}
@@ -59,13 +73,14 @@
       href: href | trim,
       current: true if filter.id == status
     }) %}
-
   {% endfor %}
 
-  {{ appSecondaryNavigation({
-    visuallyHiddenTitle: "Secondary menu",
-    items: secondaryNavItems
-  }) }}
+  {% if clinic.status !== "scheduled" %}
+    {{ appSecondaryNavigation({
+      visuallyHiddenTitle: "Secondary menu",
+      items: secondaryNavItems
+    }) }}
+  {% endif %}
 
   {# This probably shouldn't occur #}
   {% if filteredEvents.length === 0 %}

--- a/app/views/events/mammography/imaging.html
+++ b/app/views/events/mammography/imaging.html
@@ -10,7 +10,7 @@
 
 {% block pageContent %}
 
-  {{ participant | log }}
+  {{ participant | log("Participant") }}
 
   {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
 


### PR DESCRIPTION
## Description

This pr primarily does two things:
* adds mammogram image generation to seed data
* refactors the image pages to be view centric rather than left / right centric

As part of being view centric, the question about repeats now applies to the view as a whole rater than an image.

![localhost_3000_clinics_vts0mncf_events_ft4ih102_imaging](https://github.com/user-attachments/assets/b864f4ed-5c33-4008-8cb7-5a5db3623056)

The tabs shown on a clinic are now dynamic based on status. If the clinic is completed, they just show two tabs. If the clinic is upcoming, there are no tabs.

![Screenshot 2025-02-04 at 10 53 30](https://github.com/user-attachments/assets/5811c465-7f57-41ad-8768-bbddf781a4c0)

