### PR TITLE
Rework so include is about appointment history rather than screening history

### DIFF
--- a/app/views/_includes/summary-lists/screening-appointment-history.njk
+++ b/app/views/_includes/summary-lists/screening-appointment-history.njk
@@ -1,4 +1,4 @@
-{# /app/views/_includes/summary-lists/screening-history.njk #}
+{# /app/views/_includes/summary-lists/screening-appointment-history.njk #}
 
 {% set today = "" | today %}
 {% set upcomingAppointments = [] %}
@@ -13,7 +13,7 @@
 {% endfor %}
 {% if not hideUpcoming %}
   {% if upcomingAppointments.length > 0 %}
-    <h3>Upcoming appointments</h3>
+    <h3>Upcoming</h3>
     <table class="nhsuk-table">
      <thead>
        <tr>
@@ -53,7 +53,7 @@
 
 
 {% if pastAppointments.length > 0 %}
- <h3>Screening history</h3>
+ <h3>Previous</h3>
  <table class="nhsuk-table">
    <thead>
      <tr>

--- a/app/views/events/show.html
+++ b/app/views/events/show.html
@@ -243,7 +243,7 @@
 
     {% set detailsHtml %}
       {% set hideUpcoming = true %}
-      {% include "summary-lists/screening-history.njk" %}
+      {% include "summary-lists/screening-appointment-history.njk" %}
     {% endset %}
 
     {% if clinicHistory | length > 1 %}

--- a/app/views/participants/show.html
+++ b/app/views/participants/show.html
@@ -43,11 +43,11 @@
   }) }}
 
   {% set screeningHistoryHtml %}
-    {% include "summary-lists/screening-history.njk" %}
+    {% include "summary-lists/screening-appointment-history.njk" %}
   {% endset %}
 
   {{ card({
-    heading: "Screening history",
+    heading: "Appointments",
     headingLevel: "2",
     descriptionHtml: screeningHistoryHtml
   }) }}


### PR DESCRIPTION
Minor updates to content to refocus this card on appointment history rather than screening history.

Longer term the goal is probably to show prior episodes and upcoming / current appointments - but we haven't yet modelled how episodes might work, and are less likely to be able to ingest this data in the short term - starting with appointments is probably the easier first step.