### PR TITLE
Screening: show added to worklist status and settings page toggle

### DIFF
--- a/app/assets/sass/_utils.scss
+++ b/app/assets/sass/_utils.scss
@@ -1,4 +1,15 @@
+@use "sass:color";
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
+
+// Lighten a colour by mixing it with white
+@function tint($colour, $percentage) {
+  @return color.mix(#fff, $colour, $percentage);
+}
+
+// Darken a colour by mixing it with black
+@function shade($colour, $percentage) {
+  @return color.mix(#000, $colour, $percentage);
+}
 
 .app-nowrap {
   white-space: nowrap;

--- a/app/assets/sass/_utils.scss
+++ b/app/assets/sass/_utils.scss
@@ -2,12 +2,12 @@
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
 
 // Lighten a colour by mixing it with white
-@function tint($colour, $percentage) {
+@function nhsuk-tint($colour, $percentage) {
   @return color.mix(#fff, $colour, $percentage);
 }
 
 // Darken a colour by mixing it with black
-@function shade($colour, $percentage) {
+@function nhsuk-shade($colour, $percentage) {
   @return color.mix(#000, $colour, $percentage);
 }
 

--- a/app/assets/sass/_utils.scss
+++ b/app/assets/sass/_utils.scss
@@ -1,15 +1,4 @@
-@use "sass:color";
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
-
-// Lighten a colour by mixing it with white
-@function nhsuk-tint($colour, $percentage) {
-  @return color.mix(#fff, $colour, $percentage);
-}
-
-// Darken a colour by mixing it with black
-@function nhsuk-shade($colour, $percentage) {
-  @return color.mix(#000, $colour, $percentage);
-}
 
 .app-nowrap {
   white-space: nowrap;

--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -179,3 +179,26 @@ a.app-workflow-side-nav__link {
     position: static;
   }
 }
+
+// Status text shown after the NHS number in the appointment header (e.g. "Added to worklist")
+.app-header-status {
+  margin-left: nhsuk-spacing(2);
+
+  .app-header-status__icon {
+    height: 1em;
+    width: 1em;
+    vertical-align: -0.15em;
+    margin-right: 1px;
+
+    path {
+      fill: none;
+      stroke: #89E2A8;
+      stroke-width: 4;
+    }
+  }
+}
+
+.app-header-status--fail .app-header-status__icon path {
+  stroke: #FF5B5B;
+  stroke-width: 3;
+}

--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -1,6 +1,7 @@
 // app/assets/sass/components/_workflow.scss
 
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
+@use "utils" as *;
 
 // Wider container for workflow mode
 .nhsuk-width-container--wide {
@@ -192,13 +193,13 @@ a.app-workflow-side-nav__link {
 
     path {
       fill: none;
-      stroke: #89E2A8;
+      stroke: tint(nhsuk-colour("green"), 55%);
       stroke-width: 4;
     }
   }
 }
 
 .app-header-status--fail .app-header-status__icon path {
-  stroke: #FF5B5B;
+  stroke: tint(nhsuk-colour("red"), 55%);
   stroke-width: 3;
 }

--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -193,13 +193,13 @@ a.app-workflow-side-nav__link {
 
     path {
       fill: none;
-      stroke: tint(nhsuk-colour("green"), 55%);
+      stroke: nhsuk-tint(nhsuk-colour("green"), 55%);
       stroke-width: 4;
     }
   }
 }
 
 .app-header-status--fail .app-header-status__icon path {
-  stroke: tint(nhsuk-colour("red"), 55%);
+  stroke: nhsuk-tint(nhsuk-colour("red"), 55%);
   stroke-width: 3;
 }

--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -182,13 +182,13 @@ a.app-workflow-side-nav__link {
 
 // Status text shown after the NHS number in the appointment header (e.g. "Added to worklist")
 .app-header-status {
-  margin-left: nhsuk-spacing(2);
+  margin-left: nhsuk-spacing(3);
 
   .app-header-status__icon {
     height: 1em;
     width: 1em;
     vertical-align: -0.15em;
-    margin-right: 1px;
+    margin-right: -1px;
 
     path {
       fill: none;

--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -192,13 +192,15 @@ a.app-workflow-side-nav__link {
 
     path {
       fill: none;
-      stroke: nhsuk-tint(nhsuk-colour("green"), 55%);
+      // Aiming for #48B788
+      stroke: nhsuk-tint(nhsuk-colour("green"), 40%);
       stroke-width: 4;
     }
   }
 }
 
 .app-header-status--fail .app-header-status__icon path {
-  stroke: nhsuk-tint(nhsuk-colour("red"), 55%);
+  // Aiming for #E98881
+  stroke: nhsuk-tint(nhsuk-colour("red"), 44%);
   stroke-width: 3;
 }

--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -1,7 +1,6 @@
 // app/assets/sass/components/_workflow.scss
 
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
-@use "utils" as *;
 
 // Wider container for workflow mode
 .nhsuk-width-container--wide {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -99,6 +99,7 @@ const defaultSettings = {
     manualImageCollection: 'true',
     showParticipantSection: 'false',
     useCondensedReviewSummaries: 'true',
+    addedToWorklist: 'true',
     imageStreaming: {
       enabled: 'true',
       intervalMs: '3000'

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -12,6 +12,21 @@
       classes: "nhsuk-tag--yellow nhsuk-u-margin-left-1"
     })}}
   {% endif %}
+  {% if data.settings.screening.addedToWorklist == 'false' %}
+    <span class="app-header-status app-header-status--fail">
+      <svg class="app-icon app-icon--cross app-header-status__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"></path>
+      </svg>
+      <span>Not added to worklist (<a href="#">Retry</a>)</span>
+    </span>
+  {% else %}
+    <span class="app-header-status">
+      <svg class="app-icon app-icon--tick app-header-status__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
+      </svg>
+      <span>Added to worklist</span>
+    </span>
+  {% endif %}
 {% endset %}
 {% set appointmentRowItems = appointmentRowItems | push({
   key: "Appointment:",

--- a/app/views/_includes/images/image-troubleshooting.njk
+++ b/app/views/_includes/images/image-troubleshooting.njk
@@ -12,108 +12,39 @@
         <h2>Troubleshoot issues with images</h2>
 
         {% call details({
-          summaryText: "No images (or incorrect images) are displaying"
+          summaryText: "A different participant's images are displayed"
         }) %}
 
-        <p>Follow these steps if you are seeing no images, too few, too many, or images from a different participant.</p>
+        <p>Check the correct participant has been selected on the worklist.</p>
+        
+        <p>If this needs to be changed, update the mammogram machine and wait a few seconds for the image details to refresh.</p>
 
-          <ol>
-            <li>Check the correct participant has been selected on the mammogram machine</li>
-            <li>Change the participant details if necessary</li>
-            <li>Wait 15 seconds for images to update</li>
-            <li>If they do not, resend images to prompt the mammogram machine to refresh</li>
-          </ol>
+        <p>If the issue is not resolved, <a href="./images-manual" class="nhsuk-link">enable manual image mode</a>.</p>
 
-          {{ button({
-            text: "Resend images",
-            href: "#",
-            classes: "nhsuk-button nhsuk-button--secondary"
-          }) }}
+        <p>Images details will be reconciled after the appointment.</p>
 
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color">Last requested at {{ lastRequestedTime | formatTime("HH:mm:ss") }}</p>
+        {% endcall %}
 
-          <h3>If you're still seeing no images, or an incorrect number of images</h3>
+        {% call details({
+          summaryText: "The wrong number of images are displayed"
+        }) %}
 
-          <p><a href="./images-manual" class="nhsuk-link">Record image details manually</a></p>
+        <p><a href="./images-manual" class="nhsuk-link">Enable manual image mode</a>.</p>
 
-          <p>You can add details of image issues or adjustments required at the end of this appointment.</p>
+        <p>Images details will be reconciled after the appointment.</p>
+
         {% endcall %}
 
         {% call details({
           summaryText: "Images have incorrect labels"
         }) %}
-          <ol>
-            <li>Check the correct views have been selected on the mammogram machine</li>
-            <li>Change any incorrect labels</li>
-            <li>Wait 15 seconds for updated information to appear</li>
-            <li>If it does not, resend images to prompt the mammogram machine to refresh details</li>
-          </ol>
-
-          {{ button({
-            text: "Resend images",
-            href: "#",
-            classes: "nhsuk-button nhsuk-button--secondary"
-          }) }}
-
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color">Last requested at {{ lastRequestedTime | formatTime("HH:mm:ss") }}</p>
-
-          <h3>If the wrong information is still showing</h3>
-
-          <p><a href="./images-manual" class="nhsuk-link">Record image details manually</a></p>
-
-          <p>You can add details of image issues or adjustments required at the end of this appointment.</p>
-        {% endcall %}
-
-        {% call details({
-          summaryText: "Poor image quality (blurred or artifacts in view)"
-        }) %}
-          <h3>If more images can be taken to resolve the problem</h3>
-
-          <ol>
-            <li>Retake the necessary image views</li>
-            <li>Wait 15 seconds for new images to appear</li>
-            <li>If they do not, resend images to prompt the mammogram machine to refresh details</li>
-          </ol>
-
-          {{ button({
-            text: "Resend images",
-            href: "#",
-            classes: "nhsuk-button nhsuk-button--secondary"
-          }) }}
-
-          <p class="nhsuk-body-s nhsuk-u-secondary-text-color">Last requested at {{ lastRequestedTime | formatTime("HH:mm:ss") }}</p>
-
-          <h3>If the images taken are the best possible</h3>
-
-          <p>Mark as 'Imperfect, but best possible images' in the 'Additional details' section.</p>
           
-          <p>This will advise image readers not to request a technical recall.</p>
+        <p>Update image information on the mammogram machine and wait a few seconds for the image details to refresh.</p>
 
-        {% endcall %}
+        <p>If the issue is not resolved, <a href="./images-manual" class="nhsuk-link">Enable manual image mode</a>.</p>
 
-        {% call details({
-          summaryText: "Technical issues with the mammogram machine"
-        }) %}
-          <h3>If some images have been taken and they are displayed above</h3>
+        <p>Images details will be reconciled after the appointment.</p>
 
-          <ol>
-            <li>Mark as 'Not all mammograms taken' in the 'Additional details' section</li>
-            <li>Select 'Technical issues' when asked for a reason and provide details</li>
-          </ol>
-
-          <h3>If some images have been taken and they are not displayed above</h3>
-
-          <p><a href="./images-manual" class="nhsuk-link">Record image details manually</a></p>
-
-          <p>You can add details of image issues or adjustments required at the end of this appointment.</p>
-
-          <h3>If no images have been taken</h3>
-
-          <p><a href="./attended-not-screened-reason" class="nhsuk-link app-link--warning">Exit this appointment</a></p>
-
-          <p>When asked why the appointment is stopping, select 'Technical issues at clinic' and provide details.</p>
-
-          <p>Other appointments can be cancelled from the clinic list if this fault cannot be resolved.</p>
         {% endcall %}
 
   

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -115,6 +115,9 @@
     {# Show participant section #}
     {{ settingToggle("Participant section", "settings[screening][showParticipantSection]", [{value: "true", label: "Shown"}, {value: "false", label: "Hidden"}], data.settings.screening.showParticipantSection, "true") }}
 
+    {# Participant added to worklist — toggles success/fail state shown in appointment header #}
+    {{ settingToggle("Participant added to worklist", "settings[screening][addedToWorklist]", [{value: "true", label: "Successful"}, {value: "false", label: "Not successful"}], data.settings.screening.addedToWorklist, "true") }}
+
     <h2>Image reading</h2>
     {# One click normal #}
     {{ settingToggle("Confirm normal results", "settings[reading][confirmNormal]", [{value: "true", label: "Required"}, {value: "false", label: "Not required"}], data.settings.reading.confirmNormal, "true") }}


### PR DESCRIPTION
This PR: 
* Appends "added to worklist" status in the screening workflow 
* Adds setting to toggle it on / off on prototype settings 
* Updated troubleshooting messages to better reflect expected behaviour

## Added to worklist successful 
<img width="981" height="507" alt="Screenshot 2026-05-20 at 11 00 34" src="https://github.com/user-attachments/assets/bda6705a-b827-4b5c-88cf-2ef80fa22699" />

## Added to worklist not successful 
<img width="978" height="505" alt="Screenshot 2026-05-20 at 11 00 10" src="https://github.com/user-attachments/assets/c6d41e01-fc08-4ffe-81c6-36852bae360e" />

##  New setting
<img width="639" height="476" alt="Screenshot 2026-05-14 at 14 39 42" src="https://github.com/user-attachments/assets/8ccf3666-ef6a-48f6-96a4-ffeff413355f" />

