### PR TITLE
New mammogram appointment warning message

### DIFF
--- a/app/views/events/previous-mammograms/appointment-should-not-take-place.html
+++ b/app/views/events/previous-mammograms/appointment-should-not-take-place.html
@@ -1,0 +1,66 @@
+{# app/views/events/previous-mammograms/appointment-should-not-begin.html #}
+
+{% extends parentLayout or 'layout-appointment.html' %}
+
+{% set previousMammogramCount = event.previousMammograms | length %}
+
+{% set pageHeading = "This appointment should not take place" %}
+
+{% set formAction = './save' | urlWithReferrer(referrerChain, query.scrollTo) %}
+
+{% block pageContent %}
+
+  {% set previousMammograms = event.previousMammograms %}
+
+  {% set unit = data.breastScreeningUnits | findById(clinic.breastScreeningUnitId) %}
+
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-l">
+      {{ participant | getFullName }}
+    </span>
+    {{ pageHeading }}
+  </h1>
+
+  <p>
+      There is a mammogram on this participant's record from within the last 6 months. Breast x-rays should not be taken within 6 months of a previous mammogram.
+    </p>
+
+{% set mammogramHistoryHtml %}
+  {% include "_includes/medical-information/mammogram-history.njk" %}
+{% endset %}
+
+  {{ radios({
+    name: "event[appointmentStopped][needsReschedule]",
+    value: event.appointmentStopped.needsReschedule,
+    fieldset: {
+      legend: {
+        text: "Should the appointment be rescheduled?",
+        size: "m",
+        isPageHeading: false
+      }
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Yes"
+      },
+      {
+        value: "no-invite",
+        text: "No, invite to next routine appointment"
+      }
+    ]
+  } | populateErrors) }}
+
+  {# Prevents redirect loop - signals to the save route that we've already shown this warning page #}
+  <input type="hidden" name="action" value="acknowledged-warning">
+
+  <div class="nhsuk-button-group">
+    {{ button({
+      text: "Continue"
+    }) }}
+  </div>
+
+  <p>
+    <a href="{{ './proceed-anyway' | urlWithReferrer(referrerChain, query.scrollTo) }}" class="app-link--warning">Proceed with this appointment</a>
+  </p>
+{% endblock %}


### PR DESCRIPTION
New page to address [ticket 12972](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-12972) - Design better warning page to be shown if starting an appointment that has a previous mammogram less than 6 months

> if you start an appointment that has a mammogram added that is less than 6 months prior, the users are currently shown the warning page designed to be shown immediately after adding a mammogram - this page doesn't really make sense on a freshly started appointment.

Based on /previous-mammograms/appointment-should-not-proceed
- copy adjusted to reflect this scenario
- includes details of mammo on record (rather than data from 'add a mammogram' worflow)
- removes the 'Edit previous mammogram details' option (as they can't edit the record)

Retains the 'Proceed with this appointment' if they want to continue anyway
- content on the subsequent page /previous-mammograms/proceed-anyway does not need updating

Screenshot:
<img width="2164" height="2384" alt="Screenshot 2026-06-12 at 16 13 30" src="https://github.com/user-attachments/assets/d0e9483f-c357-4c0d-a97a-ead431fcf8fa" />
 
The page isn't linked to any flow but can be accessed from the index page.