### PR TITLE
Reading session – summary in progress, end state

### DIFF
--- a/app/assets/sass/components/_dark-mode.scss
+++ b/app/assets/sass/components/_dark-mode.scss
@@ -32,6 +32,9 @@ $app-tag--yellow-dark-text: nhsuk-tint(nhsuk-colour("yellow"), 50%);
 $app-tag--blue-dark-background: nhsuk-shade(nhsuk-colour("blue"), 30%);
 $app-tag--blue-dark-border: nhsuk-tint(nhsuk-colour("blue"), 80%);
 $app-tag--blue-dark-text: nhsuk-tint(nhsuk-colour("blue"), 80%);
+$app-tag--aqua-green-dark-background: nhsuk-shade(nhsuk-colour("aqua-green"), 50%);
+$app-tag--aqua-green-dark-border: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
+$app-tag--aqua-green-dark-text: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
 
 @mixin app-dark-mode-focused-text {
   background-color: $nhsuk-focus-colour;
@@ -263,6 +266,12 @@ $app-tag--blue-dark-text: nhsuk-tint(nhsuk-colour("blue"), 80%);
     color: $app-tag--blue-dark-text;
   }
 
+  .nhsuk-tag--aqua-green {
+    background-color: $app-tag--aqua-green-dark-background;
+    border-color: $app-tag--aqua-green-dark-border;
+    color: $app-tag--aqua-green-dark-text;
+  }
+
   .app-reading-compare-card.nhsuk-card--feature {
     &.app-reading-compare-card--normal {
       outline-color: $app-tag--green-dark-border;
@@ -364,6 +373,17 @@ $app-tag--blue-dark-text: nhsuk-tint(nhsuk-colour("blue"), 80%);
     }
   }
 
+  // Reading batch: highlighted "next case" row uses card surface colour so it
+  // appears as a raised grey slab on top of the dark background
+  .app-placeholder-row--next td {
+    background-color: $app-dark-mode-surface;
+  }
+
+  // Reading batch: placeholder rectangle for pending lazy-batch slots
+  .app-placeholder-tag {
+    background-color: nhsuk-shade($app-dark-mode-text-colour, 60%);
+  }
+
   .nhsuk-footer,
   .nhsuk-footer-container {
     background: $app-dark-mode-surface;
@@ -376,6 +396,10 @@ $app-tag--blue-dark-text: nhsuk-tint(nhsuk-colour("blue"), 80%);
   }
 
   .nhsuk-radios {
+    .nhsuk-radios__divider {
+      color: $app-dark-mode-text-colour-secondary;
+    }
+
     .nhsuk-radios__input + .nhsuk-radios__label::before {
       border-color: $app-dark-mode-white;
       background-color: transparent;

--- a/app/assets/sass/components/_reading.scss
+++ b/app/assets/sass/components/_reading.scss
@@ -74,6 +74,11 @@
   margin-right: 15px;
 }
 
+.app-reading-case-tag {
+  display: block;
+  margin-bottom: nhsuk-spacing(1);
+}
+
 .app-reading-batch-table th:first-child,
 .app-reading-batch-table td:first-child {
   padding-left: 0;
@@ -191,39 +196,31 @@
   color: nhsuk-colour("white");
 }
 
-.app-reading-statistics-card--zero > .nhsuk-card {
-  background-color: nhsuk-colour("grey-3");
-  color: nhsuk-colour("black");
-}
-
-.app-reading-statistics-card--zero .nhsuk-card__heading,
-.app-reading-statistics-card--zero p,
-.app-reading-statistics-card--zero a,
-.app-reading-statistics-card--zero a:visited,
-.app-reading-statistics-card--zero a:hover,
-.app-reading-statistics-card--zero a:focus {
-  color: nhsuk-colour("black");
-}
-
 .app-reading-statistics-cards {
   display: flex;
   flex-wrap: wrap;
-  margin-left: -8px;
-  margin-right: -8px;
+  gap: 10px;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .app-reading-statistics-card {
   display: flex;
-  padding-left: 8px;
-  padding-right: 8px;
+  padding-left: 0;
+  padding-right: 0;
+  float: none;
+  width: calc((100% - 30px) / 4);
+  flex: 0 0 calc((100% - 30px) / 4);
+  max-width: calc((100% - 30px) / 4);
 }
 
 .app-reading-statistics-card > .nhsuk-card {
   width: 100%;
-  max-width: 320px;
-  height: 185px;
+  max-width: 100%;
+  min-height: 180px;
+  height: 180px;
   margin-right: 0;
-  margin-bottom: nhsuk-spacing(2);
+  margin-bottom: 0;
   display: flex;
 }
 
@@ -234,7 +231,7 @@
 }
 
 .app-reading-statistics-value {
-  font-size: 2.25rem;
+  font-size: 1.75rem;
   line-height: 1.1;
 }
 

--- a/app/assets/sass/components/_reading.scss
+++ b/app/assets/sass/components/_reading.scss
@@ -191,6 +191,20 @@
   color: nhsuk-colour("white");
 }
 
+.app-reading-statistics-card--zero > .nhsuk-card {
+  background-color: nhsuk-colour("grey-3");
+  color: nhsuk-colour("black");
+}
+
+.app-reading-statistics-card--zero .nhsuk-card__heading,
+.app-reading-statistics-card--zero p,
+.app-reading-statistics-card--zero a,
+.app-reading-statistics-card--zero a:visited,
+.app-reading-statistics-card--zero a:hover,
+.app-reading-statistics-card--zero a:focus {
+  color: nhsuk-colour("black");
+}
+
 .app-reading-statistics-cards {
   display: flex;
   flex-wrap: wrap;

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -1603,7 +1603,7 @@ const createReadingBatch = (data, options) => {
 const getDefaultBatchName = (type, clinicId, data) => {
   switch (type) {
     case 'all_reads':
-      return 'All cases needing reads'
+      return 'Session overview'
     case 'first_reads':
       return '1st reads batch'
     case 'second_reads':

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -233,7 +233,6 @@ const calculateReadingMetrics = function (
   let userReadableCount = 0
   let userFirstReadableCount = 0
   let userSecondReadableCount = 0
-  let userAwaitingPriorsCount = 0
 
   if (currentUserId) {
     // Events this user has read

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -3,7 +3,7 @@
 const dayjs = require('dayjs')
 const { eligibleForReading, getStatusTagColour } = require('./status')
 const { isWithinDayRange } = require('./dates')
-const { awaitingPriors } = require('./prior-mammograms')
+const { awaitingPriors, userRequestedPriors } = require('./prior-mammograms')
 
 // /**
 //  * Get first unread event in a clinic
@@ -194,6 +194,8 @@ const calculateReadingMetrics = function (
       userFirstReadableCount: 0,
       userSecondReadableCount: 0,
       userCanRead: false,
+      awaitingPriorsCount: 0,
+      userAwaitingPriorsCount: 0,
       skippedCount: skippedEvents?.length || 0
     }
   }
@@ -219,6 +221,9 @@ const calculateReadingMetrics = function (
     (event) => getOutcome(event, settings) === 'arbitration_pending'
   ).length
 
+  // Global awaiting priors count (events with any outstanding prior request)
+  const awaitingPriorsCount = events.filter((event) => awaitingPriors(event)).length
+
   // User-specific counts
   let userReadCount = 0
   let userFirstReadCount = 0
@@ -226,6 +231,7 @@ const calculateReadingMetrics = function (
   let userReadableCount = 0
   let userFirstReadableCount = 0
   let userSecondReadableCount = 0
+  let userAwaitingPriorsCount = 0
 
   if (currentUserId) {
     // Events this user has read
@@ -271,6 +277,11 @@ const calculateReadingMetrics = function (
     userSecondReadableCount = filterEventsByNeedsSecondRead(events).filter(
       (event) => canUserReadEvent(event, currentUserId)
     ).length
+
+    // Events where this user has an outstanding prior request
+    userAwaitingPriorsCount = events.filter((event) =>
+      userRequestedPriors(event, currentUserId)
+    ).length
   }
 
   return {
@@ -295,6 +306,9 @@ const calculateReadingMetrics = function (
     userFirstReadableCount,
     userSecondReadableCount,
     userCanRead: userReadableCount > 0,
+    // Awaiting priors
+    awaitingPriorsCount,
+    userAwaitingPriorsCount,
     // Skipped events
     skippedCount: skippedEvents?.length || 0
   }
@@ -1798,7 +1812,7 @@ const getBatchReadingProgress = (
     populatedCount: batchEvents.length,
     targetSize: resolvedTargetSize,
     // Remaining reads against the target (not just currently loaded events)
-    targetRemaining: Math.max(0, resolvedTargetSize - progress.userReadCount)
+    targetRemaining: Math.max(0, resolvedTargetSize - progress.userReadCount - progress.userAwaitingPriorsCount)
   }
 }
 

--- a/app/views/_includes/reading/reading-status-bar.njk
+++ b/app/views/_includes/reading/reading-status-bar.njk
@@ -6,13 +6,13 @@
 
 {% set firstRowItems = [] %}
 
-{# Context item (Batch or Clinic) #}
-{% if isBatchContext %}
-  {% set firstRowItems = firstRowItems | push({
-    key: "Session:",
-    value: "All cases needing reads"
-  }) %}
-{% else %}
+{# Environment tag - always first item #}
+{% set firstRowItems = firstRowItems | push({
+  html: '<strong class="nhsuk-tag nhsuk-tag--aqua-green">Reading</strong>'
+}) %}
+
+{# Clinic context item (batch context has no label, just the environment tag) #}
+{% if isClinicContext %}
   {% set locationName %}
     {% if location.type === 'mobile_unit' %}
       {{ location.name }} at {{ clinic.siteName }}
@@ -26,7 +26,7 @@
   }) %}
 {% endif %}
 
-{# Progress item #}
+{# Progress text #}
 {% set progressText %}
   {{ progress.userReadCount }} read, {{ progress.targetRemaining }} remaining
   {%- if progress.skippedEvents | length > 0 -%}
@@ -34,7 +34,7 @@
   {% endif %}
 {% endset %}
 
-{# Screened date #}
+{# Screened date and progress on same row as environment tag #}
 {% if event %}
   {% set firstRowItems = firstRowItems | push({
     key: "Screened:",
@@ -42,16 +42,14 @@
   }) %}
 {% endif %}
 
-{% set progressRowItems = [] %}
-{% set progressRowItems = progressRowItems | push({
+{% set firstRowItems = firstRowItems | push({
   key: "Progress:",
   value: progressText | trim
 }) %}
 
 {# Build rows array #}
 {% set statusBarRows = [
-  { items: firstRowItems },
-  { items: progressRowItems }
+  { items: firstRowItems }
 ] %}
 
 {# Add participant row if participant exists #}

--- a/app/views/_includes/reading/reading-status-bar.njk
+++ b/app/views/_includes/reading/reading-status-bar.njk
@@ -9,8 +9,8 @@
 {# Context item (Batch or Clinic) #}
 {% if isBatchContext %}
   {% set firstRowItems = firstRowItems | push({
-    key: "Batch:",
-    value: batch.name
+    key: "Session:",
+    value: "All cases needing reads"
   }) %}
 {% else %}
   {% set locationName %}
@@ -42,14 +42,16 @@
   }) %}
 {% endif %}
 
-{% set firstRowItems = firstRowItems | push({
+{% set progressRowItems = [] %}
+{% set progressRowItems = progressRowItems | push({
   key: "Progress:",
   value: progressText | trim
 }) %}
 
 {# Build rows array #}
 {% set statusBarRows = [
-  { items: firstRowItems }
+  { items: firstRowItems },
+  { items: progressRowItems }
 ] %}
 
 {# Add participant row if participant exists #}

--- a/app/views/_templates/layout-base.html
+++ b/app/views/_templates/layout-base.html
@@ -82,7 +82,7 @@
     {% set navItems = [
       {
         href: "/reading/batch/" ~ batchId,
-        text: "Batch list"
+        text: "Session overview"
       },
       {
         href: "javascript:window.MammogramChannel.openViewer()",

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -201,9 +201,9 @@
         {% endif %}
 
         <h2>Reading session cases</h2>
-        {% set userSessionRemainingCount = (userReadableEvents | length) - readingStatus.userReadCount %}
+        {% set userSessionRemainingCount = batch.targetSize - readingStatus.userReadCount - readingStatus.userAwaitingPriorsCount %}
         {% set userSessionRemainingCount = 0 if userSessionRemainingCount < 0 else userSessionRemainingCount %}
-        <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.userReadCount }} read, {{ userSessionRemainingCount }} remaining</p>
+        <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.userReadCount }} read{%- if readingStatus.userAwaitingPriorsCount > 0 -%}, {{ readingStatus.userAwaitingPriorsCount }} awaiting priors{%- endif -%}, {{ userSessionRemainingCount }} remaining</p>
 
         <table class="nhsuk-table app-reading-batch-table">
           <thead>
@@ -401,7 +401,9 @@
       {% endif %}
 
       <h2>Reading session cases</h2>
-      <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.firstReadCount }} read, {{ readingStatus.firstReadRemaining }} remaining</p>
+      {% set allViewRemainingCount = batch.targetSize - readingStatus.userReadCount - readingStatus.userAwaitingPriorsCount %}
+      {% set allViewRemainingCount = 0 if allViewRemainingCount < 0 else allViewRemainingCount %}
+      <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.userReadCount }} read{%- if readingStatus.userAwaitingPriorsCount > 0 -%}, {{ readingStatus.userAwaitingPriorsCount }} awaiting priors{%- endif -%}, {{ allViewRemainingCount }} remaining</p>
 
       <table class="nhsuk-table app-reading-batch-table">
         <thead>

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -177,22 +177,22 @@
           <h2>Opinion summary</h2>
 
           <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if normalPercent == 0 }}">
               {{ card({
                 descriptionHtml: normalCardContent
               }) }}
             </li>
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if technicalRecallPercent == 0 }}">
               {{ card({
                 descriptionHtml: technicalRecallCardContent
               }) }}
             </li>
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if recallForAssessmentPercent == 0 }}">
               {{ card({
                 descriptionHtml: recallForAssessmentCardContent
               }) }}
             </li>
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if priorsRequestedPercent == 0 }}">
               {{ card({
                 descriptionHtml: priorsRequestedCardContent
               }) }}
@@ -405,7 +405,7 @@
         <h3>Outcome summary</h3>
 
         <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if awaitingCount == 0 }}">
             {{ card({
               descriptionHtml: awaitingCardContent
             }) }}
@@ -415,22 +415,22 @@
         <h3>Case outcomes after 2nd reads</h3>
 
         <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewNormalCount == 0 }}">
             {{ card({
               descriptionHtml: allViewNormalCardContent
             }) }}
           </li>
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewTechnicalRecallCount == 0 }}">
             {{ card({
               descriptionHtml: allViewTechnicalRecallCardContent
             }) }}
           </li>
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewRecallForAssessmentCount == 0 }}">
             {{ card({
               descriptionHtml: allViewRecallForAssessmentCardContent
             }) }}
           </li>
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewArbitrationCount == 0 }}">
             {{ card({
               descriptionHtml: allViewArbitrationCardContent
             }) }}

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -177,22 +177,22 @@
           <h2>Opinion summary</h2>
 
           <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if normalPercent == 0 }}">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
               {{ card({
                 descriptionHtml: normalCardContent
               }) }}
             </li>
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if technicalRecallPercent == 0 }}">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
               {{ card({
                 descriptionHtml: technicalRecallCardContent
               }) }}
             </li>
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if recallForAssessmentPercent == 0 }}">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
               {{ card({
                 descriptionHtml: recallForAssessmentCardContent
               }) }}
             </li>
-            <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if priorsRequestedPercent == 0 }}">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
               {{ card({
                 descriptionHtml: priorsRequestedCardContent
               }) }}
@@ -226,6 +226,9 @@
                 {% set readingHref -%}
                   /reading/batch/{{ batch.id }}/events/{{ event.id }}
                 {%- endset %}
+                {% if event.medicalInformation.symptoms | length %}
+                  <span class="app-reading-case-tag">{{ "Has symptoms" | toTag }}</span>
+                {% endif %}
                 <a href="{{ readingHref }}">{{ event.participant | getFullName }}</a>
 
                 <br>
@@ -237,12 +240,6 @@
                     {{ "1st read" if readCount == 0 else "2nd read" }}
                   {% endif %}
                 </span>
-
-                
-                {% if event.medicalInformation.symptoms | length %}
-                <br>
-                  {{ "Has symptoms" | toTag }}
-                {% endif %}
                 {% if (data.settings.debugMode | falsify) %}
                   {% if event | hasReportedMammograms %}
                     <br>{{ "Has priors" | toTag }}
@@ -401,41 +398,6 @@
 
       {% if not resumeEvent %}
         <h2>All reads ({{ allTotal }})</h2>
-
-        <h3>Outcome summary</h3>
-
-        <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if awaitingCount == 0 }}">
-            {{ card({
-              descriptionHtml: awaitingCardContent
-            }) }}
-          </li>
-        </ul>
-
-        <h3>Case outcomes after 2nd reads</h3>
-
-        <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewNormalCount == 0 }}">
-            {{ card({
-              descriptionHtml: allViewNormalCardContent
-            }) }}
-          </li>
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewTechnicalRecallCount == 0 }}">
-            {{ card({
-              descriptionHtml: allViewTechnicalRecallCardContent
-            }) }}
-          </li>
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewRecallForAssessmentCount == 0 }}">
-            {{ card({
-              descriptionHtml: allViewRecallForAssessmentCardContent
-            }) }}
-          </li>
-          <li class="nhsuk-grid-column-one-third app-reading-statistics-card{{ ' app-reading-statistics-card--zero' if allViewArbitrationCount == 0 }}">
-            {{ card({
-              descriptionHtml: allViewArbitrationCardContent
-            }) }}
-          </li>
-        </ul>
       {% endif %}
 
       <h2>Reading session cases</h2>
@@ -463,15 +425,14 @@
                 {% set readingHref -%}
                   /reading/batch/{{ batch.id }}/events/{{ event.id }}
                 {%- endset %}
+                {% if event.medicalInformation.symptoms | length %}
+                  <span class="app-reading-case-tag">{{ "Has symptoms" | toTag }}</span>
+                {% endif %}
                 <a href="{{ readingHref }}">{{ event.participant | getFullName }}</a>
 
                 {% if event | awaitingPriors %}
                 <br>
                   {{ "Awaiting priors" | toTag }}
-                {% endif %}
-                {% if event.medicalInformation.symptoms | length %}
-                <br>
-                  {{ "Has symptoms" | toTag }}
                 {% endif %}
                 {% if (data.settings.debugMode | falsify) %}
                   {% if event | hasReportedMammograms %}

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -50,15 +50,9 @@
         {{ readingActionText }}
       </a>
     {% else %}
-      {% set notificationBannerHtml %}
-        <h3 class="nhsuk-notification-banner__heading">
-          All cases in this session have been read
-        </h3>
-      {% endset %}
-
-      {{ notificationBanner({
-        html: notificationBannerHtml,
-        type: "success"
+      {{ panel({
+        titleText: "Session complete",
+        html: '<p class="nhsuk-body-s nhsuk-u-margin-bottom-0">All cases in this session have been read</p>'
       }) }}
     {% endif %}
 

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -4,11 +4,6 @@
 
 {% set isClinicContext = batch.clinicId %}
 
-{% set back = {
-  href: "/reading",
-  text: "Leave session"
-} %}
-
 {% if isClinicContext %}
   {% set back = {
     href: "/reading/clinics",
@@ -57,7 +52,7 @@
     {% else %}
       {% set notificationBannerHtml %}
         <h3 class="nhsuk-notification-banner__heading">
-          {{ "All cases in this batch have been read" if not currentUserHasRead else "You have read all available cases" }}
+          All cases in this session have been read
         </h3>
       {% endset %}
 
@@ -102,11 +97,114 @@
         {% endif %}
       {% endfor %}
 
-      <h2>Your opinion ({{ batch.targetSize or userReadableEvents | length }} in batch)</h2>
-
       {% if userReadableEvents | length == 0 %}
         <p>You don't have any cases you can read in this batch.</p>
       {% else %}
+
+        {# Build opinion counts from events the user has read #}
+        {% set normalEvents = [] %}
+        {% set technicalRecallEvents = [] %}
+        {% set recallForAssessmentEvents = [] %}
+        {% set priorsRequestedEvents = [] %}
+
+        {% for event in userReadableEvents %}
+          {% if event | userHasReadEvent %}
+            {% set read = event | getReadForUser %}
+            {% if read.opinion == 'normal' %}
+              {% set normalEvents = normalEvents | push(event) %}
+            {% elseif read.opinion == 'technical_recall' %}
+              {% set technicalRecallEvents = technicalRecallEvents | push(event) %}
+            {% elseif read.opinion == 'recall_for_assessment' %}
+              {% set recallForAssessmentEvents = recallForAssessmentEvents | push(event) %}
+            {% endif %}
+          {% elseif event | userRequestedPriors(data.currentUser.id) %}
+            {% set priorsRequestedEvents = priorsRequestedEvents | push(event) %}
+          {% endif %}
+        {% endfor %}
+
+        {% set totalCount = userReadableEvents | length %}
+        {% set normalCount = normalEvents | length %}
+        {% set technicalRecallCount = technicalRecallEvents | length %}
+        {% set recallForAssessmentCount = recallForAssessmentEvents | length %}
+        {% set priorsRequestedCount = priorsRequestedEvents | length %}
+
+        {% set normalPercent = (normalCount / totalCount * 100) | round %}
+        {% set technicalRecallPercent = (technicalRecallCount / totalCount * 100) | round %}
+        {% set recallForAssessmentPercent = (recallForAssessmentCount / totalCount * 100) | round %}
+        {% set priorsRequestedPercent = (priorsRequestedCount / totalCount * 100) | round %}
+
+        {% set normalCardContent %}
+          <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+            <span role="text">
+              <span class="nhsuk-u-visually-hidden">Normal:</span> {{ normalPercent }}%
+            </span>
+          </h2>
+          <p class="nhsuk-u-font-size-16">Normal</p>
+          <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ normalCount }} cases</p>
+        {% endset %}
+
+        {% set technicalRecallCardContent %}
+          <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+            <span role="text">
+              <span class="nhsuk-u-visually-hidden">Technical recall:</span> {{ technicalRecallPercent }}%
+            </span>
+          </h2>
+          <p class="nhsuk-u-font-size-16">Technical recall</p>
+          <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ technicalRecallCount }} cases</p>
+        {% endset %}
+
+        {% set recallForAssessmentCardContent %}
+          <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+            <span role="text">
+              <span class="nhsuk-u-visually-hidden">Recall for assessment:</span> {{ recallForAssessmentPercent }}%
+            </span>
+          </h2>
+          <p class="nhsuk-u-font-size-16">Recall for assessment</p>
+          <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ recallForAssessmentCount }} cases</p>
+        {% endset %}
+
+        {% set priorsRequestedCardContent %}
+          <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+            <span role="text">
+              <span class="nhsuk-u-visually-hidden">Priors requested:</span> {{ priorsRequestedPercent }}%
+            </span>
+          </h2>
+          <p class="nhsuk-u-font-size-16">Priors requested</p>
+          <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ priorsRequestedCount }} cases</p>
+        {% endset %}
+
+        {% if not resumeEvent %}
+          <h2>Opinion summary</h2>
+
+          <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+              {{ card({
+                descriptionHtml: normalCardContent
+              }) }}
+            </li>
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+              {{ card({
+                descriptionHtml: technicalRecallCardContent
+              }) }}
+            </li>
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+              {{ card({
+                descriptionHtml: recallForAssessmentCardContent
+              }) }}
+            </li>
+            <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+              {{ card({
+                descriptionHtml: priorsRequestedCardContent
+              }) }}
+            </li>
+          </ul>
+        {% endif %}
+
+        <h2>Reading session cases</h2>
+        {% set userSessionRemainingCount = (userReadableEvents | length) - readingStatus.userReadCount %}
+        {% set userSessionRemainingCount = 0 if userSessionRemainingCount < 0 else userSessionRemainingCount %}
+        <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.userReadCount }} read, {{ userSessionRemainingCount }} remaining</p>
+
         <table class="nhsuk-table app-reading-batch-table">
           <thead>
             <tr>
@@ -217,8 +315,131 @@
         </table>
       {% endif %}
     {% else %}
-      {# ALL READS VIEW - Shows all reads with columns for each read #}
-      <h2>Other reader's opinion and outcome ({{ batch.targetSize or events | length }})</h2>
+      {# ALL READS VIEW - Shows outcome stats and all cases #}
+
+      {# Build outcome counts for stats cards #}
+      {% set awaitingSecondReadEvents = [] %}
+      {% set allViewNormalEvents = [] %}
+      {% set allViewTechnicalRecallEvents = [] %}
+      {% set allViewRecallForAssessmentEvents = [] %}
+      {% set allViewArbitrationEvents = [] %}
+
+      {% for event in events %}
+        {% set eventOutcome = event | getOutcome %}
+        {% if eventOutcome == 'pending_second_read' %}
+          {% set awaitingSecondReadEvents = awaitingSecondReadEvents | push(event) %}
+        {% elseif eventOutcome == 'normal' %}
+          {% set allViewNormalEvents = allViewNormalEvents | push(event) %}
+        {% elseif eventOutcome == 'technical_recall' %}
+          {% set allViewTechnicalRecallEvents = allViewTechnicalRecallEvents | push(event) %}
+        {% elseif eventOutcome == 'recall_for_assessment' %}
+          {% set allViewRecallForAssessmentEvents = allViewRecallForAssessmentEvents | push(event) %}
+        {% elseif eventOutcome == 'arbitration_pending' %}
+          {% set allViewArbitrationEvents = allViewArbitrationEvents | push(event) %}
+        {% endif %}
+      {% endfor %}
+
+      {% set allTotal = events | length %}
+      {% set allTotalDenominator = allTotal if allTotal > 0 else 1 %}
+      {% set awaitingCount = awaitingSecondReadEvents | length %}
+      {% set allViewNormalCount = allViewNormalEvents | length %}
+      {% set allViewTechnicalRecallCount = allViewTechnicalRecallEvents | length %}
+      {% set allViewRecallForAssessmentCount = allViewRecallForAssessmentEvents | length %}
+      {% set allViewArbitrationCount = allViewArbitrationEvents | length %}
+      {% set twiceReadTotal = allViewNormalCount + allViewTechnicalRecallCount + allViewRecallForAssessmentCount + allViewArbitrationCount %}
+      {% set twiceReadDenominator = twiceReadTotal if twiceReadTotal > 0 else 1 %}
+
+      {% set awaitingCardContent %}
+        <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+          <span role="text">
+            <span class="nhsuk-u-visually-hidden">Awaiting second read:</span> {{ (awaitingCount / allTotalDenominator * 100) | round }}%
+          </span>
+        </h2>
+        <p class="nhsuk-u-font-size-16">Awaiting second read</p>
+        <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ awaitingCount }} cases</p>
+      {% endset %}
+
+      {% set allViewNormalCardContent %}
+        <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+          <span role="text">
+            <span class="nhsuk-u-visually-hidden">Normal:</span> {{ (allViewNormalCount / twiceReadDenominator * 100) | round }}%
+          </span>
+        </h2>
+        <p class="nhsuk-u-font-size-16">Normal</p>
+        <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ allViewNormalCount }} cases</p>
+      {% endset %}
+
+      {% set allViewTechnicalRecallCardContent %}
+        <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+          <span role="text">
+            <span class="nhsuk-u-visually-hidden">Technical recall:</span> {{ (allViewTechnicalRecallCount / twiceReadDenominator * 100) | round }}%
+          </span>
+        </h2>
+        <p class="nhsuk-u-font-size-16">Technical recall</p>
+        <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ allViewTechnicalRecallCount }} cases</p>
+      {% endset %}
+
+      {% set allViewRecallForAssessmentCardContent %}
+        <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+          <span role="text">
+            <span class="nhsuk-u-visually-hidden">Recall for assessment:</span> {{ (allViewRecallForAssessmentCount / twiceReadDenominator * 100) | round }}%
+          </span>
+        </h2>
+        <p class="nhsuk-u-font-size-16">Recall for assessment</p>
+        <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ allViewRecallForAssessmentCount }} cases</p>
+      {% endset %}
+
+      {% set allViewArbitrationCardContent %}
+        <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
+          <span role="text">
+            <span class="nhsuk-u-visually-hidden">Require arbitration:</span> {{ (allViewArbitrationCount / twiceReadDenominator * 100) | round }}%
+          </span>
+        </h2>
+        <p class="nhsuk-u-font-size-16">Require arbitration</p>
+        <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ allViewArbitrationCount }} cases</p>
+      {% endset %}
+
+      {% if not resumeEvent %}
+        <h2>All reads ({{ allTotal }})</h2>
+
+        <h3>Outcome summary</h3>
+
+        <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            {{ card({
+              descriptionHtml: awaitingCardContent
+            }) }}
+          </li>
+        </ul>
+
+        <h3>Case outcomes after 2nd reads</h3>
+
+        <ul class="nhsuk-grid-row nhsuk-list app-reading-statistics-cards">
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            {{ card({
+              descriptionHtml: allViewNormalCardContent
+            }) }}
+          </li>
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            {{ card({
+              descriptionHtml: allViewTechnicalRecallCardContent
+            }) }}
+          </li>
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            {{ card({
+              descriptionHtml: allViewRecallForAssessmentCardContent
+            }) }}
+          </li>
+          <li class="nhsuk-grid-column-one-third app-reading-statistics-card">
+            {{ card({
+              descriptionHtml: allViewArbitrationCardContent
+            }) }}
+          </li>
+        </ul>
+      {% endif %}
+
+      <h2>Reading session cases</h2>
+      <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.firstReadCount }} read, {{ readingStatus.firstReadRemaining }} remaining</p>
 
       <table class="nhsuk-table app-reading-batch-table">
         <thead>

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -232,9 +232,9 @@
                 <span class="app-text-grey app-nowrap nhsuk-body-s">
                   {% set readCount = metadata.readCount %}
                   {% if event | userHasReadEvent %}
-                    {{ "First read" if readCount == 1 else "Second read" }}
+                    {{ "1st read" if readCount == 1 else "2nd read" }}
                   {% else %}
-                    {{ "First read" if readCount == 0 else "Second read" }}
+                    {{ "1st read" if readCount == 0 else "2nd read" }}
                   {% endif %}
                 </span>
 
@@ -352,10 +352,10 @@
       {% set awaitingCardContent %}
         <h2 class="nhsuk-card__heading app-reading-statistics-value nhsuk-u-margin-bottom-1">
           <span role="text">
-            <span class="nhsuk-u-visually-hidden">Awaiting second read:</span> {{ (awaitingCount / allTotalDenominator * 100) | round }}%
+            <span class="nhsuk-u-visually-hidden">Awaiting 2nd read:</span> {{ (awaitingCount / allTotalDenominator * 100) | round }}%
           </span>
         </h2>
-        <p class="nhsuk-u-font-size-16">Awaiting second read</p>
+        <p class="nhsuk-u-font-size-16">Awaiting 2nd read</p>
         <p class="nhsuk-u-font-size-16 app-reading-statistics-meta">{{ awaitingCount }} cases</p>
       {% endset %}
 
@@ -447,8 +447,8 @@
             <th scope="col">No.</th>
             <th scope="col">Case</th>
             <th scope="col">Screening date</th>
-            <th scope="col">First read</th>
-            <th scope="col">Second read</th>
+            <th scope="col">1st read</th>
+            <th scope="col">2nd read</th>
             <th scope="col">Outcome</th>
           </tr>
         </thead>
@@ -502,7 +502,7 @@
                   {{ event.timing.startTime | formatRelativeDate }}
                 </span>
               </td>
-              {# First read column #}
+              {# 1st read column #}
               <td>
                 {% set isBlind = data.settings.reading.blindReading | falsify %}
                 {% set isCurrentUserRead = false %}
@@ -530,7 +530,7 @@
                   {{ "Not read" | toTag }}
                 {% endif %}
               </td>
-              {# Second read column #}
+              {# 2nd read column #}
               <td>
                 {% set isBlind = data.settings.reading.blindReading | falsify %}
                 {% set isCurrentUserRead = false %}


### PR DESCRIPTION
This work: 

* Adds an in-progress reading session: shows progress on own row
* Adds an end state reading session (shows statistics at end of a reading session) 
* Begins to replace the word 'batch' with 'session' (incomplete, but a beginning) 
* Adjusts the reading session info structure, including environment tags for both the 'Reading' (aqua) and 'Arbitration' (orange). Full arbitration workflow TBC.

Also: 
* Fixes to dark mode bits and bobs: fix 'or' divider, add styles for session overview state
* Replace success banner with panel

## End of session – show stats
<img width="1061" height="689" alt="Screenshot 2026-04-01 at 15 36 16" src="https://github.com/user-attachments/assets/b8af2399-7d37-4a96-93b2-89f47528a4d8" />

## In-progress session list
<img width="833" height="821" alt="Screenshot 2026-03-31 at 12 18 04" src="https://github.com/user-attachments/assets/88303370-79a3-4b03-b9ee-99fe934225ee" />

## Adapted reading session info bar with reading environment banner
<img width="1021" height="800" alt="Screenshot 2026-03-31 at 12 16 43" src="https://github.com/user-attachments/assets/cf0e243b-d172-440c-9582-4d74bb8c2210" />



