### PR TITLE
Validation for recall for assessment and technical recall journeys and other bugfixes

### DIFF
--- a/app/assets/javascript/annotation-markers.js
+++ b/app/assets/javascript/annotation-markers.js
@@ -448,7 +448,13 @@
       )
       if (!sidebarScroll) return
 
-      var html = '<h3 class="app-ann-v2__sidebar-heading">Annotations</h3>'
+      // In embedded mode, heading is provided by the template (outside scroll area)
+      var isEmbedded = !!sidebarScroll.closest('.app-ann-v2__sidebar--embedded')
+
+      var html = ''
+      if (!isEmbedded) {
+        html += '<h3 class="app-ann-v2__sidebar-heading">Annotations</h3>'
+      }
       html += '<div class="app-annotation-list">'
 
       if (sideAnnotations.length === 0) {
@@ -538,7 +544,7 @@
       var addBtnDisabled = hasIncomplete
         ? ' disabled title="Complete the current annotation before adding another"'
         : ''
-      html +=
+      var addBtnHtml =
         '<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" type="button" data-action="add-annotation" data-side="' +
         activeSide +
         '"' +
@@ -547,9 +553,24 @@
         addBtnText +
         '</button>'
 
+      if (!isEmbedded) {
+        // Non-embedded: button goes inside annotation-list
+        html += addBtnHtml
+      }
+
       html += '</div>'
 
       sidebarScroll.innerHTML = html
+
+      if (isEmbedded) {
+        // Embedded: button goes in a dedicated container outside the error wrapper
+        var btnContainer = sidebarScroll
+          .closest('.app-ann-v2__sidebar--embedded')
+          .querySelector('[data-annotation-add-button]')
+        if (btnContainer) {
+          btnContainer.innerHTML = addBtnHtml
+        }
+      }
     }
 
     // ─── Rendering: tabs ─────────────────────────────────────────────────────
@@ -1441,7 +1462,7 @@
 
     // Sidebar delegation
     container.addEventListener('click', function (e) {
-      if (e.target.closest('.app-ann-v2__sidebar-scroll')) {
+      if (e.target.closest('.app-ann-v2__sidebar-scroll') || e.target.closest('[data-annotation-add-button]')) {
         handleSidebarClick(e)
       }
     })

--- a/app/assets/javascript/annotation-markers.js
+++ b/app/assets/javascript/annotation-markers.js
@@ -108,6 +108,8 @@
     var singleAnnotationId = opts.singleAnnotationId || null // Lock to editing one annotation
     var positionsFieldId = opts.positionsField || null // Hidden field to write positions to
     var isSingleMode = !!singleAnnotationId
+    // When true, incomplete annotations get error styling and the modal shows field errors on open
+    var showIncompleteErrors = opts.showIncompleteErrors || false
 
     // In single mode, lock the active annotation
     if (isSingleMode) {
@@ -466,6 +468,16 @@
         var isIncomplete =
           !(ann.abnormalityTypes && ann.abnormalityTypes.length) &&
           !ann.levelOfConcern
+        // hasValidationError is true when we know the page has been submitted with errors
+        // and this annotation is missing at least one required field
+        var missingOtherDetails = ann.abnormalityTypes &&
+          ann.abnormalityTypes.includes('Other') &&
+          !ann.otherDetails
+        var hasValidationError = showIncompleteErrors && (
+          !(ann.abnormalityTypes && ann.abnormalityTypes.length) ||
+          !ann.levelOfConcern ||
+          missingOtherDetails
+        )
         var typeLabel = 'Type not set'
         if (ann.abnormalityTypes && ann.abnormalityTypes.length) {
           typeLabel = Array.isArray(ann.abnormalityTypes)
@@ -479,6 +491,7 @@
         html +=
           '<div class="app-annotation-list__card' +
           (isActive ? ' is-active' : '') +
+          (hasValidationError ? ' app-annotation-list__card--error' : '') +
           '" data-ann-id="' +
           ann.id +
           '" tabindex="0" role="button"' +
@@ -882,8 +895,51 @@
 
     // ─── Modal ───────────────────────────────────────────────────────────────
 
+    // ─── Modal error helpers ─────────────────────────────────────────────────
+
+    // Show an error message for a field inside the modal, identified by part of
+    // the field name (e.g. 'levelOfConcern'). Adds NHS error class and message.
+    function showModalFieldError(fieldNamePart, errorText) {
+      if (!annModal) return
+      var input = annModal.querySelector('[name*="[' + fieldNamePart + ']"]')
+      if (!input) return
+      var formGroup = input.closest('.nhsuk-form-group')
+      if (!formGroup) return
+      formGroup.classList.add('nhsuk-form-group--error')
+      var existing = formGroup.querySelector('.nhsuk-error-message[data-js-modal-error]')
+      if (existing) {
+        existing.innerHTML = '<span class="nhsuk-u-visually-hidden">Error:</span> ' + errorText
+        return
+      }
+      var errorMsg = document.createElement('span')
+      errorMsg.className = 'nhsuk-error-message'
+      errorMsg.setAttribute('data-js-modal-error', 'true')
+      errorMsg.innerHTML = '<span class="nhsuk-u-visually-hidden">Error:</span> ' + errorText
+      // Insert after legend (fieldset groups) or label (single inputs)
+      var fieldset = formGroup.querySelector('fieldset')
+      var insertParent = fieldset || formGroup
+      var anchor = insertParent.querySelector('legend, label')
+      if (anchor && anchor.nextSibling) {
+        insertParent.insertBefore(errorMsg, anchor.nextSibling)
+      } else {
+        insertParent.appendChild(errorMsg)
+      }
+    }
+
+    // Remove all JS-injected modal errors and error classes
+    function clearModalErrors() {
+      if (!annModal) return
+      annModal.querySelectorAll('.nhsuk-error-message[data-js-modal-error]').forEach(function (em) {
+        em.remove()
+      })
+      annModal.querySelectorAll('.nhsuk-form-group--error').forEach(function (fg) {
+        fg.classList.remove('nhsuk-form-group--error')
+      })
+    }
+
     function openModal(annId) {
       if (!annModal) return
+      clearModalErrors()
       modalAnnotationId = annId
       var ann = getAnnotation(annId)
       var isIncomplete =
@@ -939,6 +995,18 @@
 
       annModal.hidden = false
       annModal.classList.add('app-modal--open')
+
+      // When returning from a server validation error and this annotation is
+      // missing required fields, show field-level errors in the modal immediately
+      if (showIncompleteErrors && ann) {
+        if (!ann.abnormalityTypes || !ann.abnormalityTypes.length) {
+          showModalFieldError('abnormalityTypes', 'Select at least one abnormality type')
+        }
+        if (!ann.levelOfConcern) {
+          showModalFieldError('levelOfConcern', 'Select a level of concern')
+        }
+      }
+
       // Focus the dialog element itself so screen readers announce it.
       // Remove tabindex on first blur so it doesn't steal focus back
       // when the user clicks inside the modal.
@@ -955,6 +1023,7 @@
 
     function closeModal() {
       if (!annModal) return
+      clearModalErrors()
       annModal.hidden = true
       annModal.classList.remove('app-modal--open')
       modalAnnotationId = null
@@ -980,14 +1049,38 @@
           return cb.value
         })
       }
-      ann.abnormalityTypes = savedTypes.length ? savedTypes : null
-      ann.levelOfConcern =
+      var savedLevelOfConcern =
         (
           document.querySelector(
             '[name="imageReadingTemp[annotationTemp][levelOfConcern]"]:checked'
           ) || {}
         ).value || null
+      var otherDetailsEl = document.querySelector(
+        '[name="imageReadingTemp[annotationTemp][otherDetails]"]'
+      )
+      var savedOtherDetails = otherDetailsEl ? otherDetailsEl.value.trim() : ''
       var commentEl = document.getElementById('comment')
+
+      // Validate required fields before saving
+      clearModalErrors()
+      var hasErrors = false
+      if (!savedTypes.length) {
+        showModalFieldError('abnormalityTypes', 'Select at least one abnormality type')
+        hasErrors = true
+      }
+      if (savedTypes.includes('Other') && !savedOtherDetails) {
+        showModalFieldError('otherDetails', 'Provide details for other abnormality type')
+        hasErrors = true
+      }
+      if (!savedLevelOfConcern) {
+        showModalFieldError('levelOfConcern', 'Select a level of concern')
+        hasErrors = true
+      }
+      if (hasErrors) return
+
+      ann.abnormalityTypes = savedTypes
+      ann.otherDetails = savedTypes.includes('Other') ? savedOtherDetails : null
+      ann.levelOfConcern = savedLevelOfConcern
       ann.comment = commentEl ? commentEl.value || null : null
 
       activeAnnotationId = modalAnnotationId
@@ -997,6 +1090,53 @@
       renderMarkers()
       renderSidebar()
       autoSave()
+      clearSideErrors(ann.side)
+    }
+
+    // After a successful save, clear server-rendered error state for a breast side
+    // if all its annotations are now complete.
+    function clearSideErrors(side) {
+      var sideAnnotations = annotations.filter(function (a) { return a.side === side })
+      var hasIncomplete = sideAnnotations.some(function (a) {
+        var missingOther = a.abnormalityTypes &&
+          a.abnormalityTypes.includes('Other') &&
+          !a.otherDetails
+        return !(a.abnormalityTypes && a.abnormalityTypes.length) || !a.levelOfConcern || missingOther
+      })
+      if (hasIncomplete) return
+
+      // Clear the section-level error above the annotation list
+      var section = document.getElementById(side + '-annotations')
+      if (section) {
+        section.classList.remove('app-annotation-section--error')
+        var sectionError = section.querySelector('.app-annotation-section__error-message')
+        if (sectionError) sectionError.remove()
+      }
+
+      // Clear the tab error indicator
+      var tab = container.querySelector('[data-thumb-side="' + side + '"]')
+      if (tab) {
+        tab.classList.remove('app-ann-v2__tab--error')
+        var sideLabel = side === 'right' ? 'Right breast' : 'Left breast'
+        tab.setAttribute('aria-label', 'Switch to ' + sideLabel)
+        var errorIcon = tab.querySelector('.app-ann-v2__tab-error-icon')
+        if (errorIcon) errorIcon.remove()
+      }
+
+      // Remove the corresponding item from the page error summary
+      var errorSummary = document.querySelector('.nhsuk-error-summary__list')
+      if (errorSummary) {
+        var summaryLink = errorSummary.querySelector('a[href="#' + side + '-annotations"]')
+        if (summaryLink) {
+          var listItem = summaryLink.closest('li')
+          if (listItem) listItem.remove()
+        }
+        // Hide the whole error summary if it has no remaining items
+        if (!errorSummary.querySelector('li')) {
+          var summaryEl = document.querySelector('.nhsuk-error-summary')
+          if (summaryEl) summaryEl.hidden = true
+        }
+      }
     }
 
     function deleteModalAnnotation() {

--- a/app/assets/javascript/option-picker.js
+++ b/app/assets/javascript/option-picker.js
@@ -1,0 +1,95 @@
+// app/assets/javascript/option-picker.js
+
+// Option picker conditional reveal
+// Shows/hides conditional content panels when an option is checked/unchecked.
+// Follows the same accessibility pattern as NHS Frontend checkboxes:
+// - Promotes data-aria-controls to aria-controls
+// - Sets aria-expanded on the input
+// - Hides panels with --hidden class (no-JS fallback: panels always visible)
+
+class OptionPicker {
+  constructor(element) {
+    this.element = element
+    this.$inputs = element.querySelectorAll('.app-option-picker__input')
+
+    this.$inputs.forEach(($input) => {
+      const targetId =
+        $input.dataset.ariaControls || $input.getAttribute('aria-controls')
+
+      // Skip inputs without conditional targets
+      if (!targetId) return
+
+      const $target = document.getElementById(targetId)
+      if (!$target) return
+
+      // Promote data-aria-controls to aria-controls for accessibility
+      if (!$input.hasAttribute('aria-controls')) {
+        $input.setAttribute('aria-controls', targetId)
+        delete $input.dataset.ariaControls
+      }
+    })
+
+    // Sync state on pageshow (handles browser back/forward)
+    window.addEventListener('pageshow', () => this.syncAll())
+
+    // Sync initial state
+    this.syncAll()
+
+    // Listen for changes
+    this.element.addEventListener('change', (event) => this.handleChange(event))
+  }
+
+  syncAll() {
+    this.$inputs.forEach(($input) => this.syncConditionalReveal($input))
+  }
+
+  syncConditionalReveal($input) {
+    const targetId = $input.getAttribute('aria-controls')
+    if (!targetId) return
+
+    const $target = document.getElementById(targetId)
+    if (!$target) return
+
+    // Set aria-expanded on the input
+    $input.setAttribute('aria-expanded', $input.checked.toString())
+
+    // Toggle visibility class
+    $target.classList.toggle(
+      'app-option-picker__conditional--hidden',
+      !$input.checked
+    )
+  }
+
+  handleChange(event) {
+    const $input = event.target
+    if (
+      !($input instanceof HTMLInputElement) ||
+      !$input.classList.contains('app-option-picker__input')
+    ) {
+      return
+    }
+
+    // For radios, we need to sync all inputs (unchecking others hides their panels)
+    if ($input.type === 'radio') {
+      this.syncAll()
+    } else {
+      // For checkboxes, just sync the one that changed
+      this.syncConditionalReveal($input)
+    }
+  }
+}
+
+const initOptionPickers = (scope) => {
+  scope
+    .querySelectorAll('[data-module="app-option-picker"]')
+    .forEach((element) => {
+      new OptionPicker(element)
+    })
+}
+
+document.addEventListener('DOMContentLoaded', () => initOptionPickers(document))
+
+// Re-initialise when modal.js injects new content
+document.addEventListener('app:init', (e) => initOptionPickers(e.detail.scope))
+
+window.OptionPicker = OptionPicker

--- a/app/assets/javascript/option-picker.js
+++ b/app/assets/javascript/option-picker.js
@@ -134,7 +134,10 @@ class OptionPicker {
     this.inlineItems.forEach((item) => this.syncInline(item))
   }
 
-  syncInline({ $input, $label, $wrapper, $panel, $inlineInput, textNode, originalText }, { focusInput = false } = {}) {
+  syncInline(
+    { $input, $label, $wrapper, $panel, $inlineInput, textNode, originalText },
+    { focusInput = false } = {}
+  ) {
     const isChecked = $input.checked
 
     // Show/hide the inline input

--- a/app/assets/javascript/option-picker.js
+++ b/app/assets/javascript/option-picker.js
@@ -11,6 +11,7 @@ class OptionPicker {
   constructor(element) {
     this.element = element
     this.$inputs = element.querySelectorAll('.app-option-picker__input')
+    this.inlineItems = []
 
     this.$inputs.forEach(($input) => {
       const targetId =
@@ -27,6 +28,11 @@ class OptionPicker {
         $input.setAttribute('aria-controls', targetId)
         delete $input.dataset.ariaControls
       }
+
+      // Set up inline conditional enhancement
+      if ('conditionalInline' in $input.dataset) {
+        this.setupInline($input, $target)
+      }
     })
 
     // Sync state on pageshow (handles browser back/forward)
@@ -39,13 +45,148 @@ class OptionPicker {
     this.element.addEventListener('change', (event) => this.handleChange(event))
   }
 
+  // Set up inline conditional: move the input from the panel into the label
+  setupInline($input, $panel) {
+    const $label = this.element.querySelector(`label[for="${$input.id}"]`)
+    if (!$label) return
+
+    // Find the first input/textarea/select in the conditional panel
+    const $inlineInput = $panel.querySelector('input, textarea, select')
+    if (!$inlineInput) return
+
+    // Strip width utility classes that don't make sense inline
+    $inlineInput.classList.remove(
+      'nhsuk-u-width-two-thirds',
+      'nhsuk-u-width-one-half',
+      'nhsuk-u-width-one-third',
+      'nhsuk-u-width-full',
+      'nhsuk-input--width-20',
+      'nhsuk-input--width-10'
+    )
+
+    // Store original label text
+    const textNode = Array.from($label.childNodes).find(
+      (node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim()
+    )
+    const originalText = textNode ? textNode.textContent.trim() : ''
+
+    // Create inline wrapper
+    const $wrapper = document.createElement('span')
+    $wrapper.className = 'app-option-picker__inline-input'
+
+    // Check if input already has error state
+    if ($inlineInput.classList.contains('nhsuk-input--error')) {
+      $wrapper.classList.add('app-option-picker__inline-input--error')
+    }
+
+    // Move the input into the wrapper
+    $wrapper.appendChild($inlineInput)
+
+    // Add error icon (hidden by default, shown via CSS when --error class present)
+    const $errorIcon = document.createElement('span')
+    $errorIcon.className = 'app-option-picker__inline-error-icon'
+    $errorIcon.setAttribute('aria-hidden', 'true')
+    $errorIcon.innerHTML =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false">' +
+      '<path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 14a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Zm-1.5-9.5V13a1.5 1.5 0 0 0 3 0V6.5a1.5 1.5 0 0 0-3 0Z">' +
+      '</svg>'
+    $wrapper.appendChild($errorIcon)
+
+    // Append wrapper inside the label
+    $label.appendChild($wrapper)
+
+    // Prevent clicking/mousedown on the inline input from toggling the checkbox
+    // or causing the button press visual (:active state on the label)
+    $inlineInput.addEventListener('mousedown', (e) => {
+      e.stopPropagation()
+    })
+    $inlineInput.addEventListener('click', (e) => {
+      e.stopPropagation()
+    })
+
+    // Dynamic width: expand input as user types, up to a max
+    this.resizeInput($inlineInput)
+    $inlineInput.addEventListener('input', () => {
+      this.resizeInput($inlineInput)
+    })
+
+    // Hide the below-panel permanently (inline replaces it)
+    $panel.classList.add('app-option-picker__conditional--hidden')
+    $panel.setAttribute('aria-hidden', 'true')
+
+    // Track this inline item for sync
+    this.inlineItems.push({
+      $input,
+      $label,
+      $wrapper,
+      $panel,
+      $inlineInput,
+      textNode,
+      originalText
+    })
+
+    // Apply initial state
+    this.syncInline(this.inlineItems[this.inlineItems.length - 1])
+  }
+
   syncAll() {
     this.$inputs.forEach(($input) => this.syncConditionalReveal($input))
+    this.inlineItems.forEach((item) => this.syncInline(item))
+  }
+
+  syncInline({ $input, $label, $wrapper, $panel, $inlineInput, textNode, originalText }, { focusInput = false } = {}) {
+    const isChecked = $input.checked
+
+    // Show/hide the inline input
+    $wrapper.hidden = !isChecked
+    $inlineInput.tabIndex = isChecked ? 0 : -1
+
+    // Toggle label text: "Other" vs "Other:"
+    if (textNode) {
+      textNode.textContent = isChecked ? originalText + ': ' : originalText
+    }
+
+    // Toggle active class on the label
+    $label.classList.toggle(
+      'app-option-picker__label--inline-active',
+      isChecked
+    )
+
+    // Keep below-panel hidden (inline mode owns the input)
+    $panel.classList.add('app-option-picker__conditional--hidden')
+
+    // Focus the inline input when revealed by user action
+    if (isChecked && focusInput) {
+      $inlineInput.focus()
+    }
+  }
+
+  // Dynamically resize inline input based on content, with min/max bounds
+  resizeInput($input) {
+    const hasError = $input.classList.contains('nhsuk-input--error')
+    const minWidth = hasError ? 120 : 80
+    const maxWidth = 220
+
+    // Use a canvas to measure text width — more reliable than DOM measurement
+    const ctx = document.createElement('canvas').getContext('2d')
+    ctx.font = window.getComputedStyle($input).font
+    const textWidth = ctx.measureText($input.value || '').width
+
+    // Account for padding + border (box-sizing: border-box)
+    // Normal: 8px left pad + 8px right pad + 2px left border + 2px right border = 20px
+    // Error: 8px left pad + 32px right pad + 2px left border + 2px right border = 44px
+    const chrome = hasError ? 44 : 20
+    const totalWidth = Math.ceil(textWidth) + chrome + 4
+    const width = Math.min(Math.max(totalWidth, minWidth), maxWidth)
+    $input.style.width = width + 'px'
   }
 
   syncConditionalReveal($input) {
     const targetId = $input.getAttribute('aria-controls')
     if (!targetId) return
+
+    // Skip inline items — they're managed by syncInline
+    if ('conditionalInline' in $input.dataset) return
 
     const $target = document.getElementById(targetId)
     if (!$target) return
@@ -75,6 +216,12 @@ class OptionPicker {
     } else {
       // For checkboxes, just sync the one that changed
       this.syncConditionalReveal($input)
+
+      // Check if this is an inline item
+      const inlineItem = this.inlineItems.find((item) => item.$input === $input)
+      if (inlineItem) {
+        this.syncInline(inlineItem, { focusInput: true })
+      }
     }
   }
 }

--- a/app/assets/sass/components/_annotate-v2.scss
+++ b/app/assets/sass/components/_annotate-v2.scss
@@ -100,6 +100,30 @@ body.app-annotate-v2 {
   text-decoration: underline;
 }
 
+// Tab error state: left red border to indicate validation issue
+.app-ann-v2__tab--error {
+  border-left: $nhsuk-border-width-form-group-error solid $nhsuk-error-colour;
+
+  &.is-active {
+    border-left: $nhsuk-border-width-form-group-error solid $nhsuk-error-colour;
+  }
+}
+
+// Error exclamation mark icon in tab
+.app-ann-v2__tab-error-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: $nhsuk-error-colour;
+  color: nhsuk-colour("white");
+  font-size: 14px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
 // Thumbnail strip: small previews of each view within the tab
 .app-ann-v2__tab-thumbs {
   display: flex;
@@ -519,10 +543,25 @@ $ann-marker-shadow:
   position: static;
   max-height: none;
 
+  .app-ann-v2__sidebar-heading {
+    margin-bottom: nhsuk-spacing(3);
+  }
+
   .app-ann-v2__sidebar-scroll {
     flex: none;
     height: auto;
     overflow: visible;
+    padding: 0; // No need for focus-outline padding when overflow is visible
+  }
+
+  // Button container sits outside the error wrapper
+  [data-annotation-add-button] {
+    margin-top: nhsuk-spacing(3);
+
+    .nhsuk-button {
+      width: 100%;
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/app/assets/sass/components/_annotation-list.scss
+++ b/app/assets/sass/components/_annotation-list.scss
@@ -74,6 +74,11 @@
   &.is-active {
     box-shadow: inset 4px 0 0 nhsuk-colour("blue");
   }
+
+  &.app-annotation-list__card--error {
+    border-color: $nhsuk-error-colour;
+    box-shadow: inset 4px 0 0 $nhsuk-error-colour;
+  }
 }
 
 .app-dark-mode {

--- a/app/assets/sass/components/_annotation-list.scss
+++ b/app/assets/sass/components/_annotation-list.scss
@@ -131,3 +131,27 @@
   @include nhsuk-font(19);
   margin-top: nhsuk-spacing(1);
 }
+
+// ─── Error state (used on parent wrappers around annotation sections) ─────────
+
+.app-annotation-section--error {
+  padding-left: nhsuk-spacing(3);
+  border-left: $nhsuk-border-width-form-group-error solid $nhsuk-error-colour;
+
+  &:focus {
+    outline: none;
+  }
+
+  // Pull add-annotation button out of the error bar area
+  > .nhsuk-button,
+  .app-annotation-list > .nhsuk-button {
+    margin-left: -(nhsuk-spacing(3));
+  }
+}
+
+.app-annotation-section__error-message {
+  @include nhsuk-font(19, $weight: bold);
+  display: block;
+  margin-bottom: nhsuk-spacing(3);
+  color: $nhsuk-error-colour;
+}

--- a/app/assets/sass/components/_dark-mode.scss
+++ b/app/assets/sass/components/_dark-mode.scss
@@ -485,6 +485,12 @@ $app-tag--aqua-green-dark-text: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
     color: $app-dark-mode-text-colour;
   }
 
+  // Windows Edge doesn't inherit select colours on option elements
+  .nhsuk-select option {
+    background-color: $app-dark-mode-background;
+    color: $app-dark-mode-text-colour;
+  }
+
   .nhsuk-notification-banner__content {
     color: $app-dark-mode-text-colour;
     background: $app-dark-mode-surface;

--- a/app/assets/sass/components/_dark-mode.scss
+++ b/app/assets/sass/components/_dark-mode.scss
@@ -480,7 +480,7 @@ $app-tag--aqua-green-dark-text: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
   .nhsuk-input,
   .nhsuk-textarea,
   .nhsuk-select {
-    background-color: transparent;
+    background-color: $app-dark-mode-background;
     border-color: $app-dark-mode-white;
     color: $app-dark-mode-text-colour;
   }

--- a/app/assets/sass/components/_dark-mode.scss
+++ b/app/assets/sass/components/_dark-mode.scss
@@ -89,8 +89,40 @@ $app-tag--aqua-green-dark-text: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
   color: $app-dark-mode-text-colour;
 
   // Text colour
-  .nhsuk-fieldset__legend {
+  .nhsuk-fieldset__legend,
+  .breast-features__side-labels,
+  .app-workflow-side-nav__link,
+  .app-workflow-side-nav__item--current .app-workflow-side-nav__link {
     color: $app-dark-mode-text-colour;
+  }
+
+  // Breast features diagram - invert for dark mode
+  .breast-features__diagram {
+    background: $app-dark-mode-background;
+    border-color: $app-dark-mode-border;
+
+    svg path,
+    svg circle {
+      stroke: $app-dark-mode-white;
+    }
+  }
+
+  // Breast features popover - dark background
+  .breast-features__popover {
+    background: $app-dark-mode-surface;
+    color: $app-dark-mode-text-colour;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  // Marker labels on diagram
+  .breast-features__marker-label {
+    background: $app-dark-mode-surface;
+    border-color: $app-dark-mode-border;
+    color: $app-dark-mode-text-colour;
+
+    &:hover {
+      background: #2f2f2f;
+    }
   }
 
   .nhsuk-expander,
@@ -106,6 +138,7 @@ $app-tag--aqua-green-dark-text: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
   .nhsuk-caption-m,
   .nhsuk-caption-s,
   .app-details__summary-subtitle,
+  .app-workflow-side-nav__link--disabled,
   .app-suppress-link-styles * {
     color: $app-dark-mode-text-colour-secondary;
   }
@@ -425,7 +458,7 @@ $app-tag--aqua-green-dark-text: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
     }
     .nhsuk-radios__input + .nhsuk-radios__label::after {
       background: $app-dark-mode-white;
-      border: 10px solid $app-dark-mode-white;
+      border-color: $app-dark-mode-white;
     }
   }
 

--- a/app/assets/sass/components/_option-picker.scss
+++ b/app/assets/sass/components/_option-picker.scss
@@ -366,6 +366,102 @@ $_tick-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
   display: none;
 }
 
+// =========================================================
+// Inline conditional
+// JS enhancement: text input appears inside the button when checked.
+// The label expands to contain the input inline with the label text.
+// =========================================================
+
+.app-option-picker__inline-input {
+  display: inline-flex;
+  align-items: center;
+  margin-left: nhsuk-spacing(1);
+  position: relative;
+
+  input {
+    // Height matches label content area so button doesn't grow.
+    // Label: min-height 44px - 2*6px padding - 2*2px border = 28px content.
+    height: nhsuk-px-to-rem(28px);
+    padding: 0 nhsuk-spacing(2);
+    border: $nhsuk-border-width-form-element solid nhsuk-shade($nhsuk-brand-colour, 50%);
+    border-radius: 0;
+    background: nhsuk-colour("white");
+    color: $color_nhsuk-black;
+    font-weight: normal;
+    font-size: inherit;
+    min-width: 60px;
+    width: auto;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: $nhsuk-focus-width solid $nhsuk-focus-colour;
+      box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-text-colour;
+    }
+
+    // Error state — red border matching NHS input error pattern
+    &.nhsuk-input--error {
+      border-color: $nhsuk-error-colour;
+      // Add right padding to make room for the warning icon inside
+      padding-right: nhsuk-spacing(5);
+    }
+  }
+
+  // Warning icon shown inside the input on validation error
+  .app-option-picker__inline-error-icon {
+    display: none;
+    position: absolute;
+    right: nhsuk-spacing(1);
+    top: 50%;
+    transform: translateY(-50%);
+    width: 18px;
+    height: 18px;
+    color: $nhsuk-error-colour;
+    pointer-events: none;
+
+    svg {
+      width: 100%;
+      height: 100%;
+      fill: currentColor;
+    }
+  }
+
+  // Show error icon when input has error class
+  &--error .app-option-picker__inline-error-icon {
+    display: block;
+  }
+
+  // Hidden state (managed by JS via hidden attribute)
+  &[hidden] {
+    display: none;
+  }
+}
+
+// When inline active, allow content to flow
+.app-option-picker--button .app-option-picker__label--inline-active {
+  white-space: nowrap;
+  // Reduce right padding so space around input is consistent with vertical padding
+  padding-right: nhsuk-px-to-rem(6px);
+}
+
+// Suppress hover colour change only when the hidden input is also focused
+// (otherwise normal hover on the button is fine)
+.app-option-picker--button .app-option-picker__input:focus + .app-option-picker__label.app-option-picker__label--inline-active:hover {
+  background-color: $nhsuk-focus-colour;
+  box-shadow: 0 $nhsuk-focus-width 0 0 $nhsuk-focus-text-colour;
+  color: $nhsuk-focus-text-colour;
+}
+
+// Suppress hover/active colour changes only when the user is interacting with the
+// inline input itself — not when clicking or hovering the button/label area.
+// Uses :has() to detect hover/active on the inline input child.
+.app-option-picker--button .app-option-picker__input:checked + .app-option-picker__label.app-option-picker__label--inline-active:has(.app-option-picker__inline-input:hover),
+.app-option-picker--button .app-option-picker__input:checked + .app-option-picker__label.app-option-picker__label--inline-active:has(.app-option-picker__inline-input:active) {
+  top: 0;
+  box-shadow: 0 $nhsuk-button-shadow-size 0 nhsuk-shade($nhsuk-brand-colour, 50%);
+  background-color: $nhsuk-brand-colour;
+  color: nhsuk-colour("white");
+}
+
 // Also round the inner top corner of each neighbour adjacent to the active button,
 // so the exposed gap above the depressed button has clean curved edges on both sides.
 // Right neighbour — select via forward sibling chain

--- a/app/assets/sass/components/_option-picker.scss
+++ b/app/assets/sass/components/_option-picker.scss
@@ -445,7 +445,9 @@ $_tick-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
 
 // Suppress hover colour change only when the hidden input is also focused
 // (otherwise normal hover on the button is fine)
-.app-option-picker--button .app-option-picker__input:focus + .app-option-picker__label.app-option-picker__label--inline-active:hover {
+.app-option-picker--button
+  .app-option-picker__input:focus
+  + .app-option-picker__label.app-option-picker__label--inline-active:hover {
   background-color: $nhsuk-focus-colour;
   box-shadow: 0 $nhsuk-focus-width 0 0 $nhsuk-focus-text-colour;
   color: $nhsuk-focus-text-colour;
@@ -454,8 +456,12 @@ $_tick-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
 // Suppress hover/active colour changes only when the user is interacting with the
 // inline input itself — not when clicking or hovering the button/label area.
 // Uses :has() to detect hover/active on the inline input child.
-.app-option-picker--button .app-option-picker__input:checked + .app-option-picker__label.app-option-picker__label--inline-active:has(.app-option-picker__inline-input:hover),
-.app-option-picker--button .app-option-picker__input:checked + .app-option-picker__label.app-option-picker__label--inline-active:has(.app-option-picker__inline-input:active) {
+.app-option-picker--button
+  .app-option-picker__input:checked
+  + .app-option-picker__label.app-option-picker__label--inline-active:has(.app-option-picker__inline-input:hover),
+.app-option-picker--button
+  .app-option-picker__input:checked
+  + .app-option-picker__label.app-option-picker__label--inline-active:has(.app-option-picker__inline-input:active) {
   top: 0;
   box-shadow: 0 $nhsuk-button-shadow-size 0 nhsuk-shade($nhsuk-brand-colour, 50%);
   background-color: $nhsuk-brand-colour;

--- a/app/assets/sass/components/_option-picker.scss
+++ b/app/assets/sass/components/_option-picker.scss
@@ -349,6 +349,23 @@ $_tick-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
   }
 }
 
+// =========================================================
+// Conditional reveal
+// Panel shown below the option-picker items when an option is checked.
+// Mirrors the NHS checkboxes conditional pattern: left border, indented.
+// Without JS the panel is always visible; JS adds --hidden to toggle.
+// =========================================================
+
+.app-option-picker__conditional {
+  margin-top: nhsuk-spacing(4);
+  padding-left: nhsuk-spacing(5);
+  border-left: $nhsuk-border-width solid $nhsuk-input-border-colour;
+}
+
+.app-option-picker__conditional--hidden {
+  display: none;
+}
+
 // Also round the inner top corner of each neighbour adjacent to the active button,
 // so the exposed gap above the depressed button has clean curved edges on both sides.
 // Right neighbour — select via forward sibling chain

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -115,8 +115,8 @@ const defaultSettings = {
     showRemaining: 'true',
     autoOpenPacsViewer: 'false',
     enableOpinionDelay: 'true',
-    annotationsMode: 'with-images', // 'without-images' | 'with-images-simple' | 'with-images' | 'with-images-progressive'
-    secondReaderComparison: 'late', // 'early' | 'late' | 'off'
+    annotationsMode: 'with-images-simple', // 'without-images' | 'with-images-simple' | 'with-images' | 'with-images-progressive'
+    secondReaderComparison: 'off', // 'early' | 'late' | 'off'
     compareWhen: 'non_normal', // 'non_normal' | 'discordant_only'
     arbitrationPolicy: 'discordant_only', // 'discordant_only' | 'all_non_normal'
     lazySessions: 'true',

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1286,7 +1286,7 @@ module.exports = (router) => {
             // Abnormal breast must have at least one annotation
             if (annotations.length === 0) {
               errors.push({
-                text: `Add at least one annotation for the ${sideLabel} breast`,
+                text: `Add an annotation for the ${sideLabel} breast`,
                 name: `annotations[${side}]`,
                 href: `#${side}-annotations`
               })

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1308,7 +1308,7 @@ module.exports = (router) => {
               // Abnormal breast must have at least one annotation of M3 or higher
               else if (highLevelAnnotations.length === 0) {
                 errors.push({
-                  text: `Add at least one annotation of level 3 or higher for the ${sideLabel} breast`,
+                  text: `Add an annotation of concern level 3 or higher for the ${sideLabel} breast`,
                   name: `annotations[${side}]`,
                   href: `#${side}-annotations`
                 })

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1146,6 +1146,43 @@ module.exports = (router) => {
         selectedViews = [selectedViews]
       }
 
+      // Validate: at least one view selected, and each selected view has a reason
+      const errors = []
+
+      if (selectedViews.length === 0) {
+        errors.push({
+          text: 'Select at least one view to retake',
+          name: 'imageReadingTemp[technicalRecall][selectedViews]',
+          href: '#technicalRecall-selectedViews-right-1'
+        })
+      } else {
+        selectedViews.forEach((viewCode) => {
+          const viewData = allViewData[viewCode] || {}
+          if (!viewData.reason) {
+            errors.push({
+              text: `Select a reason for the ${viewCode} view`,
+              name: `imageReadingTemp[technicalRecall][views][${viewCode}][reason]`,
+              href: `#technicalRecall-${viewCode}-reason`
+            })
+          }
+        })
+      }
+
+      if (errors.length) {
+        const isModal = req.headers['x-requested-with'] === 'XMLHttpRequest'
+        if (isModal) {
+          return res
+            .status(422)
+            .render('reading/workflow/technical-recall', {
+              flash: { error: errors }
+            })
+        }
+        errors.forEach((err) => req.flash('error', err))
+        return res.redirect(
+          `/reading/session/${sessionId}/events/${eventId}/technical-recall`
+        )
+      }
+
       // Build clean views object with only selected views
       const cleanViews = {}
       selectedViews.forEach((viewCode) => {
@@ -1162,10 +1199,12 @@ module.exports = (router) => {
         views: cleanViews
       }
 
-      // 307 preserves POST method so opinion-details-complete can 307 to save-opinion
-      // if the confirm-technical-recall setting is off
+      // Use a regular redirect (not 307) so the browser does not resend the original
+      // POST body. A 307 would cause the prototype kit middleware to re-save the raw
+      // form data (all views) at opinion-details-complete, overwriting the clean data.
+      // save-opinion reads from session (imageReadingTemp), not the POST body, so
+      // it works correctly when reached via GET through the skip-confirmation path.
       res.redirect(
-        307,
         `/reading/session/${sessionId}/events/${eventId}/opinion-details-complete`
       )
     }
@@ -1299,7 +1338,9 @@ module.exports = (router) => {
 
   // Handle recording a reading result
   // Save the reading opinion - reads opinion from imageReadingTemp.opinion
-  router.post(
+  // Uses router.all (not router.post) so it can be reached via GET when the
+  // skip-confirmation path redirects without preserving a POST method.
+  router.all(
     '/reading/session/:sessionId/events/:eventId/save-opinion',
     (req, res) => {
       const { sessionId, eventId } = req.params

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1257,7 +1257,8 @@ module.exports = (router) => {
           errors.push({
             text: 'At least one breast must be marked abnormal or needing clinical assessment to recall for assessment',
             name: 'imageReadingTemp[left][breastAssessment]',
-            href: '#left-breastAssessment'
+            href: '#left-breastAssessment',
+            hideFromSummary: true
           })
         }
 

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1319,7 +1319,7 @@ module.exports = (router) => {
             // Normal/clinical breast must not have annotations of M3 or higher
             if (highLevelAnnotations.length > 0) {
               errors.push({
-                text: `Remove annotations of level 3 or higher from the ${sideLabel} breast, or change the opinion to abnormal`,
+                text: `A normal ${sideLabel} breast cannot have annotations with concern level 3 or higher`,
                 name: `annotations[${side}]`,
                 href: `#${side}-annotations`
               })

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1236,7 +1236,7 @@ module.exports = (router) => {
         }
         if (!leftAssessment) {
           errors.push({
-            text: 'Select your opinion of the left breast',
+            text: 'Give an opinion for the left breast',
             name: 'imageReadingTemp[left][breastAssessment]',
             href: '#left-breastAssessment'
           })

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1290,14 +1290,29 @@ module.exports = (router) => {
                 name: `annotations[${side}]`,
                 href: `#${side}-annotations`
               })
-            }
-            // Abnormal breast must have at least one annotation of M3 or higher
-            else if (highLevelAnnotations.length === 0) {
-              errors.push({
-                text: `Add at least one annotation of level 3 or higher for the ${sideLabel} breast`,
-                name: `annotations[${side}]`,
-                href: `#${side}-annotations`
-              })
+            } else {
+              // All annotations must have required fields completed
+              const incompleteAnnotations = annotations.filter(
+                (a) =>
+                  !a.abnormalityTypes ||
+                  a.abnormalityTypes.length === 0 ||
+                  !a.levelOfConcern
+              )
+              if (incompleteAnnotations.length > 0) {
+                errors.push({
+                  text: `Complete the annotation details for the ${sideLabel} breast`,
+                  name: `annotations[${side}]`,
+                  href: `#${side}-annotations`
+                })
+              }
+              // Abnormal breast must have at least one annotation of M3 or higher
+              else if (highLevelAnnotations.length === 0) {
+                errors.push({
+                  text: `Add at least one annotation of level 3 or higher for the ${sideLabel} breast`,
+                  name: `annotations[${side}]`,
+                  href: `#${side}-annotations`
+                })
+              }
             }
           }
           else if (assessment === 'normal' || assessment === 'clinical') {

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1171,11 +1171,9 @@ module.exports = (router) => {
       if (errors.length) {
         const isModal = req.headers['x-requested-with'] === 'XMLHttpRequest'
         if (isModal) {
-          return res
-            .status(422)
-            .render('reading/workflow/technical-recall', {
-              flash: { error: errors }
-            })
+          return res.status(422).render('reading/workflow/technical-recall', {
+            flash: { error: errors }
+          })
         }
         errors.forEach((err) => req.flash('error', err))
         return res.redirect(
@@ -1261,6 +1259,51 @@ module.exports = (router) => {
             name: 'imageReadingTemp[left][breastAssessment]',
             href: '#left-breastAssessment'
           })
+        }
+
+        // Validate annotations match breast assessment
+        const rightAnnotations = formData?.right?.annotations || []
+        const leftAnnotations = formData?.left?.annotations || []
+
+        for (const side of ['right', 'left']) {
+          const assessment = side === 'right' ? rightAssessment : leftAssessment
+          const annotations = side === 'right' ? rightAnnotations : leftAnnotations
+          const sideLabel = side
+
+          if (!assessment) continue
+
+          const highLevelAnnotations = annotations.filter(
+            (a) => parseInt(a.levelOfConcern, 10) >= 3
+          )
+
+          if (assessment === 'abnormal') {
+            // Abnormal breast must have at least one annotation
+            if (annotations.length === 0) {
+              errors.push({
+                text: `Add at least one annotation for the ${sideLabel} breast`,
+                name: `annotations[${side}]`,
+                href: `#${side}-annotations`
+              })
+            }
+            // Abnormal breast must have at least one annotation of M3 or higher
+            else if (highLevelAnnotations.length === 0) {
+              errors.push({
+                text: `Add at least one annotation of level 3 or higher for the ${sideLabel} breast`,
+                name: `annotations[${side}]`,
+                href: `#${side}-annotations`
+              })
+            }
+          }
+          else if (assessment === 'normal' || assessment === 'clinical') {
+            // Normal/clinical breast must not have annotations of M3 or higher
+            if (highLevelAnnotations.length > 0) {
+              errors.push({
+                text: `Remove annotations of level 3 or higher from the ${sideLabel} breast, or change the opinion to abnormal`,
+                name: `annotations[${side}]`,
+                href: `#${side}-annotations`
+              })
+            }
+          }
         }
 
         if (errors.length) {

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1229,7 +1229,7 @@ module.exports = (router) => {
 
         if (!rightAssessment) {
           errors.push({
-            text: 'Select your opinion of the right breast',
+            text: 'Give an opinion for the right breast',
             name: 'imageReadingTemp[right][breastAssessment]',
             href: '#right-breastAssessment'
           })

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1249,13 +1249,18 @@ module.exports = (router) => {
           rightAssessment === 'normal' &&
           leftAssessment === 'normal'
         ) {
+          const event = data.events.find((e) => e.id === eventId)
+          const hasSymptoms = event?.medicalInformation?.symptoms?.length > 0
+          const errorText = hasSymptoms
+            ? 'At least one breast must be marked abnormal or needing clinical assessment to recall for assessment'
+            : 'At least one breast must be marked abnormal to recall for assessment'
           errors.push({
-            text: 'At least one breast must be marked abnormal or needing clinical assessment to recall for assessment',
+            text: errorText,
             name: 'imageReadingTemp[right][breastAssessment]',
             href: '#right-breastAssessment'
           })
           errors.push({
-            text: 'At least one breast must be marked abnormal or needing clinical assessment to recall for assessment',
+            text: errorText,
             name: 'imageReadingTemp[left][breastAssessment]',
             href: '#left-breastAssessment',
             hideFromSummary: true

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -194,7 +194,7 @@ module.exports = (router) => {
     req.session.data.settings.reading.confirmNormal = 'false'
     req.session.data.settings.reading.confirmNormalWithDetails = 'false'
     req.session.data.settings.reading.confirmTechnicalRecall = 'false'
-    req.session.data.settings.reading.confirmRecallForAssessment = 'false'
+    req.session.data.settings.reading.confirmRecallForAssessment = 'true'
 
     req.flash('success', 'Image reading v1 mode enabled')
     return res.redirect('/settings')

--- a/app/views/_components/annotation-list/template.njk
+++ b/app/views/_components/annotation-list/template.njk
@@ -38,7 +38,16 @@
       {% if annotation.abnormalityTypes is string %}
         {% set _typeLabel = annotation.abnormalityTypes if annotation.abnormalityTypes else "Type not set" %}
       {% elseif annotation.abnormalityTypes | length %}
-        {% set _typeLabel = annotation.abnormalityTypes | join(", ") %}
+        {# Replace "Other" with "Other: details" when otherDetails is provided #}
+        {% set _typeItems = [] %}
+        {% for type in annotation.abnormalityTypes %}
+          {% if type == "Other" and annotation.otherDetails %}
+            {% set _typeItems = _typeItems | push("Other: " + annotation.otherDetails) %}
+          {% else %}
+            {% set _typeItems = _typeItems | push(type) %}
+          {% endif %}
+        {% endfor %}
+        {% set _typeLabel = _typeItems | join(", ") %}
       {% else %}
         {% set _typeLabel = "Type not set" %}
       {% endif %}

--- a/app/views/_components/annotation-list/template.njk
+++ b/app/views/_components/annotation-list/template.njk
@@ -14,6 +14,7 @@
     useModals      — boolean, add data-load-modal-url to edit links and add button (default: false)
     emptyText      — text shown when no annotations (default: "No annotations")
     classes        — additional CSS classes on the wrapper
+    id             — id attribute on the wrapper element
 #}
 
 {% set _annotations = params.annotations | default([]) %}
@@ -23,7 +24,7 @@
 {% set _useModals = params.useModals | default(false) %}
 {% set _emptyText = params.emptyText | default("No annotations") %}
 
-<div class="app-annotation-list{{ ' app-annotation-list--interactive' if _interactive }}{{ ' ' + params.classes if params.classes }}">
+<div class="app-annotation-list{{ ' app-annotation-list--interactive' if _interactive }}{{ ' ' + params.classes if params.classes }}"{{ ' id="' + params.id + '"' if params.id }}>
 
   {% if _annotations | length == 0 %}
     <p class="app-annotation-list__empty">{{ _emptyText }}</p>

--- a/app/views/_components/annotation-list/template.njk
+++ b/app/views/_components/annotation-list/template.njk
@@ -12,7 +12,7 @@
     addHref        — URL for "Add annotation" button (optional, only shown if editable)
     addAttributes  — additional attributes for the add button (e.g. data-load-modal-url)
     useModals      — boolean, add data-load-modal-url to edit links and add button (default: false)
-    emptyText      — text shown when no annotations (default: "No annotations")
+    emptyText      — text shown when no annotations (default: "If abnormal, add an annotation (concern level 3 or higher)")
     classes        — additional CSS classes on the wrapper
     id             — id attribute on the wrapper element
 #}
@@ -22,7 +22,7 @@
 {% set _interactive = params.interactive | default(false) %}
 {% set _editable = params.editable | default(false) %}
 {% set _useModals = params.useModals | default(false) %}
-{% set _emptyText = params.emptyText | default("No annotations") %}
+{% set _emptyText = params.emptyText | default("If abnormal, add an annotation (concern level 3 or higher)") %}
 
 <div class="app-annotation-list{{ ' app-annotation-list--interactive' if _interactive }}{{ ' ' + params.classes if params.classes }}"{{ ' id="' + params.id + '"' if params.id }}>
 

--- a/app/views/_components/annotation-tabs/template.njk
+++ b/app/views/_components/annotation-tabs/template.njk
@@ -15,6 +15,8 @@
     showThumbs    — boolean, show thumbnail previews in tabs (default: true)
     id            — id attribute for the tab bar (default: "app-annotation-tabs")
     classes       — additional CSS classes
+    rightError    — error object for right breast (truthy shows error indicator)
+    leftError     — error object for left breast (truthy shows error indicator)
 #}
 
 {% set _activeSide = params.activeSide | default("right") %}
@@ -30,6 +32,7 @@
     label: "Right breast",
     side: "right",
     count: _rightCount,
+    hasError: params.rightError,
     views: [
       { key: "rcc", label: "RCC" },
       { key: "rmlo", label: "RMLO" }
@@ -42,6 +45,7 @@
     label: "Left breast",
     side: "left",
     count: _leftCount,
+    hasError: params.leftError,
     views: [
       { key: "lcc", label: "LCC" },
       { key: "lmlo", label: "LMLO" }
@@ -55,12 +59,15 @@
 <div class="app-ann-v2__tab-bar" id="{{ _id }}">
   {% for group in _groups %}
     <button
-      class="app-ann-v2__tab{{ ' is-active' if group.side == _activeSide else ' is-inactive' }}"
+      class="app-ann-v2__tab{{ ' is-active' if group.side == _activeSide else ' is-inactive' }}{{ ' app-ann-v2__tab--error' if group.hasError }}"
       type="button"
       data-thumb-side="{{ group.side }}"
-      aria-label="Switch to {{ group.label }}"
+      aria-label="Switch to {{ group.label }}{{ ' (has errors)' if group.hasError }}"
     >
       <span class="app-ann-v2__tab-label" data-side="{{ group.side }}">{{ group.label }}</span>
+      {% if group.hasError %}
+        <span class="app-ann-v2__tab-error-icon" aria-hidden="true">!</span>
+      {% endif %}
       <span class="app-count{{ ' app-count--blue' if group.count > 0 }}" data-side-count="{{ group.side }}">{{ group.count }}</span>
       {% if _showThumbs %}
         <span class="app-ann-v2__tab-thumbs">

--- a/app/views/_components/option-picker/template.njk
+++ b/app/views/_components/option-picker/template.njk
@@ -145,6 +145,7 @@
       {{- " checked" if isChecked }}
       {{- " disabled" if item.disabled }}
       {%- if item.conditional and item.conditional.html %} data-aria-controls="conditional-{{ itemId }}"{% endif %}
+      {%- if item.conditional and item.conditional.inline %} data-conditional-inline{% endif %}
       {%- if item.attributes %}
         {%- for attr, val in item.attributes %} {{ attr }}="{{ val }}"{% endfor %}
       {%- endif %}>

--- a/app/views/_components/option-picker/template.njk
+++ b/app/views/_components/option-picker/template.njk
@@ -60,8 +60,19 @@
   {% set formGroupClasses = formGroupClasses ~ " nhsuk-form-group--error" %}
 {% endif %}
 
+{#- Determine if any item has conditional content -#}
+{% set hasConditional = false %}
+{% for item in params.items %}
+  {% if item.conditional and item.conditional.html %}
+    {% set hasConditional = true %}
+  {% endif %}
+{% endfor %}
+
 {#- Build wrapper class list -#}
 {% set wrapperClasses = "app-option-picker app-option-picker--button" %}
+{% if hasConditional %}
+  {% set wrapperClasses = wrapperClasses ~ " app-option-picker--conditional" %}
+{% endif %}
 {% if params.joined %}
   {% set wrapperClasses = wrapperClasses ~ " app-option-picker--joined" %}
 {% endif %}
@@ -133,6 +144,7 @@
       value="{{ item.value }}"
       {{- " checked" if isChecked }}
       {{- " disabled" if item.disabled }}
+      {%- if item.conditional and item.conditional.html %} data-aria-controls="conditional-{{ itemId }}"{% endif %}
       {%- if item.attributes %}
         {%- for attr, val in item.attributes %} {{ attr }}="{{ val }}"{% endfor %}
       {%- endif %}>
@@ -154,11 +166,30 @@
     </label>
   {% endfor %}
   </div>
+  {#- Conditional reveal panels rendered below the items row -#}
+  {% for item in params.items %}
+    {% if item.conditional and item.conditional.html %}
+      {% set itemId = item.id if item.id else idPrefix ~ ("-" ~ loop.index if loop.index > 1 else "") %}
+      {% if item.checked != undefined %}
+        {% set isChecked = item.checked %}
+      {% elseif params.allowMultiple and params.values %}
+        {% set isChecked = item.value in params.values %}
+      {% elseif not params.allowMultiple and params.value %}
+        {% set isChecked = item.value == params.value %}
+      {% else %}
+        {% set isChecked = false %}
+      {% endif %}
+      <div class="app-option-picker__conditional{% if not isChecked %} app-option-picker__conditional--hidden{% endif %}"
+        id="conditional-{{ itemId }}">
+        {{ item.conditional.html | safe }}
+      </div>
+    {% endif %}
+  {% endfor %}
 {% endset %}
 
 {#- Render: form group > picker wrapper > optional fieldset > hint + error + items -#}
 <div class="{{ formGroupClasses }}">
-  <div class="{{ wrapperClasses }}">
+  <div class="{{ wrapperClasses }}"{% if hasConditional %} data-module="app-option-picker"{% endif %}>
     {% if params.fieldset %}
       <fieldset class="nhsuk-fieldset{% if params.fieldset.classes %} {{ params.fieldset.classes }}{% endif %}"
         {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/app/views/_components/option-picker/template.njk
+++ b/app/views/_components/option-picker/template.njk
@@ -180,7 +180,7 @@
       {% else %}
         {% set isChecked = false %}
       {% endif %}
-      <div class="app-option-picker__conditional{% if not isChecked %} app-option-picker__conditional--hidden{% endif %}"
+      <div class="app-option-picker__conditional{% if not isChecked and not item.conditional.inline %} app-option-picker__conditional--hidden{% endif %}"
         id="conditional-{{ itemId }}">
         {{ item.conditional.html | safe }}
       </div>

--- a/app/views/_includes/flash-messages.njk
+++ b/app/views/_includes/flash-messages.njk
@@ -10,9 +10,15 @@
 {% endif %}
 
 {% if flash.error %}
+  {% set _summaryErrors = [] %}
+  {% for err in flash.error %}
+    {% if not err.hideFromSummary %}
+      {% set _ = _summaryErrors.push(err) %}
+    {% endif %}
+  {% endfor %}
   {{ errorSummary({
     "titleText": "There is a problem",
-    "errorList": flash.error
+    "errorList": _summaryErrors
   }) }}
   {{ flash.error | log("Flash error") }}
 {% endif %}

--- a/app/views/_includes/reading/annotation-form.njk
+++ b/app/views/_includes/reading/annotation-form.njk
@@ -74,6 +74,7 @@
       id: _idBase + "otherDetails",
       name: _namePrefix + "[otherDetails]",
       value: annotationTemp.otherDetails,
+      classes: "nhsuk-u-width-two-thirds",
       label: {
         text: "Describe the abnormality"
       }

--- a/app/views/_includes/reading/annotation-form.njk
+++ b/app/views/_includes/reading/annotation-form.njk
@@ -76,15 +76,14 @@
       value: annotationTemp.otherDetails,
       label: {
         text: "Describe the abnormality"
-      },
-      classes: "nhsuk-u-width-two-thirds"
+      }
     } | populateErrors) }}
   {% endset %}
 
   {% set abnormalityItems = [] %}
   {% for type in data.abnormalityTypes %}
     {% if type == "Other" %}
-      {% set abnormalityItems = abnormalityItems | push({ value: type, text: type, conditional: { html: otherDetailsHtml } }) %}
+      {% set abnormalityItems = abnormalityItems | push({ value: type, text: type, conditional: { html: otherDetailsHtml, inline: true } }) %}
     {% else %}
       {% set abnormalityItems = abnormalityItems | push({ value: type, text: type }) %}
     {% endif %}

--- a/app/views/_includes/reading/annotation-form.njk
+++ b/app/views/_includes/reading/annotation-form.njk
@@ -142,7 +142,7 @@
        }
     },
     hint: {
-      text: "From ‘1 - normal’ to ‘5 - highly suspicious’"
+      text: "1 = normal, 2 = benign, 3 = indeterminate, 4 = suspicious, 5 = highly suspicious"
     },
     items: [
       { value: "1", text: "1" },

--- a/app/views/_includes/reading/annotation-form.njk
+++ b/app/views/_includes/reading/annotation-form.njk
@@ -69,9 +69,25 @@
 {% endif %}
 
 {% if abnormalityUi == "options" %}
+  {% set otherDetailsHtml %}
+    {{ input({
+      id: _idBase + "otherDetails",
+      name: _namePrefix + "[otherDetails]",
+      value: annotationTemp.otherDetails,
+      label: {
+        text: "Describe the abnormality"
+      },
+      classes: "nhsuk-u-width-two-thirds"
+    } | populateErrors) }}
+  {% endset %}
+
   {% set abnormalityItems = [] %}
   {% for type in data.abnormalityTypes %}
-    {% set abnormalityItems = abnormalityItems | push({ value: type, text: type }) %}
+    {% if type == "Other" %}
+      {% set abnormalityItems = abnormalityItems | push({ value: type, text: type, conditional: { html: otherDetailsHtml } }) %}
+    {% else %}
+      {% set abnormalityItems = abnormalityItems | push({ value: type, text: type }) %}
+    {% endif %}
   {% endfor %}
 
   {{ appOptionPicker({

--- a/app/views/_includes/reading/annotation-form.njk
+++ b/app/views/_includes/reading/annotation-form.njk
@@ -142,14 +142,14 @@
        }
     },
     hint: {
-      text: "From ‘5 - highly suspicious’ to ‘1 - normal’"
+      text: "From ‘1 - normal’ to ‘5 - highly suspicious’"
     },
     items: [
-      { value: "5", text: "5" },
-      { value: "4", text: "4" },
-      { value: "3", text: "3" },
+      { value: "1", text: "1" },
       { value: "2", text: "2" },
-      { value: "1", text: "1" }
+      { value: "3", text: "3" },
+      { value: "4", text: "4" },
+      { value: "5", text: "5" }
     ]
   } | populateErrors) }}
 

--- a/app/views/_includes/reading/annotations-with-images-progressive.njk
+++ b/app/views/_includes/reading/annotations-with-images-progressive.njk
@@ -80,7 +80,7 @@
                   </div>
                   <div data-annotation-add-button>
                     {{ button({
-                      text: "Add another annotation" if sideAnnotations | length > 0 else "Add annotation",
+                      text: "Add another ${sideLabel} breast annotation" if sideAnnotations | length > 0 else "Add ${sideLabel} breast annotation",
                       classes: "nhsuk-button--secondary nhsuk-button--small nhsuk-u-margin-bottom-0",
                       href: "./annotation/add?side=" + breastSide
                     }) }}

--- a/app/views/_includes/reading/annotations-with-images-progressive.njk
+++ b/app/views/_includes/reading/annotations-with-images-progressive.njk
@@ -7,6 +7,7 @@
 {% from '_components/annotation-list/macro.njk' import appAnnotationList %}
 {% from '_components/annotation-images/macro.njk' import appAnnotationImages %}
 {% from '_components/annotation-tabs/macro.njk' import appAnnotationTabs %}
+{% from 'button/macro.njk' import button %}
 
 {% set hasRightAnnotations = rightAnnotations | length > 0 %}
 {% set hasLeftAnnotations = leftAnnotations | length > 0 %}
@@ -14,6 +15,13 @@
 
 {# Activate the tab for whichever side was last edited, defaulting to right #}
 {% set initialSide = data.imageReadingTemp.lastEditedSide or "right" %}
+
+{# If there's an annotation error, show the errored side first #}
+{% if rightAnnotationsError and not leftAnnotationsError %}
+  {% set initialSide = "right" %}
+{% elseif leftAnnotationsError and not rightAnnotationsError %}
+  {% set initialSide = "left" %}
+{% endif %}
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
@@ -26,7 +34,9 @@
         viewOrder: mammogramViewOrder,
         rightCount: rightAnnotations | length,
         leftCount: leftAnnotations | length,
-        showThumbs: false
+        showThumbs: false,
+        rightError: rightAnnotationsError,
+        leftError: leftAnnotationsError
       }) }}
 
       <div class="app-ann-v2__panel">
@@ -35,6 +45,7 @@
           {% set sideHasAnnotations = sideAnnotations | length > 0 %}
 
           <div class="app-annotation-panel" data-panel-side="{{ breastSide }}"{{ ' hidden' if breastSide != initialSide }}>
+            {% set _sideAnnotationsError = rightAnnotationsError if breastSide == "right" else leftAnnotationsError %}
 
             {% if sideHasAnnotations %}
               {# Full interactive UI with images and sidebar #}
@@ -50,30 +61,50 @@
                 </div>
 
                 <div class="app-ann-v2__sidebar app-ann-v2__sidebar--embedded">
-                  <div class="app-ann-v2__sidebar-scroll">
+                  <div id="{{ breastSide }}-annotations" tabindex="-1" class="{{ 'app-annotation-section--error' if _sideAnnotationsError }}">
                     <h3 class="app-ann-v2__sidebar-heading">Annotations</h3>
-                    {{ appAnnotationList({
-                      annotations: sideAnnotations,
-                      interactive: true,
-                      editable: true,
-                      editHrefPrefix: "./annotation/edit/",
-                      addHref: "./annotation/add?side=" + breastSide,
-                      useModals: data.settings.modalForms == 'true'
+                    {% if _sideAnnotationsError %}
+                      <span class="app-annotation-section__error-message">
+                        <span class="nhsuk-u-visually-hidden">Error: </span>{{ _sideAnnotationsError.text }}
+                      </span>
+                    {% endif %}
+                    <div class="app-ann-v2__sidebar-scroll">
+                      {{ appAnnotationList({
+                        annotations: sideAnnotations,
+                        interactive: true,
+                        editable: true,
+                        editHrefPrefix: "./annotation/edit/",
+                        useModals: data.settings.modalForms == 'true'
+                      }) }}
+                    </div>
+                  </div>
+                  <div data-annotation-add-button>
+                    {{ button({
+                      text: "Add another annotation" if sideAnnotations | length > 0 else "Add annotation",
+                      classes: "nhsuk-button--secondary nhsuk-button--small nhsuk-u-margin-bottom-0",
+                      href: "./annotation/add?side=" + breastSide
                     }) }}
                   </div>
                 </div>
               </div>
             {% else %}
               {# Empty state — just annotation list (which shows add link) #}
-              <div class="nhsuk-grid-row">
-                <div class="nhsuk-grid-column-one-half">
-                  {{ appAnnotationList({
-                    annotations: sideAnnotations,
-                    editable: true,
-                    editHrefPrefix: "./annotation/edit/",
-                    addHref: "./annotation/add?side=" + breastSide,
-                    useModals: data.settings.modalForms == 'true'
-                  }) }}
+              <div id="{{ breastSide }}-annotations" tabindex="-1" class="{{ 'app-annotation-section--error' if _sideAnnotationsError }}">
+                {% if _sideAnnotationsError %}
+                  <span class="app-annotation-section__error-message">
+                    <span class="nhsuk-u-visually-hidden">Error: </span>{{ _sideAnnotationsError.text }}
+                  </span>
+                {% endif %}
+                <div class="nhsuk-grid-row">
+                  <div class="nhsuk-grid-column-one-half">
+                    {{ appAnnotationList({
+                      annotations: sideAnnotations,
+                      editable: true,
+                      editHrefPrefix: "./annotation/edit/",
+                      addHref: "./annotation/add?side=" + breastSide,
+                      useModals: data.settings.modalForms == 'true'
+                    }) }}
+                  </div>
                 </div>
               </div>
             {% endif %}

--- a/app/views/_includes/reading/annotations-with-images-tabbed.njk
+++ b/app/views/_includes/reading/annotations-with-images-tabbed.njk
@@ -6,8 +6,16 @@
 {% from '_components/annotation-list/macro.njk' import appAnnotationList %}
 {% from '_components/annotation-images/macro.njk' import appAnnotationImages %}
 {% from '_components/annotation-tabs/macro.njk' import appAnnotationTabs %}
+{% from 'button/macro.njk' import button %}
 
 {% set initialSide = data.imageReadingTemp.lastEditedSide or "right" %}
+
+{# If there's an annotation error, show the errored side first #}
+{% if rightAnnotationsError and not leftAnnotationsError %}
+  {% set initialSide = "right" %}
+{% elseif leftAnnotationsError and not rightAnnotationsError %}
+  {% set initialSide = "left" %}
+{% endif %}
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
@@ -20,7 +28,9 @@
         viewOrder: mammogramViewOrder,
         rightCount: rightAnnotations | length,
         leftCount: leftAnnotations | length,
-        showThumbs: false
+        showThumbs: false,
+        rightError: rightAnnotationsError,
+        leftError: leftAnnotationsError
       }) }}
 
       {# Tab panels — JS shows/hides based on active tab #}
@@ -29,6 +39,8 @@
           {% set sideAnnotations = rightAnnotations if breastSide == "right" else leftAnnotations %}
 
           <div class="app-annotation-panel" data-panel-side="{{ breastSide }}"{{ ' hidden' if breastSide != initialSide }}>
+            {% set _sideAnnotationsError = rightAnnotationsError if breastSide == "right" else leftAnnotationsError %}
+
             <div class="app-ann-v2">
               {# Images column #}
               <div class="app-ann-v2__images">
@@ -41,17 +53,30 @@
                 }) }}
               </div>
 
-              {# Sidebar: annotation list (JS will re-render this interactively) #}
+              {# Sidebar: annotation list #}
               <div class="app-ann-v2__sidebar app-ann-v2__sidebar--embedded">
-                <div class="app-ann-v2__sidebar-scroll">
+                <div id="{{ breastSide }}-annotations" tabindex="-1" class="{{ 'app-annotation-section--error' if _sideAnnotationsError }}">
                   <h3 class="app-ann-v2__sidebar-heading">Annotations</h3>
-                  {{ appAnnotationList({
-                    annotations: sideAnnotations,
-                    interactive: true,
-                    editable: true,
-                    editHrefPrefix: "./annotation/edit/",
-                    addHref: "./annotation/add?side=" + breastSide,
-                    useModals: data.settings.modalForms == 'true'
+                  {% if _sideAnnotationsError %}
+                    <span class="app-annotation-section__error-message">
+                      <span class="nhsuk-u-visually-hidden">Error: </span>{{ _sideAnnotationsError.text }}
+                    </span>
+                  {% endif %}
+                  <div class="app-ann-v2__sidebar-scroll">
+                    {{ appAnnotationList({
+                      annotations: sideAnnotations,
+                      interactive: true,
+                      editable: true,
+                      editHrefPrefix: "./annotation/edit/",
+                      useModals: data.settings.modalForms == 'true'
+                    }) }}
+                  </div>
+                </div>
+                <div data-annotation-add-button>
+                  {{ button({
+                    text: "Add another annotation" if sideAnnotations | length > 0 else "Add annotation",
+                    classes: "nhsuk-button--secondary nhsuk-button--small nhsuk-u-margin-bottom-0",
+                    href: "./annotation/add?side=" + breastSide
                   }) }}
                 </div>
               </div>

--- a/app/views/_includes/reading/annotations-with-images-tabbed.njk
+++ b/app/views/_includes/reading/annotations-with-images-tabbed.njk
@@ -112,7 +112,8 @@
       container: '#annotation-container',
       annotations: allAnnotations,
       activeSide: '{{ initialSide }}',
-      saveUrl: './save-annotations-json'
+      saveUrl: './save-annotations-json',
+      showIncompleteErrors: {{ "true" if (rightAnnotationsError or leftAnnotationsError) else "false" }}
     })
   })()
 </script>

--- a/app/views/_includes/scripts.html
+++ b/app/views/_includes/scripts.html
@@ -10,6 +10,7 @@
   <script type="module" src="/assets/javascript/expandable-sections.js"></script>
   <script type="module" src="/assets/javascript/stepper-input.js"></script>
   <script type="module" src="/assets/javascript/collapsible-input.js"></script>
+  <script type="module" src="/assets/javascript/option-picker.js"></script>
   <script type="module" src="/assets/javascript/autocomplete.js"></script>
   <script type="module" src="/assets/javascript/mammogram-channel.js"></script>
   <script type="module" src="/assets/javascript/keyboard-shortcuts.js"></script>

--- a/app/views/_includes/summary-lists/read-summary.njk
+++ b/app/views/_includes/summary-lists/read-summary.njk
@@ -144,11 +144,13 @@
     {% set viewsHtml %}
       <ul class="nhsuk-list">
         {% for viewCode, viewData in techRecallViews %}
-          <li>
-            <strong>{{ viewCode }}</strong>
-            {%- if viewData.reason %}: {{ viewData.reason }}{% endif %}
-            {%- if viewData.additionalDetails %} – {{ viewData.additionalDetails }}{% endif %}
-          </li>
+          {# Only show views that have a reason — unselected views are stored with an empty reason #}
+          {% if viewData.reason %}
+            <li>
+              <strong>{{ viewCode }}</strong>: {{ viewData.reason }}
+              {%- if viewData.additionalDetails %} – {{ viewData.additionalDetails }}{% endif %}
+            </li>
+          {% endif %}
         {% endfor %}
       </ul>
     {% endset %}

--- a/app/views/_templates/layout-modal-form.html
+++ b/app/views/_templates/layout-modal-form.html
@@ -40,6 +40,7 @@
 {%- from '_components/status-message/macro.njk' import appStatusMessage %}
 {%- from '_components/stepper-input/macro.njk' import appStepperInput %}
 {%- from '_components/summary-card/macro.njk' import appSummaryCard %}
+{%- from '_components/collapsible-input/macro.njk' import appCollapsibleInput %}
 {%- from '_components/summary-list/macro.njk' import appSummaryList %}
 {%- from '_components/summary-list/macro.njk' import appSummaryListRow %}
 

--- a/app/views/reading/workflow/annotate-v2.html
+++ b/app/views/reading/workflow/annotate-v2.html
@@ -537,7 +537,10 @@
       const isIncomplete = !ann.abnormalityTypes?.length && !ann.levelOfConcern
       let typeLabel = 'Type not set'
       if (ann.abnormalityTypes?.length) {
-        typeLabel = ann.abnormalityTypes.join(', ')
+        typeLabel = ann.abnormalityTypes.map(t => {
+          if (t === 'Other' && ann.otherDetails) return 'Other: ' + ann.otherDetails
+          return t
+        }).join(', ')
       }
       const concernLabel = ann.levelOfConcern ? CONCERN_LABELS[ann.levelOfConcern] : ''
       const metaParts = [concernLabel].filter(Boolean)

--- a/app/views/reading/workflow/annotation.html
+++ b/app/views/reading/workflow/annotation.html
@@ -162,7 +162,8 @@
           allAnnotations.push({
             id: tempId,
             side: '{{ side }}',
-            positions: {}
+            {# Preserve positions from session if returning from a validation error #}
+            positions: {{ (annotation.positions | dump | safe) if annotation.positions else '{}' }}
           })
           var activeId = tempId
         {% else %}

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -167,42 +167,33 @@
     </div>
   {% endif %}
 
-  {# Info: received priors that have a message (request reason) #}
+  {# Info: received priors #}
   {% if priorsSummary.counts.received > 0 %}
     {% set receivedMammograms = event.previousMammograms | where("requestStatus", "received") %}
-    {% set receivedWithMessage = [] %}
-    {% for mammogram in receivedMammograms %}
-      {% if mammogram.requestReason %}
-        {% set receivedWithMessage = receivedWithMessage | push(mammogram) %}
-      {% endif %}
-    {% endfor %}
-    {% if receivedWithMessage | length > 0 %}
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-full">
-          {% set receivedHtml %}
-            {% for mammogram in receivedWithMessage %}
-              <p class="nhsuk-u-margin-bottom-1">
-                {% if mammogram.requestedBy %}
-                 Requested by {{ mammogram.requestedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}. Request reason:
-                {% endif %}
-                {% if not mammogram.requestedBy %}
-                  Request reason:
-                {% endif %} {{ mammogram.requestReason }}
-              </p>
-            {% endfor %}
-          {% endset %}
-        
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-full">
+        {% set receivedHtml %}
+          {% for mammogram in receivedMammograms %}
+            <p class="nhsuk-u-margin-bottom-1">
+              {{ mammogram | summarisePriorMammogram({ unitName: unit.name }) }}
+              {% if mammogram.requestedBy %}
+                – requested by {{ mammogram.requestedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}{% if mammogram.requestReason %}: {{ mammogram.requestReason }}{% endif %}
+              {% elseif mammogram.requestReason %}
+                – {{ mammogram.requestReason }}
+              {% endif %}
+            </p>
+          {% endfor %}
+        {% endset %}
 
-          {% call insetText({
-            classes: "app-inset-text--compact" if data.settings.compactMode in ["true", true]
-          }) %}
-            <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Priors recently received</p>
-            {{ receivedHtml | safe }}
-          {% endcall %}
+        {% call insetText({
+          classes: "app-inset-text--compact" if data.settings.compactMode in ["true", true]
+        }) %}
+          <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Priors received</p>
+          {{ receivedHtml | safe }}
+        {% endcall %}
 
-        </div>
       </div>
-    {% endif %}
+    </div>
   {% endif %}
 
   {# Opinion form with thumbnails #}

--- a/app/views/reading/workflow/recall-for-assessment-details.html
+++ b/app/views/reading/workflow/recall-for-assessment-details.html
@@ -71,7 +71,7 @@
     {% if params.annotationsHtml %}
       <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
       <div id="{{ params.side }}-annotations" tabindex="-1" class="{{ 'app-annotation-section--error' if params.annotationError }}">
-        <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">${sideLabel} breast annotations</h3>
+        <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">{{ params.side | sentenceCase }} breast annotations</h3>
         {% if params.annotationError %}
           <span class="app-annotation-section__error-message">
             <span class="nhsuk-u-visually-hidden">Error: </span>{{ params.annotationError.text }}

--- a/app/views/reading/workflow/recall-for-assessment-details.html
+++ b/app/views/reading/workflow/recall-for-assessment-details.html
@@ -44,7 +44,7 @@
         },
         {
           value: "clinical",
-          text: "Normal, but symptoms need clinical assessment"
+          text: "Normal, symptoms need clinical assessment"
         } if event.medicalInformation.symptoms | length > 0,
         {
           value: "abnormal",
@@ -71,7 +71,7 @@
     {% if params.annotationsHtml %}
       <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
       <div id="{{ params.side }}-annotations" tabindex="-1" class="{{ 'app-annotation-section--error' if params.annotationError }}">
-        <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">Annotations</h3>
+        <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">${sideLabel} breast annotations</h3>
         {% if params.annotationError %}
           <span class="app-annotation-section__error-message">
             <span class="nhsuk-u-visually-hidden">Error: </span>{{ params.annotationError.text }}

--- a/app/views/reading/workflow/recall-for-assessment-details.html
+++ b/app/views/reading/workflow/recall-for-assessment-details.html
@@ -168,7 +168,8 @@
           {{ appAnnotationList({
             annotations: sideAnnotations,
             editable: true,
-            editHrefPrefix: "./annotation/edit/"
+            editHrefPrefix: "./annotation/edit/",
+            useModals: data.settings.modalForms == 'true'
           }) }}
 
           <span hidden data-annotation-count="{{ breastSide }}" data-count="{{ sideAnnotations | length }}"></span>

--- a/app/views/reading/workflow/recall-for-assessment-details.html
+++ b/app/views/reading/workflow/recall-for-assessment-details.html
@@ -70,8 +70,16 @@
     {# Per-breast annotations (non-tab modes only) #}
     {% if params.annotationsHtml %}
       <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
-      <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">Annotations</h3>
-      {{ params.annotationsHtml | safe }}
+      <div id="{{ params.side }}-annotations" tabindex="-1" class="{{ 'app-annotation-section--error' if params.annotationError }}">
+        <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">Annotations</h3>
+        {% if params.annotationError %}
+          <span class="app-annotation-section__error-message">
+            <span class="nhsuk-u-visually-hidden">Error: </span>{{ params.annotationError.text }}
+          </span>
+        {% endif %}
+        {{ params.annotationsHtml | safe }}
+      </div>
+      {{ params.annotationsButtonHtml | safe }}
     {% endif %}
 
   {% endset %}
@@ -116,6 +124,10 @@
   {% set leftAnnotations = data.imageReadingTemp.left.annotations | default([]) %}
   {% set rightAnnotations = data.imageReadingTemp.right.annotations | default([]) %}
 
+  {# Annotation validation errors #}
+  {% set rightAnnotationsError = 'annotations[right]' | getFlashError %}
+  {% set leftAnnotationsError = 'annotations[left]' | getFlashError %}
+
   {# For non-tab modes, annotations go inside each breast card #}
   {% set isInlineAnnotationsMode = annotationsMode == 'without-images' or annotationsMode == 'with-images-simple' %}
 
@@ -126,6 +138,7 @@
 
       {# Build per-side annotation HTML for inline modes #}
       {% set sideAnnotationsHtml = "" %}
+      {% set _sideAnnotationsError = rightAnnotationsError if breastSide == "right" else leftAnnotationsError %}
       {% if isInlineAnnotationsMode %}
 
         {% set sideAnnotationsHtml %}
@@ -155,18 +168,31 @@
           {{ appAnnotationList({
             annotations: sideAnnotations,
             editable: true,
-            editHrefPrefix: "./annotation/edit/",
-            addHref: "./annotation/add?side=" + breastSide,
-            useModals: data.settings.modalForms == 'true'
+            editHrefPrefix: "./annotation/edit/"
           }) }}
 
           <span hidden data-annotation-count="{{ breastSide }}" data-count="{{ sideAnnotations | length }}"></span>
         {% endset %}
 
+        {# Button rendered separately so it sits outside the error bar #}
+        {% set sideAnnotationsButtonHtml %}
+          {{ button({
+            text: "Add another annotation" if sideAnnotations | length > 0 else "Add annotation",
+            classes: "nhsuk-button--secondary nhsuk-button--small nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-3",
+            href: "./annotation/add?side=" + breastSide,
+            attributes: { "data-load-modal-url": "./annotation/add?side=" + breastSide } if data.settings.modalForms == 'true'
+          }) }}
+        {% endset %}
+
       {% endif %}
 
       <div class="nhsuk-grid-column-one-half">
-        {{ breastDetails({ side: breastSide, annotationsHtml: sideAnnotationsHtml if isInlineAnnotationsMode }) }}
+        {{ breastDetails({
+          side: breastSide,
+          annotationsHtml: sideAnnotationsHtml if isInlineAnnotationsMode,
+          annotationsButtonHtml: sideAnnotationsButtonHtml if isInlineAnnotationsMode,
+          annotationError: _sideAnnotationsError if isInlineAnnotationsMode
+        }) }}
       </div>
     {% endfor %}
   </div>
@@ -258,6 +284,47 @@
           } else {
             window.location.href = url
           }
+        }
+      })
+    })()
+  </script>
+
+  {# Handle annotation error summary links — focus target and switch tabs #}
+  <script>
+    (function () {
+      document.addEventListener('click', function (e) {
+        var link = e.target.closest('a[href="#right-annotations"], a[href="#left-annotations"]')
+        if (!link) return
+
+        var href = link.getAttribute('href')
+        var side = href === '#right-annotations' ? 'right' : 'left'
+        var target = document.getElementById(href.slice(1))
+
+        {% if not isInlineAnnotationsMode %}
+        // Switch tab using the annotation instance if available
+        if (window._annotationInstance && window._annotationInstance.switchSide) {
+          window._annotationInstance.switchSide(side)
+        } else {
+          // Lightweight tab switching for progressive / tabbed modes
+          var container = document.getElementById('annotation-progressive-container') ||
+                          document.getElementById('annotation-container')
+          if (container) {
+            container.querySelectorAll('[data-thumb-side]').forEach(function (t) {
+              t.classList.toggle('is-active', t.dataset.thumbSide === side)
+              t.classList.toggle('is-inactive', t.dataset.thumbSide !== side)
+            })
+            container.querySelectorAll('[data-panel-side]').forEach(function (panel) {
+              panel.hidden = panel.dataset.panelSide !== side
+            })
+          }
+        }
+        {% endif %}
+
+        // Scroll to and focus the target element
+        if (target) {
+          target.scrollIntoView()
+          target.focus({ preventScroll: true })
+          e.preventDefault()
         }
       })
     })()

--- a/app/views/reading/workflow/technical-recall.html
+++ b/app/views/reading/workflow/technical-recall.html
@@ -61,9 +61,18 @@
   {% set leftCheckboxItems = [] %}
   {% set currentTechRecall = data.imageReadingTemp.technicalRecall.views | default({}) %}
 
+  {# Normalize selectedViews to array — needed to correctly pre-check boxes after a validation error,
+     where the user may have checked a view without selecting a reason (reason would be empty,
+     so checking viewData.reason alone would incorrectly uncheck the box on redirect) #}
+  {% set currentSelectedViews = data.imageReadingTemp.technicalRecall.selectedViews | default([]) %}
+  {% if currentSelectedViews is string %}
+    {% set currentSelectedViews = [] | push(currentSelectedViews) %}
+  {% endif %}
+
   {% for viewCode in views %}
     {% set viewData = currentTechRecall[viewCode] | default({}) %}
-    
+    {% set isChecked = viewData.reason or viewCode in currentSelectedViews %}
+
     {% set conditionalHtml %}
       {{ select({
         id: "technicalRecall-" + viewCode + "-reason",
@@ -73,23 +82,25 @@
           text: "Reason for recall"
         },
         items: selectItems
-      }) }}
+      } | populateErrors) }}
 
-      {{ input({
-        id: "technicalRecall-" + viewCode + "-additionalDetails",
-        name: "imageReadingTemp[technicalRecall][views][" + viewCode + "][additionalDetails]",
-        value: viewData.additionalDetails,
-        label: {
-          text: "Additional details (optional)",
-          classes: "nhsuk-label--s"
-        }
-      }) }}
+      {% call appCollapsibleInput({ text: "Add additional details" }) %}
+        {{ input({
+          id: "technicalRecall-" + viewCode + "-additionalDetails",
+          name: "imageReadingTemp[technicalRecall][views][" + viewCode + "][additionalDetails]",
+          value: viewData.additionalDetails,
+          label: {
+            text: "Additional details (optional)",
+            classes: "nhsuk-label--s"
+          }
+        }) }}
+      {% endcall %}
     {% endset %}
 
     {% set checkboxItem = {
       value: viewCode,
       text: viewCode,
-      checked: viewData.reason,
+      checked: isChecked,
       conditional: {
         html: conditionalHtml
       }
@@ -102,13 +113,24 @@
     {% endif %}
   {% endfor %}
 
+  {% set _viewsError = 'imageReadingTemp[technicalRecall][selectedViews]' | getFlashError %}
+
+  <div class="nhsuk-form-group{{ ' nhsuk-form-group--error' if _viewsError else '' }}">
   {% call fieldset({
     legend: {
       text: "Which views need to be retaken?",
       classes: "nhsuk-fieldset__legend--m",
       isPageHeading: false
-    }
+    },
+    describedBy: "selectedViews-error" if _viewsError
   }) %}
+
+    {% if _viewsError %}
+      {{ errorMessage({
+        id: "selectedViews-error",
+        text: _viewsError.text
+      }) }}
+    {% endif %}
 
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-half">
@@ -132,6 +154,7 @@
     </div>
 
   {% endcall %}
+  </div>
 
   {{ button({
     text: "Continue"

--- a/app/views/style-guide/option-picker.html
+++ b/app/views/style-guide/option-picker.html
@@ -182,4 +182,61 @@
   }) }}
 </div>
 
+<hr>
+
+<h3>Conditional reveal</h3>
+
+<p>Pass <code>conditional.html</code> on an item to reveal content below the options when that item is checked. Follows the same accessibility pattern as NHS checkboxes: <code>aria-controls</code> and <code>aria-expanded</code> are managed by JavaScript. Without JS the panel is always visible.</p>
+
+<h4>Radio with conditional</h4>
+
+<div class="sg-example">
+  {% set otherRadioHtml %}
+    <div class="nhsuk-form-group">
+      <label class="nhsuk-label" for="other-reason">Provide details</label>
+      <input class="nhsuk-input nhsuk-u-width-two-thirds" id="other-reason" name="other-reason" type="text">
+    </div>
+  {% endset %}
+
+  {{ appOptionPicker({
+    idPrefix: "reason-demo",
+    name: "reason-demo",
+    fieldset: {
+      legend: { text: "Reason for recall" }
+    },
+    items: [
+      { value: "technical", text: "Technical recall" },
+      { value: "clinical", text: "Clinical recall" },
+      { value: "other", text: "Other", conditional: { html: otherRadioHtml } }
+    ]
+  }) }}
+</div>
+
+<h4>Checkbox with conditional</h4>
+
+<div class="sg-example">
+  {% set otherCheckboxHtml %}
+    <div class="nhsuk-form-group">
+      <label class="nhsuk-label" for="other-type">Provide details</label>
+      <input class="nhsuk-input nhsuk-u-width-two-thirds" id="other-type" name="other-type" type="text">
+    </div>
+  {% endset %}
+
+  {{ appOptionPicker({
+    idPrefix: "type-demo",
+    name: "type-demo[]",
+    allowMultiple: true,
+    values: ["mass"],
+    fieldset: {
+      legend: { text: "Abnormality type" }
+    },
+    items: [
+      { value: "mass", text: "Mass" },
+      { value: "calcification", text: "Calcification" },
+      { value: "distortion", text: "Distortion" },
+      { value: "other", text: "Other", conditional: { html: otherCheckboxHtml } }
+    ]
+  }) }}
+</div>
+
 {% endblock %}

--- a/app/views/style-guide/option-picker.html
+++ b/app/views/style-guide/option-picker.html
@@ -239,4 +239,30 @@
   }) }}
 </div>
 
+<h4>Checkbox with inline conditional</h4>
+
+<p>Add <code>conditional.inline: true</code> to reveal the input inside the button itself. This is a JS-only enhancement — without JS it falls back to the standard below-panel reveal.</p>
+
+<div class="sg-example">
+  {% set otherInlineHtml %}
+    <input class="nhsuk-input" id="other-inline-type" name="other-inline-type" type="text">
+  {% endset %}
+
+  {{ appOptionPicker({
+    idPrefix: "inline-demo",
+    name: "inline-demo[]",
+    allowMultiple: true,
+    values: ["mass"],
+    fieldset: {
+      legend: { text: "Abnormality type" }
+    },
+    items: [
+      { value: "mass", text: "Mass" },
+      { value: "calcification", text: "Calcification" },
+      { value: "distortion", text: "Distortion" },
+      { value: "other", text: "Other", conditional: { html: otherInlineHtml, inline: true } }
+    ]
+  }) }}
+</div>
+
 {% endblock %}


### PR DESCRIPTION
## Description

Primarily focuses on adding validation to recall for assessment to:
* Require that opinions are given for both breasts
* Require that both breasts cannot be normal
* For each breast that is abnormal, at least one annotation is added of M3 or higher
* For each breast that is normal, they cannot have an annotation of M3 or higher

Other changes:
* More dark mode fixes (never ending)
* Fix technical recall data saving and display
* Add validation to technical recall
* Swap more optional fields to collapsible input.
* Adds a conditional free text for 'other' abnormality type - validated if 'other' is picked

<img width="2128" height="2106" alt="Screenshot 2026-05-29 at 16 26 59" src="https://github.com/user-attachments/assets/c0c44a4b-915b-4904-9671-570534bb4060" />

<img width="2116" height="2060" alt="Screenshot 2026-05-29 at 16 27 33" src="https://github.com/user-attachments/assets/ac1256c3-e99e-45e1-83e4-6093721e773c" />

Conditional input with js:
<img width="843" height="442" alt="manage-inline-conditional-2" src="https://github.com/user-attachments/assets/bcf53017-38fa-455f-9a89-d7b1670584be" />

Conditional input with validation:
<img width="1482" height="312" alt="Screenshot 2026-05-29 at 16 32 09" src="https://github.com/user-attachments/assets/e5ea6041-c280-4872-8021-d2390cfc7c02" />


Conditional input without js:
<img width="1488" height="1268" alt="Screenshot 2026-05-29 at 15 40 14" src="https://github.com/user-attachments/assets/8cac1a41-3652-4ae5-a60f-95311199119d" />

