### PR TITLE
Various updates to previous mammogram form and summary

### DIFF
--- a/app/lib/utils/prior-mammograms.js
+++ b/app/lib/utils/prior-mammograms.js
@@ -150,14 +150,14 @@ const summarisePriorMammogram = (mammogram, options = {}) => {
   // Date detail — combine formatted date and relative time into parenthesised suffix
   const dateParts = []
   if (mammogram.dateType === 'dateKnown' && mammogram.dateTaken) {
-    dateParts.push(formatDate(mammogram.dateTaken, 'MMMM YYYY'))
+    dateParts.push(formatDate(mammogram.dateTaken, 'MMM YYYY'))
     if (mammogram._rawDate) {
       dateParts.push(formatRelativeDate(mammogram._rawDate))
     }
   } else if (mammogram.dateType === 'moreThanSixMonths') {
-    dateParts.push(mammogram.approximateDate || 'over 6 months ago')
+    dateParts.push('over 6 months ago')
   } else if (mammogram.dateType === 'lessThanSixMonths') {
-    dateParts.push(mammogram.approximateDate || 'less than 6 months ago')
+    dateParts.push('less than 6 months ago')
   }
 
   const dateDetail = dateParts.length > 0 ? `(${dateParts.join(', ')})` : ''

--- a/app/lib/utils/prior-mammograms.js
+++ b/app/lib/utils/prior-mammograms.js
@@ -129,21 +129,19 @@ const summarisePriorMammogram = (mammogram, options = {}) => {
   let location = ''
   switch (mammogram.location) {
     case 'bsu':
-      location = mammogram.bsu || 'NHS breast screening unit'
+      location = 'At another BSU'
       break
     case 'otherUk':
-      location = mammogram.otherUk || 'Other UK location'
+      location = 'Elsewhere in the UK'
       break
     case 'otherNonUk':
-      location = mammogram.otherNonUk
-        ? `Outside UK: ${mammogram.otherNonUk}`
-        : 'Outside UK'
+      location = 'Outside the UK'
       break
     case 'currentBsu':
-      location = unitName || 'Current BSU'
+      location = `At ${unitName || 'this BSU'}`
       break
     case 'preferNotToSay':
-      location = 'Location not given'
+      location = 'Location not provided'
       break
     default:
       location = ''

--- a/app/views/_includes/medical-information/index.njk
+++ b/app/views/_includes/medical-information/index.njk
@@ -12,7 +12,7 @@
 
 {# Mammogram history #}
 {% set sectionHeading = "Mammogram history" %}
-{% set subHeading = "The last confirmed mammogram and any added manually since then" %}
+{% set subHeading = "Previous mammograms from screening records and any reported by the participant" %}
 {% set sectionId = sectionHeading | kebabCase %}
 {% set scrollTo = sectionId %}
 

--- a/app/views/_includes/medical-information/mammogram-history.njk
+++ b/app/views/_includes/medical-information/mammogram-history.njk
@@ -12,7 +12,7 @@
     {{ mostRecentClinic.location.name }}</br>
     {{ mostRecentClinic.event.type | sentenceCase }}
   {% else %}
-    {{ "Not applicable" | asHint }}
+    {{ "No information" | asHint }}
   {% endif %}
 {% endset %}
 

--- a/app/views/_includes/medical-information/mammogram-history.njk
+++ b/app/views/_includes/medical-information/mammogram-history.njk
@@ -3,9 +3,6 @@
 {% set hasAdditionalMammograms = event.previousMammograms | length > 0 %}
 
 {# System record - last known mammogram from BSU records #}
-{% if hasAdditionalMammograms %}
-  <h3 class="nhsuk-heading-s">From screening records</h3>
-{% endif %}
 
 {% set systemRecordHtml %}
   {% set mostRecentClinic = data | getParticipantMostRecentClinic(participant.id) %}
@@ -15,7 +12,7 @@
     {{ mostRecentClinic.location.name }}</br>
     {{ mostRecentClinic.event.type | sentenceCase }}
   {% else %}
-    {{ "Not known" | asHint }}
+    {{ "Not applicable" | asHint }}
   {% endif %}
 {% endset %}
 
@@ -23,7 +20,7 @@
   rows: [
     {
       key: {
-        text: "Last known mammogram"
+        text: "Most recent mammogram on record"
       },
       value: {
         html: systemRecordHtml

--- a/app/views/events/previous-mammograms/form.html
+++ b/app/views/events/previous-mammograms/form.html
@@ -289,7 +289,7 @@
     },
     value: event.previousMammogramTemp.otherDetails,
     hint: {
-      text: "For example, the reason for the mammograms and the outcome of the assessment"
+      text: "For example, the reason for the mammogram, the participant's previous address, and the outcome of the assessment"
     }
   }) }}
 


### PR DESCRIPTION
Content update related to 3 tickets:

* [DTOSS-12979](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-12979) - Medical information can show "last known mammogram: not known"
* [DTOSS-13114](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-13114) - Expand hint text for additional info for previous mammos
* [DTOSS-13075](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-13075) - Add mammogram summary to final confirmation page

Mammogram history card updated so missing data is 'not applicable' rather than 'not known' - also updated rob label and hint text for clarity 

<img width="1095" height="521" alt="image" src="https://github.com/user-attachments/assets/adbfa1c9-c453-46b0-a4c6-14694d07f29c" />

Adapted hint text for additional info when adding a new mammogram (to reflect type of data entered during pilot test)

<img width="765" height="272" alt="image" src="https://github.com/user-attachments/assets/eac44b19-c6bf-48d6-bbde-72306cd4729c" />

Adjusted summary text displayed on the 'Check information' step in the appointment workflow (uses standard text from options rather than free text entered)

For example....if these new mammograms are entered...

<img width="880" height="872" alt="image" src="https://github.com/user-attachments/assets/fa366ee5-06a6-4293-b70d-777bdb6bd824" />

the summary will display as...

<img width="922" height="324" alt="image" src="https://github.com/user-attachments/assets/6bcde70d-9052-4ebe-a683-23118d9e6a3c" />

(note, the full info is still visible from the view/change link)