### PR TITLE
Display worklist accession number and failover to manual image collection

### DIFF
--- a/app/assets/javascript/retry-worklist-connection.js
+++ b/app/assets/javascript/retry-worklist-connection.js
@@ -1,0 +1,54 @@
+// app/assets/javascript/retry-worklist-connection.js
+//
+// Adds a brief "Attempting to reconnect" transient state to the Retry
+// connection button so the user sees feedback before the page reloads.
+
+(function () {
+  const RECONNECT_DELAY_MS = 1500
+  const button = document.querySelector('[data-retry-connection-button]')
+  if (!button) return
+
+  const form = button.form
+  if (!form) return
+
+  const originalText = button.textContent
+
+  // Reset the button on initial load and when restored from bfcache, so it
+  // doesn't get stuck in the "Attempting to reconnect" disabled state after
+  // the post-redirect page load.
+  const resetButton = function () {
+    button.disabled = false
+    button.textContent = originalText
+  }
+  resetButton()
+  window.addEventListener('pageshow', resetButton)
+
+  let isSubmitting = false
+
+  form.addEventListener('submit', function (event) {
+    // Only intercept when the user clicked the Retry button (not the
+    // secondary "Switch to manual" button, which uses its own formaction).
+    if (event.submitter !== button) return
+
+    // After the simulated reconnect delay we re-submit programmatically;
+    // let that submission through without re-intercepting it.
+    if (isSubmitting) return
+
+    event.preventDefault()
+
+    button.disabled = true
+    button.textContent = 'Attempting to reconnect'
+
+    window.setTimeout(function () {
+      isSubmitting = true
+      // Re-enable so the value is submitted, then submit using the
+      // button's formaction.
+      button.disabled = false
+      if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit(button)
+      } else {
+        form.submit()
+      }
+    }, RECONNECT_DELAY_MS)
+  })
+})()

--- a/app/assets/javascript/retry-worklist-connection.js
+++ b/app/assets/javascript/retry-worklist-connection.js
@@ -1,9 +1,11 @@
 // app/assets/javascript/retry-worklist-connection.js
 //
-// Adds a brief "Attempting to reconnect" transient state to the Retry
-// connection button so the user sees feedback before the page reloads.
+// Handles retry connection simulation entirely client-side.
+// First click: shows "Attempting to reconnect" then shows a failure message.
+// Second click: shows "Attempting to reconnect" then submits the form (server
+// marks worklist as connected and redirects via referrerChain).
 
-(function () {
+;(function () {
   const RECONNECT_DELAY_MS = 1500
   const button = document.querySelector('[data-retry-connection-button]')
   if (!button) return
@@ -11,12 +13,13 @@
   const form = button.form
   if (!form) return
 
+  const failureMessage = document.querySelector('[data-retry-failure-message]')
+  const retryTimeSpan = document.querySelector('[data-retry-time]')
   const originalText = button.textContent
+  let attempts = 0
 
-  // Reset the button on initial load and when restored from bfcache, so it
-  // doesn't get stuck in the "Attempting to reconnect" disabled state after
-  // the post-redirect page load.
-  const resetButton = function () {
+  // Reset button state on page load and bfcache restore
+  const resetButton = () => {
     button.disabled = false
     button.textContent = originalText
   }
@@ -25,13 +28,11 @@
 
   let isSubmitting = false
 
-  form.addEventListener('submit', function (event) {
-    // Only intercept when the user clicked the Retry button (not the
-    // secondary "Switch to manual" button, which uses its own formaction).
+  form.addEventListener('submit', (event) => {
+    // Only intercept the Retry button (not the secondary Switch to manual button)
     if (event.submitter !== button) return
 
-    // After the simulated reconnect delay we re-submit programmatically;
-    // let that submission through without re-intercepting it.
+    // After a successful retry we re-submit programmatically — let it through
     if (isSubmitting) return
 
     event.preventDefault()
@@ -39,16 +40,34 @@
     button.disabled = true
     button.textContent = 'Attempting to reconnect'
 
-    window.setTimeout(function () {
-      isSubmitting = true
-      // Re-enable so the value is submitted, then submit using the
-      // button's formaction.
-      button.disabled = false
-      if (typeof form.requestSubmit === 'function') {
-        form.requestSubmit(button)
-      } else {
-        form.submit()
+    setTimeout(() => {
+      attempts++
+
+      if (attempts >= 2) {
+        // Second attempt: simulate success — submit form to server
+        isSubmitting = true
+        button.disabled = false
+        if (typeof form.requestSubmit === 'function') {
+          form.requestSubmit(button)
+        } else {
+          form.submit()
+        }
+        return
       }
+
+      // First attempt: simulate failure — show message and re-enable button
+      if (failureMessage && retryTimeSpan) {
+        const now = new Date()
+        const timeString = now.toLocaleTimeString('en-GB', {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit'
+        })
+        retryTimeSpan.textContent = timeString
+        failureMessage.style.display = ''
+      }
+
+      resetButton()
     }, RECONNECT_DELAY_MS)
   })
 })()

--- a/app/assets/sass/_utils.scss
+++ b/app/assets/sass/_utils.scss
@@ -17,3 +17,7 @@
 .app-display-none {
   display: none;
 }
+
+.app-code-font {
+  font-family: $nhsuk-code-font;
+}

--- a/app/assets/sass/_utils.scss
+++ b/app/assets/sass/_utils.scss
@@ -20,4 +20,5 @@
 
 .app-code-font {
   font-family: $nhsuk-code-font;
+  word-spacing: -0.5ch;
 }

--- a/app/assets/sass/components/_status-bar.scss
+++ b/app/assets/sass/components/_status-bar.scss
@@ -28,6 +28,10 @@
   align-items: center;
 }
 
+.app-status-bar__row--compact {
+  gap: 10px;
+}
+
 .app-status-bar__row + .app-status-bar__row {
   margin-top: 8px;
   padding-top: 8px;
@@ -43,6 +47,10 @@
 .app-status-bar__key {
   @include nhsuk-typography-weight-bold($important: true);
   opacity: 0.9;
+}
+
+.app-status-bar__worklist-status {
+  margin-left: 4px;
 }
 
 .app-status-bar__viewer-link {

--- a/app/assets/sass/components/_status-bar.scss
+++ b/app/assets/sass/components/_status-bar.scss
@@ -28,9 +28,9 @@
   align-items: center;
 }
 
-.app-status-bar__row--compact {
-  gap: 10px;
-}
+// .app-status-bar__row--compact {
+//   gap: 10px;
+// }
 
 .app-status-bar__row + .app-status-bar__row {
   margin-top: 8px;

--- a/app/lib/generators/clinic-generator.js
+++ b/app/lib/generators/clinic-generator.js
@@ -183,6 +183,7 @@ const generateClinic = (
     clinicCode: generateClinicCode(),
     date: clinicDate.format('YYYY-MM-DD'),
     breastScreeningUnitId: breastScreeningUnit.id,
+    bsuAbbreviation: breastScreeningUnit.abbreviation,
     locationType: location.type,
     clinicType,
     riskLevels,

--- a/app/lib/generators/event-generator.js
+++ b/app/lib/generators/event-generator.js
@@ -143,10 +143,19 @@ const generateEvent = ({
     eventStatus = 'event_in_progress'
   }
 
+  // Generate accession number for this appointment - format: ABCYYYYMMDD#####
+  // ABC = BSU abbreviation, YYYYMMDD = clinic date, ##### = random 5-digit sequence
+  const accessionNumber = [
+    clinic.bsuAbbreviation || 'BSU',
+    dayjs(clinic.date).format('YYYYMMDD'),
+    faker.number.int({ min: 10000, max: 99999 })
+  ].join('')
+
   const eventBase = {
     id: id || generateId(),
     participantId: participant.id,
     clinicId: clinic.id,
+    accessionNumber,
     slotId: slot.id,
     type: clinic.clinicType,
     timing: {
@@ -271,6 +280,7 @@ const generateEvent = ({
       // Add mammogram images for completed events
       event.mammogramData = generateMammogramImages({
         startTime: actualStartTime,
+        accessionNumber: eventBase.accessionNumber,
         isSeedData: true,
         config: participant.config,
         scenarioWeights: seedDataProfile?.mammogram?.scenarioWeights,
@@ -347,6 +357,7 @@ const generateEvent = ({
       if (event.workflowStatus?.['take-images'] === 'completed') {
         event.mammogramData = generateMammogramImages({
           startTime: dayjs(event.sessionDetails.startedAt),
+          accessionNumber: event.accessionNumber,
           isSeedData: true,
           config: participant.config,
           scenarioWeights: seedDataProfile?.mammogram?.scenarioWeights,

--- a/app/lib/generators/mammogram-generator.js
+++ b/app/lib/generators/mammogram-generator.js
@@ -145,6 +145,7 @@ const generateViewImages = ({
  *
  * @param {object} [options] - Generation options
  * @param {Date|string} [options.startTime] - Starting timestamp (defaults to now)
+ * @param {string} [options.accessionNumber] - Accession number for this study (from the event)
  * @param {boolean} [options.isSeedData] - Whether generating seed data
  * @param {object} [options.config] - Optional configuration for specific scenarios
  * @param {string} [options.config.scenario] - Force a specific scenario ('standard', 'extraImages', 'technicalRepeat', 'incomplete', 'incompleteImperfect')
@@ -155,13 +156,15 @@ const generateViewImages = ({
  */
 const generateMammogramImages = ({
   startTime = new Date(),
+  accessionNumber = null,
   isSeedData = false,
   config = {},
   scenarioWeights = null,
   imperfectChanceForTechnicalOrIncomplete = 0.15,
   notesForReaderChanceWithoutImperfect = 0.05
 } = {}) => {
-  const accessionBase = faker.number
+  // Use the provided accession number as base, or fall back to a random number
+  const accessionBase = accessionNumber || faker.number
     .int({ min: 100000000, max: 999999999 })
     .toString()
   let currentIndex = 1
@@ -359,7 +362,6 @@ const generateMammogramImages = ({
   }
 
   return {
-    accessionBase,
     views,
     ...incompleteMammographyData,
     ...imperfectData,

--- a/app/lib/utils/strings.js
+++ b/app/lib/utils/strings.js
@@ -357,6 +357,29 @@ const formatNhsNumber = (input) => {
 // formatNhsNumber('485 777 3456') // returns '485 777 3456'
 
 /**
+ * Format an accession number for display with spaces (ABC YYYYMMDD ##### format)
+ *
+ * @param {string} input - Raw accession number, e.g. 'KOX2026052712345'
+ * @returns {string} Formatted accession number, e.g. 'KOX 20260527 12345'
+ * @example
+ * formatAccessionNumber('KOX2026052712345') // 'KOX 20260527 12345'
+ */
+const formatAccessionNumber = (input) => {
+  if (!input) return ''
+  const str = input.toString().replace(/\s/g, '')
+
+  // Expect 3 letters + 8 digits (date) + remaining digits
+  if (!/^[A-Z]{3}\d{13,}$/.test(str)) {
+    return input
+  }
+
+  const bsu = str.slice(0, 3)
+  const date = str.slice(3, 11)
+  const sequence = str.slice(11)
+  return `${bsu} ${date} ${sequence}`
+}
+
+/**
  * Make a word plural based on a count
  *
  * @param {string} word - Word to pluralise
@@ -394,6 +417,7 @@ const formatMammogramViewCode = (code) => {
 
 module.exports = {
   addIndefiniteArticle,
+  formatAccessionNumber,
   formatCurrency,
   formatCurrencyForCsv,
   formatNhsNumber,

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -2382,6 +2382,12 @@ module.exports = (router) => {
   router.get('/clinics/:clinicId/events/:eventId/images-manual', (req, res) => {
     const { clinicId, eventId } = req.params
     const data = req.session.data
+    const validTroubleshootingIssues = [
+      'worklist-participant',
+      'wrong-image-count',
+      'incorrect-image-labels'
+    ]
+    const troubleshootingIssue = req.query.issue
 
     // If mammogramData exists and is manual entry, prepopulate temp for editing
     if (data.event?.mammogramData?.isManualEntry) {
@@ -2408,6 +2414,17 @@ module.exports = (router) => {
         }
         data.event.mammogramDataTemp.isManualFailover = true
       }
+    }
+
+    // Persist troubleshooting issue context when navigating from troubleshooting links
+    if (validTroubleshootingIssues.includes(troubleshootingIssue)) {
+      if (!data.event.mammogramDataTemp) {
+        data.event.mammogramDataTemp = {}
+      }
+      data.event.mammogramDataTemp.troubleshootingIssue = troubleshootingIssue
+    } else if (data.event?.mammogramDataTemp?.troubleshootingIssue) {
+      // Clear stale issue context for non-troubleshooting entry points
+      delete data.event.mammogramDataTemp.troubleshootingIssue
     }
 
     // Let the dynamic routing handle the actual rendering

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -5,6 +5,7 @@ const _ = require('lodash')
 const {
   getParticipant,
   getFullName,
+  getAge,
   saveTempParticipantToParticipant
 } = require('../lib/utils/participants')
 const {
@@ -25,7 +26,7 @@ const {
 } = require('../lib/utils/referrers')
 const { createDynamicTemplateRoute } = require('../lib/utils/dynamic-routing')
 const { isAppointmentWorkflow } = require('../lib/utils/status')
-const { sentenceCase } = require('../lib/utils/strings')
+const { sentenceCase, formatNhsNumber } = require('../lib/utils/strings')
 const { getImageSetForEvent } = require('../lib/utils/mammogram-images')
 const {
   ensureSeedProfilesState,
@@ -2228,10 +2229,133 @@ module.exports = (router) => {
     }
   )
 
+  // Worklist connection retry routes
+
+  // Helper: only allow same-origin app paths as return URLs.
+  const safeReturnUrl = (url) => {
+    if (typeof url !== 'string') return null
+    if (!url.startsWith('/')) return null
+    if (url.startsWith('//')) return null
+    return url
+  }
+
+  // GET the retry page - capture where the user came from so we can send them
+  // back after a successful reconnect.
+  router.get('/clinics/:clinicId/events/:eventId/retry-worklist-connection', (req, res) => {
+    const data = req.session.data
+
+    const fromQuery = safeReturnUrl(req.query.returnUrl)
+    if (fromQuery) {
+      data.worklistRetryReturnUrl = fromQuery
+    }
+
+    res.render('events/retry-worklist-connection')
+  })
+
+  // Handle "Retry connection" button.
+  // The first attempt always fails (updates the "last retry attempt" time).
+  // The second (and any subsequent) attempt succeeds: marks the appointment as
+  // added to the worklist, flashes a success message, and returns the user to
+  // wherever they clicked Retry from.
+  router.post('/clinics/:clinicId/events/:eventId/retry-worklist-connection', (req, res) => {
+    const { clinicId, eventId } = req.params
+    const data = req.session.data
+
+    data.settings = data.settings || {}
+    data.settings.screening = data.settings.screening || {}
+
+    const attempts = (data.worklistRetryAttempts || 0) + 1
+
+    if (attempts >= 2) {
+      // Success: connection restored.
+      data.settings.screening.addedToWorklist = 'true'
+      delete data.settings.screening.worklistLastRetryAt
+      delete data.worklistRetryAttempts
+
+      const returnUrl =
+        safeReturnUrl(data.worklistRetryReturnUrl) ||
+        `/clinics/${clinicId}/events/${eventId}/take-images`
+      delete data.worklistRetryReturnUrl
+
+      const participantName = getFullName(data.participant)
+      req.flash('success', {
+        html: `<p class="nhsuk-notification-banner__heading">${participantName} is now on the worklist</p>
+<p>Image information will be sent automatically from the mammogram machine</p>`
+      })
+      return res.redirect(returnUrl)
+    }
+
+    // Failed attempt.
+    data.worklistRetryAttempts = attempts
+    data.settings.screening.worklistLastRetryAt = new Date().toISOString()
+
+    res.redirect(`/clinics/${clinicId}/events/${eventId}/retry-worklist-connection`)
+  })
+
+  // Handle "Switch to manual image mode" button - enable manual mode, return
+  // the user to where they clicked Retry from, and flash a success banner
+  // explaining what they need to do on the mammogram machine.
+  router.post('/clinics/:clinicId/events/:eventId/switch-to-manual-image-mode', (req, res) => {
+    const { clinicId, eventId } = req.params
+    const data = req.session.data
+
+    data.settings = data.settings || {}
+    data.settings.screening = data.settings.screening || {}
+    data.settings.screening.manualImageCollection = 'true'
+
+    const returnUrl =
+      safeReturnUrl(data.worklistRetryReturnUrl) ||
+      `/clinics/${clinicId}/events/${eventId}/take-images`
+
+    delete data.worklistRetryAttempts
+    delete data.worklistRetryReturnUrl
+    delete data.settings.screening.worklistLastRetryAt
+
+    const participant = data.participant || {}
+    const demographic = participant.demographicInformation || {}
+    const medical = participant.medicalInformation || {}
+    const participantName = getFullName(participant)
+    const nhsNumber = formatNhsNumber(medical.nhsNumber)
+    const dob = demographic.dateOfBirth
+    const dobFormatted = dob ? dayjs(dob).format('D MMMM YYYY') : ''
+    const age = getAge(participant)
+    const dobValue = dobFormatted
+      ? `${dobFormatted}${age ? ` (${age} years old)` : ''}`
+      : ''
+
+    const html = `
+<p class="nhsuk-notification-banner__heading">Manual image mode enabled</p>
+<p>Set up an unscheduled appointment for ${participantName} on the mammogram machine before taking images.</p>
+<p>Add the following details so mammograms can be matched to the correct participant:</p>
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">NHS number</dt>
+    <dd class="nhsuk-summary-list__value">${nhsNumber}</dd>
+  </div>
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">Full name</dt>
+    <dd class="nhsuk-summary-list__value">${participantName}</dd>
+  </div>
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">Date of birth</dt>
+    <dd class="nhsuk-summary-list__value">${dobValue}</dd>
+  </div>
+</dl>`
+
+    req.flash('success', {
+      title: 'Success',
+      html
+    })
+
+    res.redirect(returnUrl)
+  })
+
   // Manual imaging routes
 
-  // Handle take-images route - redirect to appropriate page based on state
-  router.get('/clinics/:clinicId/events/:eventId/take-images', (req, res) => {
+  // Handle take-images route - redirect to appropriate page based on state.
+  // Use `all` so the gate applies to the POST from review-medical-information
+  // as well as direct GET navigation.
+  router.all('/clinics/:clinicId/events/:eventId/take-images', (req, res) => {
     const { clinicId, eventId } = req.params
     const data = req.session.data
 
@@ -2239,6 +2363,19 @@ module.exports = (router) => {
       data.settings?.screening?.manualImageCollection === 'true'
     const imagesStageCompleted =
       data.event?.workflowStatus?.['take-images'] === 'completed'
+
+    // Gate: if the appointment was not added to the worklist and the user
+    // hasn't yet switched to manual image mode, divert to the retry page
+    // before letting them into the image-taking step.
+    const isAddedToWorklist =
+      data.settings?.screening?.addedToWorklist !== 'false'
+
+    if (!isAddedToWorklist && !isManualImageCollection) {
+      return res.redirect(
+        `/clinics/${clinicId}/events/${eventId}/retry-worklist-connection?returnUrl=` +
+          encodeURIComponent(`/clinics/${clinicId}/events/${eventId}/take-images`)
+      )
+    }
 
     // If manual flow and images already completed, redirect to details page for editing
     if (

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -5,7 +5,6 @@ const _ = require('lodash')
 const {
   getParticipant,
   getFullName,
-  getAge,
   saveTempParticipantToParticipant
 } = require('../lib/utils/participants')
 const {
@@ -26,7 +25,7 @@ const {
 } = require('../lib/utils/referrers')
 const { createDynamicTemplateRoute } = require('../lib/utils/dynamic-routing')
 const { isAppointmentWorkflow } = require('../lib/utils/status')
-const { sentenceCase, formatNhsNumber } = require('../lib/utils/strings')
+const { sentenceCase } = require('../lib/utils/strings')
 const { getImageSetForEvent } = require('../lib/utils/mammogram-images')
 const {
   ensureSeedProfilesState,
@@ -2311,40 +2310,9 @@ module.exports = (router) => {
     delete data.worklistRetryReturnUrl
     delete data.settings.screening.worklistLastRetryAt
 
-    const participant = data.participant || {}
-    const demographic = participant.demographicInformation || {}
-    const medical = participant.medicalInformation || {}
-    const participantName = getFullName(participant)
-    const nhsNumber = formatNhsNumber(medical.nhsNumber)
-    const dob = demographic.dateOfBirth
-    const dobFormatted = dob ? dayjs(dob).format('D MMMM YYYY') : ''
-    const age = getAge(participant)
-    const dobValue = dobFormatted
-      ? `${dobFormatted}${age ? ` (${age} years old)` : ''}`
-      : ''
-
-    const html = `
-<p class="nhsuk-notification-banner__heading">Manual image mode enabled</p>
-<p>Set up an unscheduled appointment for ${participantName} on the mammogram machine before taking images.</p>
-<p>Add the following details so mammograms can be matched to the correct participant:</p>
-<dl class="nhsuk-summary-list">
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">NHS number</dt>
-    <dd class="nhsuk-summary-list__value">${nhsNumber}</dd>
-  </div>
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">Full name</dt>
-    <dd class="nhsuk-summary-list__value">${participantName}</dd>
-  </div>
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">Date of birth</dt>
-    <dd class="nhsuk-summary-list__value">${dobValue}</dd>
-  </div>
-</dl>`
-
     req.flash('success', {
       title: 'Success',
-      html
+      html: '<p class="nhsuk-notification-banner__heading">Manual image mode enabled</p>'
     })
 
     res.redirect(returnUrl)

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -2335,6 +2335,18 @@ module.exports = (router) => {
     const { clinicId, eventId } = req.params
     const data = req.session.data
 
+    const isAddedToWorklist =
+      data.settings?.screening?.addedToWorklist !== 'false'
+
+    // When a participant is on the worklist, image transfer should use the
+    // automatic flow. Clear any stale manual-mode state from prior actions.
+    if (isAddedToWorklist) {
+      data.settings = data.settings || {}
+      data.settings.screening = data.settings.screening || {}
+      data.settings.screening.manualImageCollection = 'false'
+      delete data.settings.screening.manualImageModeEnabledByUser
+    }
+
     const isManualImageCollection =
       data.settings?.screening?.manualImageCollection === 'true'
     const imagesStageCompleted =
@@ -2343,8 +2355,6 @@ module.exports = (router) => {
     // Gate: if the appointment was not added to the worklist and the user
     // hasn't yet switched to manual image mode, divert to the retry page
     // before letting them into the image-taking step.
-    const isAddedToWorklist =
-      data.settings?.screening?.addedToWorklist !== 'false'
 
     if (!isAddedToWorklist && !isManualImageCollection) {
       return res.redirect(

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -2229,102 +2229,63 @@ module.exports = (router) => {
   )
 
   // Worklist connection retry routes
+  //
+  // The retry page is rendered as a simple GET (auto-routed or via this route).
+  // Retry counting is handled entirely client-side — the JS fakes a failed
+  // first attempt and a successful second attempt, then submits the form.
+  //
+  // POST retry-worklist-connection: marks worklist as connected and redirects
+  // back using the standard referrerChain system.
+  //
+  // POST switch-to-manual-image-mode: stores manual mode on the EVENT (not
+  // globally) and redirects back via referrerChain.
 
-  // Helper: only allow same-origin app paths as return URLs.
-  const safeReturnUrl = (url) => {
-    if (typeof url !== 'string') return null
-    if (!url.startsWith('/')) return null
-    if (url.startsWith('//')) return null
-    return url
-  }
+  // Handle successful "Retry connection" — client-side JS only submits after
+  // simulating a successful reconnect.
+  router.post(
+    '/clinics/:clinicId/events/:eventId/retry-worklist-connection',
+    (req, res) => {
+      const { clinicId, eventId } = req.params
+      const data = req.session.data
 
-  // GET the retry page - capture where the user came from so we can send them
-  // back after a successful reconnect.
-  router.get('/clinics/:clinicId/events/:eventId/retry-worklist-connection', (req, res) => {
-    const data = req.session.data
-
-    const fromQuery = safeReturnUrl(req.query.returnUrl)
-    if (fromQuery) {
-      data.worklistRetryReturnUrl = fromQuery
-    }
-
-    res.render('events/retry-worklist-connection')
-  })
-
-  // Handle "Retry connection" button.
-  // The first attempt always fails (updates the "last retry attempt" time).
-  // The second (and any subsequent) attempt succeeds: marks the appointment as
-  // added to the worklist, flashes a success message, and returns the user to
-  // wherever they clicked Retry from.
-  router.post('/clinics/:clinicId/events/:eventId/retry-worklist-connection', (req, res) => {
-    const { clinicId, eventId } = req.params
-    const data = req.session.data
-
-    data.settings = data.settings || {}
-    data.settings.screening = data.settings.screening || {}
-
-    const attempts = (data.worklistRetryAttempts || 0) + 1
-
-    if (attempts >= 2) {
-      // Success: connection restored.
-      data.settings.screening.addedToWorklist = 'true'
-      delete data.settings.screening.worklistLastRetryAt
-      delete data.worklistRetryAttempts
-
-      const returnUrl =
-        safeReturnUrl(data.worklistRetryReturnUrl) ||
-        `/clinics/${clinicId}/events/${eventId}/take-images`
-      delete data.worklistRetryReturnUrl
+      // Mark this event as reconnected (per-event, doesn't change the global setting)
+      data.event.isOnWorklist = true
 
       const participantName = getFullName(data.participant)
       req.flash('success', {
         html: `<p class="nhsuk-notification-banner__heading">${participantName} is now on the worklist</p>
 <p>Image information will be sent automatically from the mammogram machine</p>`
       })
+
+      const returnUrl = getReturnUrl(
+        `/clinics/${clinicId}/events/${eventId}/take-images`,
+        req.query.referrerChain
+      )
       return res.redirect(returnUrl)
     }
+  )
 
-    // Failed attempt.
-    data.worklistRetryAttempts = attempts
-    data.settings.screening.worklistLastRetryAt = new Date().toISOString()
+  // Handle "Switch to manual image mode" — stores override on the event only.
+  router.post(
+    '/clinics/:clinicId/events/:eventId/switch-to-manual-image-mode',
+    (req, res) => {
+      const { clinicId, eventId } = req.params
+      const data = req.session.data
 
-    res.redirect(`/clinics/${clinicId}/events/${eventId}/retry-worklist-connection`)
-  })
+      // Store manual mode on the event itself, not globally
+      data.event.isManualImageCollection = true
 
-  // Handle "Switch to manual image mode" button - enable manual mode, return
-  // the user to where they clicked Retry from, and flash a success banner
-  // explaining what they need to do on the mammogram machine.
-  router.post('/clinics/:clinicId/events/:eventId/switch-to-manual-image-mode', (req, res) => {
-    const { clinicId, eventId } = req.params
-    const data = req.session.data
+      req.flash('success', {
+        html: '<p class="nhsuk-notification-banner__heading">Manual image mode enabled</p>'
+      })
 
-    data.settings = data.settings || {}
-    data.settings.screening = data.settings.screening || {}
-    data.settings.screening.manualImageCollection = 'true'
-    data.settings.screening.manualImageModeEnabledByUser = 'true'
-
-    const returnUrl =
-      safeReturnUrl(data.worklistRetryReturnUrl) ||
-      `/clinics/${clinicId}/events/${eventId}/take-images`
-
-    delete data.worklistRetryAttempts
-    delete data.worklistRetryReturnUrl
-    delete data.settings.screening.worklistLastRetryAt
-
-    // Clear any failover flag from a prior automatic→manual switch so we
-    // don't incorrectly show the "Reason for switching" input here (the
-    // reason is implicit when arriving via the retry-connection flow).
-    if (data.event?.mammogramDataTemp) {
-      delete data.event.mammogramDataTemp.isManualFailover
+      const returnUrl = getReturnUrl(
+        `/clinics/${clinicId}/events/${eventId}/take-images`,
+        req.query.referrerChain
+      )
+      res.redirect(returnUrl)
     }
-
-    req.flash('success', {
-      title: 'Success',
-      html: '<p class="nhsuk-notification-banner__heading">Manual image mode enabled</p>'
-    })
-
-    res.redirect(returnUrl)
-  })
+  )
 
   // Manual imaging routes
 
@@ -2336,30 +2297,27 @@ module.exports = (router) => {
     const data = req.session.data
 
     const isAddedToWorklist =
-      data.settings?.screening?.addedToWorklist !== 'false'
+      data.settings?.screening?.addedToWorklist !== 'false' ||
+      data.event?.isOnWorklist === true
 
-    // When a participant is on the worklist, image transfer should use the
-    // automatic flow. Clear any stale manual-mode state from prior actions.
-    if (isAddedToWorklist) {
-      data.settings = data.settings || {}
-      data.settings.screening = data.settings.screening || {}
-      data.settings.screening.manualImageCollection = 'false'
-      delete data.settings.screening.manualImageModeEnabledByUser
-    }
-
+    // Manual mode is true if the global setting says so, OR this specific
+    // event was switched to manual (e.g. via the retry-connection page).
     const isManualImageCollection =
-      data.settings?.screening?.manualImageCollection === 'true'
+      data.settings?.screening?.manualImageCollection === 'true' ||
+      data.event?.isManualImageCollection === true
+
     const imagesStageCompleted =
       data.event?.workflowStatus?.['take-images'] === 'completed'
 
     // Gate: if the appointment was not added to the worklist and the user
     // hasn't yet switched to manual image mode, divert to the retry page
     // before letting them into the image-taking step.
-
     if (!isAddedToWorklist && !isManualImageCollection) {
       return res.redirect(
-        `/clinics/${clinicId}/events/${eventId}/retry-worklist-connection?returnUrl=` +
-          encodeURIComponent(`/clinics/${clinicId}/events/${eventId}/take-images`)
+        urlWithReferrer(
+          `/clinics/${clinicId}/events/${eventId}/retry-worklist-connection`,
+          `/clinics/${clinicId}/events/${eventId}/take-images`
+        )
       )
     }
 
@@ -2412,14 +2370,16 @@ module.exports = (router) => {
       // Clear any existing temp data for fresh start
       delete data.event.mammogramDataTemp
 
-      // Check if this is a failover from automatic mode
-      const isManualImageCollection =
+      // Check if this is a failover from automatic mode (event was switched
+      // to manual via the retry-connection page, or user navigated here from
+      // the troubleshooting link on the automatic images page).
+      const isGlobalManualSetting =
         data.settings?.screening?.manualImageCollection === 'true'
       const hadAutomaticData =
         !!data.event?.mammogramData && !data.event?.mammogramData?.isManualEntry
 
       // Set failover flag if switching from automatic to manual
-      if (!isManualImageCollection || hadAutomaticData) {
+      if (!isGlobalManualSetting || hadAutomaticData) {
         if (!data.event.mammogramDataTemp) {
           data.event.mammogramDataTemp = {}
         }

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -2301,6 +2301,7 @@ module.exports = (router) => {
     data.settings = data.settings || {}
     data.settings.screening = data.settings.screening || {}
     data.settings.screening.manualImageCollection = 'true'
+    data.settings.screening.manualImageModeEnabledByUser = 'true'
 
     const returnUrl =
       safeReturnUrl(data.worklistRetryReturnUrl) ||

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -2310,6 +2310,13 @@ module.exports = (router) => {
     delete data.worklistRetryReturnUrl
     delete data.settings.screening.worklistLastRetryAt
 
+    // Clear any failover flag from a prior automatic→manual switch so we
+    // don't incorrectly show the "Reason for switching" input here (the
+    // reason is implicit when arriving via the retry-connection flow).
+    if (data.event?.mammogramDataTemp) {
+      delete data.event.mammogramDataTemp.isManualFailover
+    }
+
     req.flash('success', {
       title: 'Success',
       html: '<p class="nhsuk-notification-banner__heading">Manual image mode enabled</p>'

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -64,6 +64,38 @@ const getCustomOverridesFromBody = (body = {}, fallbackProfile = {}) => {
 }
 
 module.exports = (router) => {
+  // Keep worklist simulation settings consistent with image collection mode:
+  // - "Not successful": clear any stale "manual mode enabled by user" marker
+  //   so retry messaging is shown
+  // - "Successful": return to automatic image collection mode
+  router.get('/settings', (req, res, next) => {
+    const addedToWorklistFromQuery =
+      req.query?.settings?.screening?.addedToWorklist
+
+    if (addedToWorklistFromQuery === 'false') {
+      if (!req.session.data.settings) {
+        req.session.data.settings = {}
+      }
+      if (!req.session.data.settings.screening) {
+        req.session.data.settings.screening = {}
+      }
+
+      delete req.session.data.settings.screening.manualImageModeEnabledByUser
+    } else if (addedToWorklistFromQuery === 'true') {
+      if (!req.session.data.settings) {
+        req.session.data.settings = {}
+      }
+      if (!req.session.data.settings.screening) {
+        req.session.data.settings.screening = {}
+      }
+
+      req.session.data.settings.screening.manualImageCollection = 'false'
+      delete req.session.data.settings.screening.manualImageModeEnabledByUser
+    }
+
+    next()
+  })
+
   // Ensure any POST to settings resolves to a GET render
   router.post('/settings', (req, res) => {
     return res.redirect(303, '/settings')

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -64,38 +64,6 @@ const getCustomOverridesFromBody = (body = {}, fallbackProfile = {}) => {
 }
 
 module.exports = (router) => {
-  // Keep worklist simulation settings consistent with image collection mode:
-  // - "Not successful": clear any stale "manual mode enabled by user" marker
-  //   so retry messaging is shown
-  // - "Successful": return to automatic image collection mode
-  router.get('/settings', (req, res, next) => {
-    const addedToWorklistFromQuery =
-      req.query?.settings?.screening?.addedToWorklist
-
-    if (addedToWorklistFromQuery === 'false') {
-      if (!req.session.data.settings) {
-        req.session.data.settings = {}
-      }
-      if (!req.session.data.settings.screening) {
-        req.session.data.settings.screening = {}
-      }
-
-      delete req.session.data.settings.screening.manualImageModeEnabledByUser
-    } else if (addedToWorklistFromQuery === 'true') {
-      if (!req.session.data.settings) {
-        req.session.data.settings = {}
-      }
-      if (!req.session.data.settings.screening) {
-        req.session.data.settings.screening = {}
-      }
-
-      req.session.data.settings.screening.manualImageCollection = 'false'
-      delete req.session.data.settings.screening.manualImageModeEnabledByUser
-    }
-
-    next()
-  })
-
   // Ensure any POST to settings resolves to a GET render
   router.post('/settings', (req, res) => {
     return res.redirect(303, '/settings')

--- a/app/views/_components/status-bar/template.njk
+++ b/app/views/_components/status-bar/template.njk
@@ -6,7 +6,7 @@
 <div class="app-status-bar {{ classes }}">
   <div class="nhsuk-width-container">
     {% for row in params.rows %}
-      <div class="app-status-bar__row">
+      <div class="app-status-bar__row{% if row.classes %} {{ row.classes }}{% endif %}">
         {% for item in row.items %}
           <div class="app-status-bar__item">
             {% if item.key and item.value %}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -21,13 +21,13 @@
 
 {# Worklist status #}
 {% set worklistStatusHtml %}
-  {% if data.settings.screening.addedToWorklist == 'false' %}
+  {% if data.settings.screening.addedToWorklist == 'false' and not data.event.isOnWorklist %}
     <span class="app-header-status app-header-status--fail">
       {{ appIcon("cross", { classes: "app-header-status__icon" }) }}
-      {% if data.settings.screening.manualImageCollection == 'true' and data.settings.screening.manualImageModeEnabledByUser == 'true' %}
+      {% if data.event.isManualImageCollection %}
         <span>Worklist issue, manual mode enabled</span>
       {% else %}
-        <span>Not on worklist (<a href="/clinics/{{ clinicId }}/events/{{ event.id }}/retry-worklist-connection?returnUrl={{ currentUrl | urlencode }}">Retry</a>)</span>
+        <span>Not on worklist (<a href="{{ ('/clinics/' + clinicId + '/events/' + event.id + '/retry-worklist-connection') | urlWithReferrer(currentUrl) }}">Retry</a>)</span>
       {% endif %}
     </span>
   {% else %}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -4,7 +4,7 @@
 {% set appointmentRowItems = [] %}
 
 {# Date and time #}
-{% set appointmentHtml %}
+{% set appointmentDateTimeHtml %}
   {{ clinic.date | formatDate }} at {{ event.timing.startTime | formatTimeString }}
   {% if event | isSpecialAppointment %}
     {{ tag({
@@ -13,25 +13,39 @@
       classes: "nhsuk-u-margin-left-1"
     })}}
   {% endif %}
+{% endset %}
+{% set appointmentRowItems = appointmentRowItems | push({
+  key: '<abbr title="Appointment">Appt</abbr>:',
+  value: appointmentDateTimeHtml
+}) %}
+
+{# Worklist accession number #}
+{% set appointmentRowItems = appointmentRowItems | push({
+  key: '<abbr title="Accession number">Accn</abbr>:',
+  value: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>'
+}) %}
+
+{# Worklist status #}
+{% set worklistStatusHtml %}
   {% if data.settings.screening.addedToWorklist == 'false' %}
     <span class="app-header-status app-header-status--fail">
       {{ appIcon("cross", { classes: "app-header-status__icon" }) }}
       {% if data.settings.screening.manualImageCollection == 'true' %}
         <span>Not added to worklist (manual image mode enabled)</span>
       {% else %}
-        <span>Not added to worklist (ID: KOX20260527A1246) <a href="/clinics/{{ clinicId }}/events/{{ event.id }}/retry-worklist-connection?returnUrl={{ currentUrl | urlencode }}">Retry</a></span>
+        <span>Not added to worklist <a href="/clinics/{{ clinicId }}/events/{{ event.id }}/retry-worklist-connection?returnUrl={{ currentUrl | urlencode }}">Retry</a></span>
       {% endif %}
     </span>
   {% else %}
     <span class="app-header-status">
       {{ appIcon("tick", { classes: "app-header-status__icon" }) }}
-      <span>Added to worklist (ID: KOX20260527A1246)</span>
+      <span>Added to worklist</span>
     </span>
   {% endif %}
 {% endset %}
 {% set appointmentRowItems = appointmentRowItems | push({
-  key: "Appointment:",
-  value: appointmentHtml
+  key: '<span class="nhsuk-u-visually-hidden">Worklist status</span>',
+  value: worklistStatusHtml
 }) %}
 
 {# Appointment type #}
@@ -90,7 +104,7 @@
 {# NHS Number #}
 {% set participantRowItems = participantRowItems | push({
   key: "NHS:",
-  value: participant.medicalInformation.nhsNumber | formatNhsNumber
+  value: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber | replace(' ', '&#8201;')) + '</span>'
 }) %}
 
 {{ appStatusBar({

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -16,12 +16,16 @@
   {% if data.settings.screening.addedToWorklist == 'false' %}
     <span class="app-header-status app-header-status--fail">
       {{ appIcon("cross", { classes: "app-header-status__icon" }) }}
-      <span>Not added to worklist (ID: A123BC4) (<a href="#">Retry</a>)</span>
+      {% if data.settings.screening.manualImageCollection == 'true' %}
+        <span>Not added to worklist (manual image mode enabled)</span>
+      {% else %}
+        <span>Not added to worklist (ID: KOX20260527A1246) <a href="/clinics/{{ clinicId }}/events/{{ event.id }}/retry-worklist-connection?returnUrl={{ currentUrl | urlencode }}">Retry</a></span>
+      {% endif %}
     </span>
   {% else %}
     <span class="app-header-status">
       {{ appIcon("tick", { classes: "app-header-status__icon" }) }}
-      <span>Added to worklist (ID: A123BC4)</span>
+      <span>Added to worklist (ID: KOX20260527A1246)</span>
     </span>
   {% endif %}
 {% endset %}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -39,9 +39,10 @@
 {% endset %}
 
 {# Worklist accession number with inline worklist status #}
+{% set accessionNumberFormatted = event.accessionNumber | formatAccessionNumber %}
 {% set appointmentRowItems = appointmentRowItems | push({
   key: '<abbr title="Accession number">Accn</abbr>:',
-  value: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span><span class="app-status-bar__worklist-status">' + worklistStatusHtml + '</span>'
+  value: '<span class="app-code-font nhsuk-u-nowrap">' + accessionNumberFormatted + '</span><span class="app-status-bar__worklist-status">' + worklistStatusHtml + '</span>'
 }) %}
 
 {# Appointment type #}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -42,7 +42,7 @@
 {% set accessionNumberFormatted = event.accessionNumber | formatAccessionNumber %}
 {% set appointmentRowItems = appointmentRowItems | push({
   key: '<abbr title="Accession number">Accn</abbr>:',
-  value: '<span class="app-code-font nhsuk-u-nowrap">' + accessionNumberFormatted + '</span><span class="app-status-bar__worklist-status">' + worklistStatusHtml + '</span>'
+  value: '<span class="nhsuk-u-font-code nhsuk-u-nowrap">' + accessionNumberFormatted + '</span><span class="app-status-bar__worklist-status">' + worklistStatusHtml + '</span>'
 }) %}
 
 {# Appointment type #}
@@ -101,7 +101,7 @@
 {# NHS Number #}
 {% set participantRowItems = participantRowItems | push({
   key: "NHS:",
-  value: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber) + '</span>'
+  value: '<span class="nhsuk-u-font-code nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber) + '</span>'
 }) %}
 
 {{ appStatusBar({

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -16,12 +16,12 @@
   {% if data.settings.screening.addedToWorklist == 'false' %}
     <span class="app-header-status app-header-status--fail">
       {{ appIcon("cross", { classes: "app-header-status__icon" }) }}
-      <span>Not added to worklist (<a href="#">Retry</a>)</span>
+      <span>Not added to worklist (ID: A123BC4) (<a href="#">Retry</a>)</span>
     </span>
   {% else %}
     <span class="app-header-status">
       {{ appIcon("tick", { classes: "app-header-status__icon" }) }}
-      <span>Added to worklist</span>
+      <span>Added to worklist (ID: A123BC4)</span>
     </span>
   {% endif %}
 {% endset %}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -19,33 +19,29 @@
   value: appointmentDateTimeHtml
 }) %}
 
-{# Worklist accession number #}
-{% set appointmentRowItems = appointmentRowItems | push({
-  key: '<abbr title="Accession number">Accn</abbr>:',
-  value: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>'
-}) %}
-
 {# Worklist status #}
 {% set worklistStatusHtml %}
   {% if data.settings.screening.addedToWorklist == 'false' %}
     <span class="app-header-status app-header-status--fail">
       {{ appIcon("cross", { classes: "app-header-status__icon" }) }}
-      {% if data.settings.screening.manualImageCollection == 'true' %}
-        <span>Not added to worklist (manual image mode enabled)</span>
+      {% if data.settings.screening.manualImageCollection == 'true' and data.settings.screening.manualImageModeEnabledByUser == 'true' %}
+        <span>Worklist issue, manual mode enabled</span>
       {% else %}
-        <span>Not added to worklist <a href="/clinics/{{ clinicId }}/events/{{ event.id }}/retry-worklist-connection?returnUrl={{ currentUrl | urlencode }}">Retry</a></span>
+        <span>Not on worklist (<a href="/clinics/{{ clinicId }}/events/{{ event.id }}/retry-worklist-connection?returnUrl={{ currentUrl | urlencode }}">Retry</a>)</span>
       {% endif %}
     </span>
   {% else %}
     <span class="app-header-status">
       {{ appIcon("tick", { classes: "app-header-status__icon" }) }}
-      <span>Added to worklist</span>
+      <span>On worklist</span>
     </span>
   {% endif %}
 {% endset %}
+
+{# Worklist accession number with inline worklist status #}
 {% set appointmentRowItems = appointmentRowItems | push({
-  key: '<span class="nhsuk-u-visually-hidden">Worklist status</span>',
-  value: worklistStatusHtml
+  key: '<abbr title="Accession number">Accn</abbr>:',
+  value: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span><span class="app-status-bar__worklist-status">' + worklistStatusHtml + '</span>'
 }) %}
 
 {# Appointment type #}

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -101,7 +101,7 @@
 {# NHS Number #}
 {% set participantRowItems = participantRowItems | push({
   key: "NHS:",
-  value: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber | replace(' ', '&#8201;')) + '</span>'
+  value: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber) + '</span>'
 }) %}
 
 {{ appStatusBar({

--- a/app/views/_includes/images/image-troubleshooting.njk
+++ b/app/views/_includes/images/image-troubleshooting.njk
@@ -19,7 +19,7 @@
         
         <p>If this needs to be changed, update the mammogram machine and wait a few seconds for the image details to refresh.</p>
 
-        <p>If the issue is not resolved, <a href="./images-manual" class="nhsuk-link">enable manual image mode</a>.</p>
+        <p>If the issue is not resolved, <a href="./images-manual?issue=worklist-participant" class="nhsuk-link">enable manual image mode</a>.</p>
 
         <p>Images details will be reconciled after the appointment.</p>
 
@@ -29,7 +29,7 @@
           summaryText: "The wrong number of images are displayed"
         }) %}
 
-        <p><a href="./images-manual" class="nhsuk-link">Enable manual image mode</a>.</p>
+        <p><a href="./images-manual?issue=wrong-image-count" class="nhsuk-link">Enable manual image mode</a>.</p>
 
         <p>Images details will be reconciled after the appointment.</p>
 
@@ -41,7 +41,7 @@
           
         <p>Update image information on the mammogram machine and wait a few seconds for the image details to refresh.</p>
 
-        <p>If the issue is not resolved, <a href="./images-manual" class="nhsuk-link">enable manual image mode</a>.</p>
+        <p>If the issue is not resolved, <a href="./images-manual?issue=incorrect-image-labels" class="nhsuk-link">enable manual image mode</a>.</p>
 
         <p>Images details will be reconciled after the appointment.</p>
 

--- a/app/views/_includes/summary-lists/medical-information/mammogram-image-data.njk
+++ b/app/views/_includes/summary-lists/medical-information/mammogram-image-data.njk
@@ -117,6 +117,25 @@
 
 {% set defaultHref = "./images-automatic" %}
 
+{# Image recording method - only show if manual entry #}
+{% if isManualEntry %}
+  {% set imageRecordingValueHtml %}
+    <p>Manual</p>
+    {% if event.mammogramData.isManualFailover %}
+      <p><a href="{{ './images-manual-problem-description' | urlWithReferrer(referrerChain, scrollTo) }}" class="nhsuk-link">Add a reason for using manual data collection</a></p>
+    {% endif %}
+  {% endset %}
+
+  {% set summaryRows = summaryRows | push({
+    key: {
+      text: "Image recording method"
+    },
+    value: {
+      html: imageRecordingValueHtml
+    }
+  }) %}
+{% endif %}
+
 {# Machine room #}
 {% if event.mammogramData.machineRoom %}
   {# Check if this is a mobile clinic #}
@@ -142,25 +161,6 @@
     },
     actions: {
       items: machineRoomActions
-    }
-  }) %}
-{% endif %}
-
-{# Image recording method - only show if manual entry #}
-{% if isManualEntry %}
-  {% set imageRecordingValueHtml %}
-    <p>Manual</p>
-    {% if event.mammogramData.isManualFailover %}
-      <p><a href="{{ './images-manual-problem-description' | urlWithReferrer(referrerChain, scrollTo) }}" class="nhsuk-link">Add a reason for using manual data collection</a></p>
-    {% endif %}
-  {% endset %}
-
-  {% set summaryRows = summaryRows | push({
-    key: {
-      text: "Image recording method"
-    },
-    value: {
-      html: imageRecordingValueHtml
     }
   }) %}
 {% endif %}

--- a/app/views/_includes/summary-lists/medical-information/mammogram-image-data.njk
+++ b/app/views/_includes/summary-lists/medical-information/mammogram-image-data.njk
@@ -121,9 +121,10 @@
 {% if isManualEntry %}
   {% set imageRecordingValueHtml %}
     <p>Manual</p>
-    {% if event.mammogramData.isManualFailover %}
+    {# Commented out until we decide how to collect a reason #}
+    {# {% if event.mammogramData.isManualFailover %}
       <p><a href="{{ './images-manual-problem-description' | urlWithReferrer(referrerChain, scrollTo) }}" class="nhsuk-link">Add a reason for using manual data collection</a></p>
-    {% endif %}
+    {% endif %} #}
   {% endset %}
 
   {% set summaryRows = summaryRows | push({

--- a/app/views/events/appointment.html
+++ b/app/views/events/appointment.html
@@ -258,7 +258,7 @@
             text: "Accession number"
           },
           value: {
-            html: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>'
+            html: '<span class="app-code-font nhsuk-u-nowrap">' + (event.accessionNumber | formatAccessionNumber) + '</span>'
           },
           actions: {
             items: []

--- a/app/views/events/appointment.html
+++ b/app/views/events/appointment.html
@@ -258,7 +258,7 @@
             text: "Accession number"
           },
           value: {
-            html: '<span class="app-code-font nhsuk-u-nowrap">' + (event.accessionNumber | formatAccessionNumber) + '</span>'
+            html: '<span class="nhsuk-u-font-code nhsuk-u-nowrap">' + (event.accessionNumber | formatAccessionNumber) + '</span>'
           },
           actions: {
             items: []

--- a/app/views/events/appointment.html
+++ b/app/views/events/appointment.html
@@ -252,6 +252,17 @@
               } | openInModal
             ] if event.status != "event_complete" else []
           }
+        },
+        {
+          key: {
+            text: "Accession number"
+          },
+          value: {
+            html: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>'
+          },
+          actions: {
+            items: []
+          }
         }
       ]
     } | handleSummaryListMissingInformation) }}

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -79,10 +79,13 @@
     ]
   }) }} #}
 
-  {# When the worklist connection failed and the user chose manual mode,
-     show the details they need to enter on the mammogram machine to set up
-     an unscheduled appointment. #}
-  {% if data.settings.screening.addedToWorklist == 'false' and data.settings.screening.manualImageCollection == 'true' %}
+  {# Show unscheduled-appointment setup details whenever the appointment is
+     being handled in manual image collection mode. The reason-for-switching
+     input is only shown when the user manually switched mid-appointment via
+     the troubleshooting link on the automatic images page (failover). #}
+  {% set isManualFailover = event.mammogramDataTemp.isManualFailover %}
+
+  {% if data.settings.screening.manualImageCollection == 'true' or isManualFailover %}
     <p>Set up an unscheduled appointment on the mammogram machine before taking images.</p>
     <p>Add the following details so your admin team can match mammograms to the correct participant once the appointment has been completed:</p>
     {{ summaryList({
@@ -105,6 +108,23 @@
         }
       ]
     }) }}
+
+    {% if isManualFailover %}
+      {% call details({
+        summaryText: "Add reason for switching to manual"
+      }) %}
+        {{ textarea({
+          label: {
+            text: "Reason for switching to manual",
+            classes: "nhsuk-label--s"
+          },
+          id: "manualImageModeReason",
+          name: "event[mammogramDataTemp][manualImageModeReason]",
+          rows: 3,
+          value: mammogramSource.manualImageModeReason
+        }) }}
+      {% endcall %}
+    {% endif %}
   {% endif %}
 
   {{ radios({

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -95,12 +95,12 @@
     {{ summaryList({
       rows: [
         {
-          key: { text: "ID" },
-          value: { text: "KOX20260527A1246" }
+          key: { html: '<abbr title="Accession number">Accn</abbr>' },
+          value: { html: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>' }
         },
         {
           key: { text: "NHS number" },
-          value: { text: participant.medicalInformation.nhsNumber | formatNhsNumber }
+          value: { html: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber | replace(' ', '&#8201;')) + '</span>' }
         },
         {
           key: { text: "Full name" },

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -84,10 +84,14 @@
      input is only shown when the user manually switched mid-appointment via
      the troubleshooting link on the automatic images page (failover). #}
   {% set isManualFailover = event.mammogramDataTemp.isManualFailover %}
+  {% set troubleshootingIssue = event.mammogramDataTemp.troubleshootingIssue %}
+  {% set hasTroubleshootingIssue = troubleshootingIssue in ['worklist-participant', 'wrong-image-count', 'incorrect-image-labels'] %}
+  {% set showWorklistMatchingContent = troubleshootingIssue == 'worklist-participant' %}
+  {% set showDefaultManualContent = data.settings.screening.manualImageCollection == 'true' or isManualFailover %}
 
-  {% if data.settings.screening.manualImageCollection == 'true' or isManualFailover %}
-    <p>Set up an unscheduled appointment on the mammogram machine before taking images.</p>
-    <p>Add the following details so your admin team can match mammograms to the correct participant once the appointment has been completed:</p>
+  {% if (hasTroubleshootingIssue and showWorklistMatchingContent) or (not hasTroubleshootingIssue and showDefaultManualContent) %}
+    <h2>Manually add participant details</h2>
+    <p>Set up an unscheduled appointment using the following information so mammograms can be assigned correctly:</p>
     {{ summaryList({
       rows: [
         {

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -113,7 +113,7 @@
       ]
     }) }}
 
-    {% if isManualFailover %}
+    {# {% if isManualFailover %}
       {% call details({
         summaryText: "Add reason for switching to manual"
       }) %}
@@ -128,7 +128,7 @@
           value: mammogramSource.manualImageModeReason
         }) }}
       {% endcall %}
-    {% endif %}
+    {% endif %} #}
   {% endif %}
 
   {{ radios({

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -4,7 +4,7 @@
 {% set hideBackLink = true %}
 {% set activeWorkflowStep = 'take-images' %}
 
-{% set pageHeading = "Record images taken" %}
+{% set pageHeading = "Manually record image information" %}
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
@@ -78,6 +78,34 @@
       }
     ]
   }) }} #}
+
+  {# When the worklist connection failed and the user chose manual mode,
+     show the details they need to enter on the mammogram machine to set up
+     an unscheduled appointment. #}
+  {% if data.settings.screening.addedToWorklist == 'false' and data.settings.screening.manualImageCollection == 'true' %}
+    <p>Set up an unscheduled appointment on the mammogram machine before taking images.</p>
+    <p>Add the following details so your admin team can match mammograms to the correct participant once the appointment has been completed:</p>
+    {{ summaryList({
+      rows: [
+        {
+          key: { text: "ID" },
+          value: { text: "KOX20260527A1246" }
+        },
+        {
+          key: { text: "NHS number" },
+          value: { text: participant.medicalInformation.nhsNumber | formatNhsNumber }
+        },
+        {
+          key: { text: "Full name" },
+          value: { text: participant | getFullName }
+        },
+        {
+          key: { text: "Date of birth" },
+          value: { text: participant.demographicInformation.dateOfBirth | formatDate }
+        }
+      ]
+    }) }}
+  {% endif %}
 
   {{ radios({
     idPrefix: "imagingComplete",

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -96,11 +96,11 @@
       rows: [
         {
           key: { text: "Accession number" },
-          value: { html: '<span class="app-code-font nhsuk-u-nowrap">' + (event.accessionNumber | formatAccessionNumber) + '</span>' }
+          value: { html: '<span class="nhsuk-u-font-code nhsuk-u-nowrap">' + (event.accessionNumber | formatAccessionNumber) + '</span>' }
         },
         {
           key: { text: "NHS number" },
-          value: { html: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber) + '</span>' }
+          value: { html: '<span class="nhsuk-u-font-code nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber) + '</span>' }
         },
         {
           key: { text: "Full name" },

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -96,11 +96,11 @@
       rows: [
         {
           key: { text: "Accession number" },
-          value: { html: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>' }
+          value: { html: '<span class="app-code-font nhsuk-u-nowrap">' + (event.accessionNumber | formatAccessionNumber) + '</span>' }
         },
         {
           key: { text: "NHS number" },
-          value: { html: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber | replace(' ', '&#8201;')) + '</span>' }
+          value: { html: '<span class="app-code-font nhsuk-u-nowrap">' + (participant.medicalInformation.nhsNumber | formatNhsNumber) + '</span>' }
         },
         {
           key: { text: "Full name" },

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -95,7 +95,7 @@
     {{ summaryList({
       rows: [
         {
-          key: { html: '<abbr title="Accession number">Accn</abbr>' },
+          key: { text: "Accession number" },
           value: { html: '<span class="app-code-font nhsuk-u-nowrap">KOX&#8201;20260527&#8201;A1246</span>' }
         },
         {

--- a/app/views/events/images-manual.html
+++ b/app/views/events/images-manual.html
@@ -87,7 +87,7 @@
   {% set troubleshootingIssue = event.mammogramDataTemp.troubleshootingIssue %}
   {% set hasTroubleshootingIssue = troubleshootingIssue in ['worklist-participant', 'wrong-image-count', 'incorrect-image-labels'] %}
   {% set showWorklistMatchingContent = troubleshootingIssue == 'worklist-participant' %}
-  {% set showDefaultManualContent = data.settings.screening.manualImageCollection == 'true' or isManualFailover %}
+  {% set showDefaultManualContent = data.settings.screening.manualImageCollection == 'true' or data.event.isManualImageCollection or isManualFailover %}
 
   {% if (hasTroubleshootingIssue and showWorklistMatchingContent) or (not hasTroubleshootingIssue and showDefaultManualContent) %}
     <h2>Manually add participant details</h2>

--- a/app/views/events/retry-worklist-connection.html
+++ b/app/views/events/retry-worklist-connection.html
@@ -20,7 +20,7 @@
       {{ button({
         text: "Retry connection",
         attributes: {
-          formaction: "./retry-worklist-connection",
+          formaction: "./retry-worklist-connection" | urlWithReferrer(referrerChain),
           "data-retry-connection-button": ""
         }
       }) }}
@@ -29,15 +29,15 @@
         text: "Switch to manual image mode",
         classes: "nhsuk-button--secondary",
         attributes: {
-          formaction: "./switch-to-manual-image-mode"
+          formaction: "./switch-to-manual-image-mode" | urlWithReferrer(referrerChain)
         }
       }) }}
   </div>
 
-  {% set lastRetryAt = data.settings.screening.worklistLastRetryAt %}
-  {% if lastRetryAt %}
-    <p class="nhsuk-u-secondary-text-color">Connection failed on retry. Last retry attempt at {{ lastRetryAt | formatTime('HH:mm:ss') }}</p>
-  {% endif %}
+  {# Failure message rendered by client-side JS after first retry attempt #}
+  <p class="nhsuk-u-secondary-text-color" data-retry-failure-message style="display: none">
+    Connection failed on retry. Last attempt at <span data-retry-time></span>
+  </p>
 
   <script src="/assets/javascript/retry-worklist-connection.js"></script>
 

--- a/app/views/events/retry-worklist-connection.html
+++ b/app/views/events/retry-worklist-connection.html
@@ -1,0 +1,52 @@
+{# app/views/events/retry-worklist-connection.html #}
+
+{% extends 'layout-appointment.html' %}
+
+{% set hideBackLink = true %}
+{% set activeWorkflowStep = 'take-images' %}
+{% set activeTab = 'images' %}
+
+{% set pageHeading = (participant | getFullName) + " has not been added to the worklist" %}
+
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+
+{% block pageContent %}
+
+  {{ backLink({
+    href: "javascript:history.back();",
+    text: "Back",
+    classes: "nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
+  }) }}
+
+  <h1>{{ pageHeading }}</h1>
+
+  <p>Due to a connection issue, image information for this appointment cannot be transferred automatically from the mammogram machine.</p>
+
+  <form method="post">
+    <div class="nhsuk-button-group">
+      {{ button({
+        text: "Retry connection",
+        attributes: {
+          formaction: "./retry-worklist-connection",
+          "data-retry-connection-button": ""
+        }
+      }) }}
+
+      {{ button({
+        text: "Switch to manual image mode",
+        classes: "nhsuk-button--secondary",
+        attributes: {
+          formaction: "./switch-to-manual-image-mode"
+        }
+      }) }}
+    </div>
+  </form>
+
+  {% set lastRetryAt = data.settings.screening.worklistLastRetryAt %}
+  {% if lastRetryAt %}
+    <p class="nhsuk-u-secondary-text-color">Connection failed on retry. Last retry attempt at {{ lastRetryAt | formatTime('HH:mm:ss') }}</p>
+  {% endif %}
+
+  <script src="/assets/javascript/retry-worklist-connection.js"></script>
+
+{% endblock %}

--- a/app/views/events/retry-worklist-connection.html
+++ b/app/views/events/retry-worklist-connection.html
@@ -2,9 +2,9 @@
 
 {% extends 'layout-appointment.html' %}
 
-{% set hideBackLink = true %}
 {% set activeWorkflowStep = 'take-images' %}
 {% set activeTab = 'images' %}
+{% set isForm = true %}
 
 {% set pageHeading = (participant | getFullName) + " has not been added to the worklist" %}
 
@@ -12,18 +12,11 @@
 
 {% block pageContent %}
 
-  {{ backLink({
-    href: "javascript:history.back();",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4"
-  }) }}
-
   <h1>{{ pageHeading }}</h1>
 
   <p>Due to a connection issue, image information for this appointment cannot be transferred automatically from the mammogram machine.</p>
 
-  <form method="post">
-    <div class="nhsuk-button-group">
+  <div class="nhsuk-button-group">
       {{ button({
         text: "Retry connection",
         attributes: {
@@ -39,8 +32,7 @@
           formaction: "./switch-to-manual-image-mode"
         }
       }) }}
-    </div>
-  </form>
+  </div>
 
   {% set lastRetryAt = data.settings.screening.worklistLastRetryAt %}
   {% if lastRetryAt %}

--- a/app/views/events/take-images.html
+++ b/app/views/events/take-images.html
@@ -10,7 +10,7 @@
 {# Used in automatic flow to show holding page #}
 {# {% set isAwaitingImages = event.workflowStatus['awaiting-images'] != 'completed' %} #}
 
-{% set isManualImageCollection = data.settings.screening.manualImageCollection | falsify %}
+{% set isManualImageCollection = (data.settings.screening.manualImageCollection | falsify) or data.event.isManualImageCollection %}
 
 {# {% set imagesStageCompleted = true if data.event.workflowStatus['take-images'] == 'completed' else false %} #}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,6 +1010,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1029,6 +1032,9 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1050,6 +1056,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,6 +1078,9 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1090,6 +1102,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,6 +1124,9 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1230,11 +1248,10 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1252,13 +1269,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1340,7 +1359,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/async": {
       "version": "2.6.4",
@@ -1672,7 +1692,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1792,7 +1811,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1876,6 +1894,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -1986,6 +2005,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2584,7 +2604,6 @@
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2684,6 +2703,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2782,6 +2802,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -2852,6 +2873,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -2930,6 +2952,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2939,6 +2962,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3233,6 +3257,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -3340,7 +3365,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-wsl": {
       "version": "1.1.0",
@@ -3504,6 +3530,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3639,16 +3666,16 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.1.tgz",
-      "integrity": "sha512-O6GqxHZ6UBePTc7uiItNttZoi8+J3dTC5vUN6bMs0cAoL8TgvNOiYwppFMrMB/nHVk+PtFtf+F8x2tz7OdNS1Q==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
+      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"
       },
@@ -3873,6 +3900,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3921,6 +3949,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -4000,7 +4029,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4504,6 +4532,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -4748,6 +4777,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -4848,7 +4878,6 @@
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.100.0.tgz",
       "integrity": "sha512-Ut8wlQSk19tm7jMK6mz6cF1+e+E7tUnW2tM02zQDPnOTcVbV8qCQG8UWxZkkNlY50+hV3hqP24OOkUlMz8xBpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "colorjs.io": "^0.5.0",
@@ -5004,6 +5033,7 @@
       "cpu": [
         "arm"
       ],
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5020,6 +5050,7 @@
       "cpu": [
         "arm64"
       ],
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5036,6 +5067,7 @@
       "cpu": [
         "arm"
       ],
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5052,6 +5084,7 @@
       "cpu": [
         "arm64"
       ],
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5068,6 +5101,7 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5084,6 +5118,7 @@
       "cpu": [
         "x64"
       ],
+      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5100,6 +5135,7 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5116,6 +5152,7 @@
       "cpu": [
         "x64"
       ],
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5239,9 +5276,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5255,6 +5292,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -5395,6 +5433,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -6053,7 +6092,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
       "version": "8.20.1",


### PR DESCRIPTION
This work: 

* Adds accession number (placeholder) to the worklist status
* Adds success messages and states when failing over to manual and ability to retry connection with interruption page
* Adds accession number to the appointment tab

## Screenshots 

### All is well: Accession number in worklist ('on worklist') 

<img width="1264" height="802" alt="Screenshot 2026-06-04 at 14 16 18" src="https://github.com/user-attachments/assets/c30c8cc3-f269-4355-b8bb-37c1cf623c8a" />

### All is not well: Accession number in worklist ('not on worklist') 

<img width="1267" height="747" alt="Screenshot 2026-06-04 at 14 06 26" src="https://github.com/user-attachments/assets/aa7463e1-745e-48f2-9a6b-64f36968e1e1" />

### All is not well: Retry page from the retry link
* For the prototype, retry connection will fail on the first try, then it will work

<img width="1030" height="601" alt="Screenshot 2026-06-04 at 14 11 27" src="https://github.com/user-attachments/assets/fdc006ba-b6f0-4b6b-bd37-cda11f23914d" />

### All is not well, and the user has enabled manual image mode 

<img width="1289" height="806" alt="Screenshot 2026-06-04 at 14 06 38" src="https://github.com/user-attachments/assets/63170d2b-c0ed-436b-8e21-fb5732c6e00a" />


### All is not well: Manual image page interruption when there is an unfixed worklist issue
* We show the retry page as an interruption if the user tries to proceed to take images without sorting out the worklist issue, to force them to try to reconnect or switch to manual 

<img width="1030" height="601" alt="Screenshot 2026-06-04 at 14 11 27" src="https://github.com/user-attachments/assets/fdc006ba-b6f0-4b6b-bd37-cda11f23914d" />

### Troubleshooting info on automatic images page 
* We show this to help the user sort out issues where the system says that things are fine, but they're still experiencing an issue
* When switching to manual from here, this shows worklist-related content on the manual images page for the first issue but not for the second two 
* That is because when there is an issue unrelated to the worklist we *don't* need to give the user the info to sort out the worklist matching, as the issue is about something else (no of images, labels...) 

<img width="1284" height="744" alt="Screenshot 2026-06-04 at 15 02 32" src="https://github.com/user-attachments/assets/e0a71f22-8b54-404d-85c4-ef79e0086b95" />

### Troubleshooting info – worklist related
* When there is an issue, and the user needs the info to sort out the worklist matching 

<img width="944" height="823" alt="Screenshot 2026-06-04 at 15 22 18" src="https://github.com/user-attachments/assets/aac2871d-e796-424b-bfc2-b272e2e65b7b" />


### Troubleshooting info – not worklist related 

<img width="1066" height="810" alt="Screenshot 2026-06-04 at 14 19 02" src="https://github.com/user-attachments/assets/3b7d42d0-437a-4422-af69-64cd28bb47e0" />

### Add accession number row to appointment tab

<img width="1032" height="439" alt="Screenshot 2026-06-04 at 15 21 34" src="https://github.com/user-attachments/assets/717ea9c3-56bf-472a-bd89-95b03da11828" />


