### PR TITLE
Make special appointment support detail labels optional

### DIFF
--- a/app/views/events/special-appointment/edit.html
+++ b/app/views/events/special-appointment/edit.html
@@ -40,7 +40,7 @@
             html: textarea({
               name: "event[specialAppointment][implantDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.implantDetails,
               lines: 3
@@ -57,7 +57,7 @@
             html: textarea({
               name: "event[specialAppointment][implantedMedicalDevicesDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.implantedMedicalDevicesDetails,
               lines: 3
@@ -71,7 +71,7 @@
             html: textarea({
               name: "event[specialAppointment][visionDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.visionDetails,
               lines: 3
@@ -85,7 +85,7 @@
             html: textarea({
               name: "event[specialAppointment][hearingDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.hearingDetails,
               lines: 3
@@ -102,7 +102,7 @@
             html: textarea({
               name: "event[specialAppointment][physicalRestrictionDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.physicalRestrictionDetails,
               lines: 3
@@ -119,7 +119,7 @@
             html: textarea({
               name: "event[specialAppointment][socialEmotionalMentalHealthDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.socialEmotionalMentalHealthDetails,
               lines: 3
@@ -133,7 +133,7 @@
             html: textarea({
               name: "event[specialAppointment][languageDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.languageDetails,
               lines: 3
@@ -147,7 +147,7 @@
             html: textarea({
               name: "event[specialAppointment][genderIdentityDetails]",
               label: {
-                text: "Describe support required"
+                text: "Describe support required (optional)"
               },
               value: data.event.specialAppointment.genderIdentityDetails,
               lines: 3


### PR DESCRIPTION
## Description

Marks all the special appointment conditionals as optional with the exception of the final 'Other' item.