### PR TITLE
Fix nested query strings and section statuses

### DIFF
--- a/app.js
+++ b/app.js
@@ -225,6 +225,10 @@ app.use(locals(config))
 app.set('view engine', 'html')
 exampleTemplatesApp.set('view engine', 'html')
 
+// Support for parsing nested query strings
+// https://github.com/nhsuk/nhsuk-prototype-kit/issues/644
+app.set('query parser', 'extended')
+
 // This setting trusts the X-Forwarded headers set by
 // a proxy and uses them to set the standard header in
 // req. This is needed for hosts like Heroku.

--- a/app/assets/javascript/expandable-sections.js
+++ b/app/assets/javascript/expandable-sections.js
@@ -45,6 +45,8 @@ document.addEventListener('DOMContentLoaded', function () {
           newStatus = 'Complete'
         } else if (currentStatus === 'To review') {
           newStatus = 'Reviewed'
+        } else if (currentStatus === 'Reviewed') {
+          newStatus = 'Reviewed' // Keep as reviewed
         } else {
           newStatus = 'Complete' // Default fallback
         }


### PR DESCRIPTION
## Description

Fixes for:
* Nested query params not working (which broke our images tab)
* Tag statuses could go wrong in the review medical information tab