### PR TITLE
'Added to worklist' switch to use nhsukIcons instead of SVGs to standardise icons

### DIFF
--- a/app/assets/sass/_workflow.scss
+++ b/app/assets/sass/_workflow.scss
@@ -189,18 +189,12 @@ a.app-workflow-side-nav__link {
     width: 1em;
     vertical-align: -0.15em;
     margin-right: -1px;
-
-    path {
-      fill: none;
-      // Aiming for #48B788
-      stroke: nhsuk-tint(nhsuk-colour("green"), 40%);
-      stroke-width: 4;
-    }
+    // Aiming for #48B788
+    fill: nhsuk-tint(nhsuk-colour("green"), 40%);
   }
 }
 
-.app-header-status--fail .app-header-status__icon path {
+.app-header-status--fail .app-header-status__icon {
   // Aiming for #E98881
-  stroke: nhsuk-tint(nhsuk-colour("red"), 44%);
-  stroke-width: 3;
+  fill: nhsuk-tint(nhsuk-colour("red"), 44%);
 }

--- a/app/views/_components/icon/macro.njk
+++ b/app/views/_components/icon/macro.njk
@@ -18,6 +18,6 @@
   <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 3.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Zm-1.5 6.5V17a1.5 1.5 0 0 0 3 0V12a1.5 1.5 0 0 0-3 0Z">
 </svg>
 {%- else -%}
-  {{- nhsukIcon(name) -}}
+  {{- nhsukIcon(name, params) -}}
 {%- endif -%}
 {%- endmacro %}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -14,16 +14,12 @@
   {% endif %}
   {% if data.settings.screening.addedToWorklist == 'false' %}
     <span class="app-header-status app-header-status--fail">
-      <svg class="app-icon app-icon--cross app-header-status__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"></path>
-      </svg>
+      {{ appIcon("cross", { classes: "app-header-status__icon" }) }}
       <span>Not added to worklist (<a href="#">Retry</a>)</span>
     </span>
   {% else %}
     <span class="app-header-status">
-      <svg class="app-icon app-icon--tick app-header-status__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
-      </svg>
+      {{ appIcon("tick", { classes: "app-header-status__icon" }) }}
       <span>Added to worklist</span>
     </span>
   {% endif %}


### PR DESCRIPTION
## For the added to worklist status: switch from using SVGs to the nhsukIcons

<img width="988" height="507" alt="Screenshot 2026-05-21 at 12 51 26" src="https://github.com/user-attachments/assets/a929b658-e4f3-488f-a8c9-a0c407de1a11" />

<img width="980" height="433" alt="Screenshot 2026-05-21 at 12 51 07" src="https://github.com/user-attachments/assets/6d575436-dd70-4003-8bd6-0e29412a9f31" />
