### PR TITLE
Defer reading a case

### DIFF
--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -1366,6 +1366,16 @@ const shouldShowComparePage = function (
  * @param {object} [options] - Options for determining eligibility
  * @returns {boolean} Whether the current user can read this event
  */
+/**
+ * Check if an event has been deferred from reading
+ *
+ * @param {object} event - The event to check
+ * @returns {boolean} Whether the event has been deferred
+ */
+const isDeferred = (event) => {
+  return !!(event?.imageReading?.deferral?.deferredAt)
+}
+
 const canUserReadEvent = function (event, userId = null, options = {}) {
   const { maxReadsPerEvent = 2 } = options
 
@@ -1380,6 +1390,11 @@ const canUserReadEvent = function (event, userId = null, options = {}) {
 
   // Can't read if event is awaiting priors
   if (awaitingPriors(event)) {
+    return false
+  }
+
+  // Can't read if event has been deferred
+  if (isDeferred(event)) {
     return false
   }
 
@@ -1821,17 +1836,23 @@ const getSessionReadingProgress = (
 
   const resolvedTargetSize = session.targetSize || sessionEvents.length
 
+  // Count deferred events so they count toward the session target
+  const deferredCount = sessionEvents.filter(isDeferred).length
+
   return {
     ...progress,
     // How many events are currently loaded vs the overall target
     populatedCount: sessionEvents.length,
     targetSize: resolvedTargetSize,
+    // Deferred events count as 'done' for session progress purposes
+    deferredCount,
     // Remaining reads against the target (not just currently loaded events)
     targetRemaining: Math.max(
       0,
       resolvedTargetSize -
         progress.userReadCount -
-        progress.userAwaitingPriorsCount
+        progress.userAwaitingPriorsCount -
+        deferredCount
     )
   }
 }
@@ -1884,6 +1905,7 @@ module.exports = {
   // Booleans
   userHasReadEvent,
   canUserReadEvent,
+  isDeferred,
   hasReads,
   needsArbitration,
   needsFirstRead,

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -1373,7 +1373,7 @@ const shouldShowComparePage = function (
  * @returns {boolean} Whether the event has been deferred
  */
 const isDeferred = (event) => {
-  return !!(event?.imageReading?.deferral?.deferredAt)
+  return !!event?.imageReading?.deferral?.deferredAt
 }
 
 const canUserReadEvent = function (event, userId = null, options = {}) {

--- a/app/lib/utils/status.js
+++ b/app/lib/utils/status.js
@@ -283,6 +283,7 @@ const getStatusTagColour = (status) => {
     'prior_pending': 'orange',
     'prior_requested': 'yellow',
     'priors_requested': 'yellow',
+    'deferred': 'orange',
     'prior_received': 'green',
     'prior_not_available': 'grey',
     'prior_not_needed': 'grey'

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -807,8 +807,12 @@ module.exports = (router) => {
       // Normalise approximateDate in session now, before any redirect, so the
       // warning page doesn't display a raw array (e.g. ",June 2025") caused by
       // both conditional inputs being submitted together.
-      if (previousMammogramTemp && Array.isArray(previousMammogramTemp.approximateDate)) {
-        previousMammogramTemp.approximateDate = previousMammogramTemp.approximateDate.find((v) => v) || ''
+      if (
+        previousMammogramTemp &&
+        Array.isArray(previousMammogramTemp.approximateDate)
+      ) {
+        previousMammogramTemp.approximateDate =
+          previousMammogramTemp.approximateDate.find((v) => v) || ''
       }
 
       // Check if this is a recent mammogram (within 6 months)

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -804,6 +804,13 @@ module.exports = (router) => {
         return res.redirect(modalBreakout(`/clinics/${clinicId}/`))
       }
 
+      // Normalise approximateDate in session now, before any redirect, so the
+      // warning page doesn't display a raw array (e.g. ",June 2025") caused by
+      // both conditional inputs being submitted together.
+      if (previousMammogramTemp && Array.isArray(previousMammogramTemp.approximateDate)) {
+        previousMammogramTemp.approximateDate = previousMammogramTemp.approximateDate.find((v) => v) || ''
+      }
+
       // Check if this is a recent mammogram (within 6 months)
       const isRecentMammogram = checkIfRecentMammogram(previousMammogramTemp)
 

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -814,13 +814,22 @@ module.exports = (router) => {
     res.render('reading/deferred')
   })
 
-  // Undo deferral from the deferred cases management page
+  // Unflag a deferral from the deferred cases management page
+  // Keeps a record of the resolved deferral so the reason stays visible
   router.post('/reading/deferred/undo', (req, res) => {
     const data = req.session.data
     const { eventId } = req.body
 
     const event = data.events.find((e) => e.id === eventId)
     if (event?.imageReading?.deferral) {
+      if (!event.imageReading.deferralHistory) {
+        event.imageReading.deferralHistory = []
+      }
+      event.imageReading.deferralHistory.push({
+        ...event.imageReading.deferral,
+        resolvedAt: new Date().toISOString(),
+        resolvedBy: data.currentUser?.id
+      })
       delete event.imageReading.deferral
 
       if (data.event && data.event.id === eventId) {

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -550,6 +550,14 @@ module.exports = (router) => {
       )
     }
 
+    // Check if event has been deferred from reading
+    const { isDeferred } = require('../lib/utils/reading')
+    if (isDeferred(event)) {
+      return res.redirect(
+        `/reading/session/${sessionId}/events/${eventId}/existing-read`
+      )
+    }
+
     // Delete temporary data from previous steps
     delete data.imageReadingTemp
 
@@ -653,12 +661,12 @@ module.exports = (router) => {
           editHref: `/reading/session/${sessionId}/events/${eventId}/existing-read`
         }
         res.redirect(
-          `/reading/session/${sessionId}/events/${nextUnreadEvent.id}`
+          modalBreakout(`/reading/session/${sessionId}/events/${nextUnreadEvent.id}`)
         )
       } else if (session.skippedEvents.length > 0) {
-        res.redirect(`/reading/session/${sessionId}/skipped-review`)
+        res.redirect(modalBreakout(`/reading/session/${sessionId}/skipped-review`))
       } else {
-        res.redirect(`/reading/session/${sessionId}`)
+        res.redirect(modalBreakout(`/reading/session/${sessionId}`))
       }
     }
   )
@@ -698,6 +706,124 @@ module.exports = (router) => {
     }
   )
 
+  /************************************************************************
+  // Case deferral
+  /***********************************************************************/
+
+  // Handle deferring a case from reading
+  router.post(
+    '/reading/session/:sessionId/events/:eventId/defer-case-answer',
+    (req, res) => {
+      const data = req.session.data
+      const { sessionId, eventId } = req.params
+      const currentUserId = data.currentUser?.id
+
+      const reason = req.body.deferralReason || ''
+
+      // Find the event and save deferral data
+      const event = data.events.find((e) => e.id === eventId)
+      if (event) {
+        if (!event.imageReading) {
+          event.imageReading = {}
+        }
+
+        // Remove any existing read by this user — deferral replaces a prior opinion
+        if (event.imageReading.reads?.[currentUserId]) {
+          delete event.imageReading.reads[currentUserId]
+        }
+
+        event.imageReading.deferral = {
+          deferredAt: new Date().toISOString(),
+          deferredBy: currentUserId,
+          reason: reason || null
+        }
+
+        // Also update the mirrored event in data.event
+        if (data.event && data.event.id === eventId) {
+          data.event.imageReading = event.imageReading
+        }
+      }
+
+      // Top up the session with the next eligible event if under target size
+      topUpSession(data, sessionId)
+
+      // Find next readable event after current position
+      const session = getReadingSession(data, sessionId)
+      const sessionEvents = session.eventIds
+        .map((id) => data.events.find((e) => e.id === id))
+        .filter(Boolean)
+      const nextUnreadEvent = getNextUserReadableEvent(
+        sessionEvents,
+        eventId,
+        currentUserId,
+        { wrap: false }
+      )
+
+      // Show a banner on the next case if there is one
+      if (nextUnreadEvent) {
+        const participant = data.participants.find(
+          (person) => person.id === event?.participantId
+        )
+        const shortName = getShortName(participant)
+        data.readingOpinionBanner = {
+          text: `Case deferred for ${shortName}`,
+          participantName: shortName,
+          editHref: `/reading/session/${sessionId}/events/${eventId}/existing-read`
+        }
+        res.redirect(
+          modalBreakout(`/reading/session/${sessionId}/events/${nextUnreadEvent.id}`)
+        )
+      } else if (session.skippedEvents.length > 0) {
+        res.redirect(modalBreakout(`/reading/session/${sessionId}/skipped-review`))
+      } else {
+        res.redirect(modalBreakout(`/reading/session/${sessionId}`))
+      }
+    }
+  )
+
+  // Undo a case deferral — removes the deferral so the case returns to reading
+  router.all(
+    '/reading/session/:sessionId/events/:eventId/undo-defer',
+    (req, res) => {
+      const data = req.session.data
+      const { sessionId, eventId } = req.params
+
+      const event = data.events.find((e) => e.id === eventId)
+      if (event?.imageReading?.deferral) {
+        delete event.imageReading.deferral
+
+        // Also update the mirrored event in data.event
+        if (data.event && data.event.id === eventId) {
+          data.event.imageReading = event.imageReading
+        }
+      }
+
+      res.redirect(`/reading/session/${sessionId}/events/${eventId}/opinion`)
+    }
+  )
+
+  // Deferred cases management page
+  router.get('/reading/deferred', (req, res) => {
+    res.render('reading/deferred')
+  })
+
+  // Undo deferral from the deferred cases management page
+  router.post('/reading/deferred/undo', (req, res) => {
+    const data = req.session.data
+    const { eventId } = req.body
+
+    const event = data.events.find((e) => e.id === eventId)
+    if (event?.imageReading?.deferral) {
+      delete event.imageReading.deferral
+
+      if (data.event && data.event.id === eventId) {
+        data.event.imageReading = event.imageReading
+      }
+    }
+
+    res.redirect('/reading/deferred')
+  })
+
   // Render appropriate template for reading views
   router.get(
     '/reading/session/:sessionId/events/:eventId/:step',
@@ -719,6 +845,7 @@ module.exports = (router) => {
         'existing-read',
         'compare',
         'request-priors',
+        'defer-case',
         'medical-information'
       ]
 

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -40,9 +40,8 @@ module.exports = (router) => {
   // Reading index — choose layout based on setting
   router.get('/reading', (req, res) => {
     const layout = req.session.data?.settings?.reading?.indexLayout || 'simple'
-    const template = layout === 'complex'
-      ? 'reading/index-complex'
-      : 'reading/index-simple'
+    const template =
+      layout === 'complex' ? 'reading/index-complex' : 'reading/index-simple'
     res.render(template)
   })
 
@@ -661,10 +660,14 @@ module.exports = (router) => {
           editHref: `/reading/session/${sessionId}/events/${eventId}/existing-read`
         }
         res.redirect(
-          modalBreakout(`/reading/session/${sessionId}/events/${nextUnreadEvent.id}`)
+          modalBreakout(
+            `/reading/session/${sessionId}/events/${nextUnreadEvent.id}`
+          )
         )
       } else if (session.skippedEvents.length > 0) {
-        res.redirect(modalBreakout(`/reading/session/${sessionId}/skipped-review`))
+        res.redirect(
+          modalBreakout(`/reading/session/${sessionId}/skipped-review`)
+        )
       } else {
         res.redirect(modalBreakout(`/reading/session/${sessionId}`))
       }
@@ -771,10 +774,14 @@ module.exports = (router) => {
           editHref: `/reading/session/${sessionId}/events/${eventId}/existing-read`
         }
         res.redirect(
-          modalBreakout(`/reading/session/${sessionId}/events/${nextUnreadEvent.id}`)
+          modalBreakout(
+            `/reading/session/${sessionId}/events/${nextUnreadEvent.id}`
+          )
         )
       } else if (session.skippedEvents.length > 0) {
-        res.redirect(modalBreakout(`/reading/session/${sessionId}/skipped-review`))
+        res.redirect(
+          modalBreakout(`/reading/session/${sessionId}/skipped-review`)
+        )
       } else {
         res.redirect(modalBreakout(`/reading/session/${sessionId}`))
       }
@@ -819,6 +826,12 @@ module.exports = (router) => {
       if (data.event && data.event.id === eventId) {
         data.event.imageReading = event.imageReading
       }
+
+      const participant = data.participants.find(
+        (p) => p.id === event.participantId
+      )
+      const shortName = getShortName(participant)
+      req.flash('success', `${shortName} returned to reading queue`)
     }
 
     res.redirect('/reading/deferred')
@@ -1438,7 +1451,8 @@ module.exports = (router) => {
 
         for (const side of ['right', 'left']) {
           const assessment = side === 'right' ? rightAssessment : leftAssessment
-          const annotations = side === 'right' ? rightAnnotations : leftAnnotations
+          const annotations =
+            side === 'right' ? rightAnnotations : leftAnnotations
           const sideLabel = side
 
           if (!assessment) continue
@@ -1479,8 +1493,7 @@ module.exports = (router) => {
                 })
               }
             }
-          }
-          else if (assessment === 'normal' || assessment === 'clinical') {
+          } else if (assessment === 'normal' || assessment === 'clinical') {
             // Normal/clinical breast must not have annotations of M3 or higher
             if (highLevelAnnotations.length > 0) {
               errors.push({

--- a/app/views/_includes/reading/reading-status-bar.njk
+++ b/app/views/_includes/reading/reading-status-bar.njk
@@ -32,6 +32,9 @@
   {%- if progress.userAwaitingPriorsCount > 0 -%}
     , {{ progress.userAwaitingPriorsCount }} awaiting priors
   {%- endif -%}
+  {%- if progress.deferredCount > 0 -%}
+    , {{ progress.deferredCount }} deferred
+  {%- endif -%}
   , {{ progress.targetRemaining }} remaining
   {%- if progress.skippedEvents | length > 0 %}
      ({{ progress.skippedEvents | length }} skipped)

--- a/app/views/reading/deferred.html
+++ b/app/views/reading/deferred.html
@@ -2,8 +2,10 @@
 
 {% extends 'layout-app.html' %}
 
+{% from '_components/summary-list/macro.njk' import appSummaryList %}
+
 {% set pageHeading = "Deferred cases" %}
-{% set gridColumn = "nhsuk-grid-column-full" %}
+{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 
 {% set back = {
   href: "/reading",
@@ -23,6 +25,15 @@
   {# Sort by deferral date, most recent first #}
   {% set deferredEvents = deferredEvents | sort(true, false, 'imageReading.deferral.deferredAt') %}
 
+  {# Collect resolved deferrals across all events, most recently resolved first #}
+  {% set resolvedDeferrals = [] %}
+  {% for thisEvent in data.events %}
+    {% for pastDeferral in thisEvent.imageReading.deferralHistory %}
+      {% set resolvedDeferrals = resolvedDeferrals | push({ event: thisEvent, deferral: pastDeferral }) %}
+    {% endfor %}
+  {% endfor %}
+  {% set resolvedDeferrals = resolvedDeferrals | sort(true, false, 'deferral.resolvedAt') %}
+
   <span class="nhsuk-caption-l">Image reading</span>
   <h1 class="nhsuk-heading-l">{{ pageHeading }}</h1>
 
@@ -32,69 +43,125 @@
     <p>No deferred cases.</p>
   {% else %}
 
-    <table class="nhsuk-table">
-      <thead class="nhsuk-table__head">
-        <tr>
-          <th scope="col">Participant</th>
-          <th scope="col">Screening date</th>
-          <th scope="col">Deferred</th>
-          <th scope="col">Reason</th>
-          <th scope="col"><span class="nhsuk-u-visually-hidden">Action</span></th>
-        </tr>
-      </thead>
-      <tbody class="nhsuk-table__body">
-        {% for thisEvent in deferredEvents %}
-          {% set thisParticipant = data | getParticipant(thisEvent.participantId) %}
-          {% set deferral = thisEvent.imageReading.deferral %}
-          <tr>
-            <td>
-              <a href="/clinics/{{ thisEvent.clinicId }}/events/{{ thisEvent.id }}">
-                {{ thisParticipant | getFullName }}
-              </a>
-            </td>
+    {% for thisEvent in deferredEvents %}
+      {% set thisParticipant = data | getParticipant(thisEvent.participantId) %}
+      {% set deferral = thisEvent.imageReading.deferral %}
 
-            <td>
-              {% set daysSinceScreening = thisEvent.timing.startTime | daysSince %}
-              {% if daysSinceScreening >= data.config.reading.urgentThreshold %}
-                {{ "Urgent" | toTag }}<br>
-              {% elseif daysSinceScreening >= data.config.reading.priorityThreshold %}
-                {{ "Due soon" | toTag }}<br>
-              {% endif %}
-              {{ thisEvent.timing.startTime | formatDate }}<br>
-              <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
-                {{ thisEvent.timing.startTime | formatRelativeDate }}
-              </span>
-            </td>
+      {% set screenedHtml %}
+        {% set daysSinceScreening = thisEvent.timing.startTime | daysSince %}
+        {% if daysSinceScreening >= data.config.reading.urgentThreshold %}
+          {{ "Urgent" | toTag }}<br>
+        {% elseif daysSinceScreening >= data.config.reading.priorityThreshold %}
+          {{ "Due soon" | toTag }}<br>
+        {% endif %}
+        {{ thisEvent.timing.startTime | formatDate }}
+        <span class="nhsuk-u-secondary-text-colour">({{ thisEvent.timing.startTime | formatRelativeDate }})</span>
+      {% endset %}
 
-            <td>
-              {{ deferral.deferredAt | formatDate("D MMM YYYY") }}<br>
-              <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
-                {% if deferral.deferredBy %}
-                  by {{ deferral.deferredBy | getUsername({ format: "short", identifyCurrentUser: true }) }}
-                {% endif %}
-              </span>
-            </td>
+      {% set deferredHtml %}
+        {{ deferral.deferredAt | formatDate("D MMM YYYY") }}
+        <span class="nhsuk-u-secondary-text-colour">({{ deferral.deferredAt | formatRelativeDate }})</span>
+      {% endset %}
 
-            <td>
-              {% if deferral.reason %}
-                {{ deferral.reason }}
-              {% else %}
-                <span class="nhsuk-u-secondary-text-colour">No reason given</span>
-              {% endif %}
-            </td>
+      {% set reasonHtml %}
+        {% if deferral.reason %}
+          {{ deferral.reason }}
+        {% else %}
+          <span class="nhsuk-u-secondary-text-colour">No reason given</span>
+        {% endif %}
+        {% if deferral.deferredBy %}
+          <br>
+          <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+            {{ deferral.deferredBy | getUsername({ format: "short", identifyCurrentUser: true }) }}
+          </span>
+        {% endif %}
+      {% endset %}
 
-            <td>
-              <form action="/reading/deferred/undo" method="POST">
-                <input type="hidden" name="eventId" value="{{ thisEvent.id }}">
-                <button type="submit" class="nhsuk-link--no-visited-state app-link-button">
-                  Unflag case
-                </button>
-              </form>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+      <div class="nhsuk-summary-card">
+        <div class="nhsuk-summary-card__title-wrapper">
+          <h2 class="nhsuk-summary-card__title">
+            <a href="/clinics/{{ thisEvent.clinicId }}/events/{{ thisEvent.id }}" class="nhsuk-link--no-visited-state">
+              {{ thisParticipant | getFullName }}
+            </a>
+          </h2>
+          <div class="nhsuk-summary-card__actions">
+            <form action="/reading/deferred/undo" method="POST">
+              <input type="hidden" name="eventId" value="{{ thisEvent.id }}">
+              <button type="submit" class="nhsuk-link--no-visited-state app-link-button">
+                Unflag case<span class="nhsuk-u-visually-hidden"> for {{ thisParticipant | getFullName }}</span>
+              </button>
+            </form>
+          </div>
+        </div>
+        <div class="nhsuk-summary-card__content">
+          {{ appSummaryList({
+            rows: [
+              { key: { text: "Screened" }, value: { html: screenedHtml } },
+              { key: { text: "Deferred" }, value: { html: deferredHtml } },
+              { key: { text: "Reason" }, value: { html: reasonHtml } }
+            ]
+          }) }}
+        </div>
+      </div>
+    {% endfor %}
+
+  {% endif %}
+
+  {% if resolvedDeferrals | length > 0 %}
+
+    <h2 class="nhsuk-heading-m nhsuk-u-margin-top-6">Recently resolved</h2>
+    <p>These cases have been unflagged and returned to the reading queue.</p>
+
+    {% for row in resolvedDeferrals %}
+      {% set thisEvent = row.event %}
+      {% set deferral = row.deferral %}
+      {% set thisParticipant = data | getParticipant(thisEvent.participantId) %}
+
+      {% set deferredHtml %}
+        {{ deferral.deferredAt | formatDate("D MMM YYYY") }}
+        <span class="nhsuk-u-secondary-text-colour">({{ deferral.deferredAt | formatRelativeDate }})</span>
+      {% endset %}
+
+      {% set reasonHtml %}
+        {% if deferral.reason %}
+          {{ deferral.reason }}
+        {% else %}
+          <span class="nhsuk-u-secondary-text-colour">No reason given</span>
+        {% endif %}
+        {% if deferral.deferredBy %}
+          <br>
+          <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+            {{ deferral.deferredBy | getUsername({ format: "short", identifyCurrentUser: true }) }}
+          </span>
+        {% endif %}
+      {% endset %}
+
+      {% set resolvedHtml %}
+        {{ deferral.resolvedAt | formatDate("D MMM YYYY") }}
+        {% if deferral.resolvedBy %}
+          by {{ deferral.resolvedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}
+        {% endif %}
+      {% endset %}
+
+      <div class="nhsuk-summary-card">
+        <div class="nhsuk-summary-card__title-wrapper">
+          <h3 class="nhsuk-summary-card__title">
+            <a href="/clinics/{{ thisEvent.clinicId }}/events/{{ thisEvent.id }}" class="nhsuk-link--no-visited-state">
+              {{ thisParticipant | getFullName }}
+            </a>
+          </h3>
+        </div>
+        <div class="nhsuk-summary-card__content">
+          {{ appSummaryList({
+            rows: [
+              { key: { text: "Deferred" }, value: { html: deferredHtml } },
+              { key: { text: "Reason" }, value: { html: reasonHtml } },
+              { key: { text: "Returned to queue" }, value: { html: resolvedHtml } }
+            ]
+          }) }}
+        </div>
+      </div>
+    {% endfor %}
 
   {% endif %}
 

--- a/app/views/reading/deferred.html
+++ b/app/views/reading/deferred.html
@@ -1,0 +1,101 @@
+{# app/views/reading/deferred.html #}
+
+{% extends 'layout-app.html' %}
+
+{% set pageHeading = "Deferred cases" %}
+{% set gridColumn = "nhsuk-grid-column-full" %}
+
+{% set back = {
+  href: "/reading",
+  text: "Back"
+} %}
+
+{% block pageContent %}
+
+  {# Get all events that have been deferred #}
+  {% set deferredEvents = [] %}
+  {% for thisEvent in data.events %}
+    {% if thisEvent | isDeferred %}
+      {% set deferredEvents = deferredEvents | push(thisEvent) %}
+    {% endif %}
+  {% endfor %}
+
+  {# Sort by deferral date, most recent first #}
+  {% set deferredEvents = deferredEvents | sort(true, false, 'imageReading.deferral.deferredAt') %}
+
+  <span class="nhsuk-caption-l">Image reading</span>
+  <h1 class="nhsuk-heading-l">{{ pageHeading }}</h1>
+
+  <p>Cases deferred from reading require manual review before they can be returned to the reading queue.</p>
+
+  {% if deferredEvents | length == 0 %}
+    <p>No deferred cases.</p>
+  {% else %}
+
+    <table class="nhsuk-table">
+      <thead class="nhsuk-table__head">
+        <tr>
+          <th scope="col">Participant</th>
+          <th scope="col">Screening date</th>
+          <th scope="col">Deferred</th>
+          <th scope="col">Reason</th>
+          <th scope="col"><span class="nhsuk-u-visually-hidden">Action</span></th>
+        </tr>
+      </thead>
+      <tbody class="nhsuk-table__body">
+        {% for thisEvent in deferredEvents %}
+          {% set thisParticipant = data | getParticipant(thisEvent.participantId) %}
+          {% set deferral = thisEvent.imageReading.deferral %}
+          <tr>
+            <td>
+              <a href="/clinics/{{ thisEvent.clinicId }}/events/{{ thisEvent.id }}">
+                {{ thisParticipant | getFullName }}
+              </a>
+            </td>
+
+            <td>
+              {% set daysSinceScreening = thisEvent.timing.startTime | daysSince %}
+              {% if daysSinceScreening >= data.config.reading.urgentThreshold %}
+                {{ "Urgent" | toTag }}<br>
+              {% elseif daysSinceScreening >= data.config.reading.priorityThreshold %}
+                {{ "Due soon" | toTag }}<br>
+              {% endif %}
+              {{ thisEvent.timing.startTime | formatDate }}<br>
+              <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+                {{ thisEvent.timing.startTime | formatRelativeDate }}
+              </span>
+            </td>
+
+            <td>
+              {{ deferral.deferredAt | formatDate("D MMM YYYY") }}<br>
+              <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+                {% if deferral.deferredBy %}
+                  by {{ deferral.deferredBy | getUsername({ format: "short", identifyCurrentUser: true }) }}
+                {% endif %}
+              </span>
+            </td>
+
+            <td>
+              {% if deferral.reason %}
+                {{ deferral.reason }}
+              {% else %}
+                <span class="nhsuk-u-secondary-text-colour">No reason given</span>
+              {% endif %}
+            </td>
+
+            <td>
+              <form action="/reading/deferred/undo" method="POST">
+                <input type="hidden" name="eventId" value="{{ thisEvent.id }}">
+                <button type="submit" class="nhsuk-link--no-visited-state app-link-button">
+                  Unflag case
+                </button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+  {% endif %}
+
+{% endblock %}

--- a/app/views/reading/index-complex.html
+++ b/app/views/reading/index-complex.html
@@ -12,17 +12,21 @@
 
 <h2>Start new reading session</h2>
 
-{# Awaiting priors not automatically filtered #}
-{% set allReadsEventsWithAwaitingPriors = data.events | filterEventsByEligibleForReading | filterEventsByNeedsAnyRead | sortEventsByScreeningDate %}
-
-{# Split into awaiting priors and available for reading #}
-{# Events with 'requested' status mammograms are held from reading #}
-{% set allReadsEvents = [] %}
+{# Awaiting priors — count across all eligible events, not just those needing reads #}
 {% set awaitingPriorsEvents = [] %}
-{% for thisEvent in allReadsEventsWithAwaitingPriors %}
+{% for thisEvent in data.events | filterEventsByEligibleForReading %}
   {% if thisEvent | awaitingPriors %}
     {% set awaitingPriorsEvents = awaitingPriorsEvents | push(thisEvent) %}
-  {% else %}
+  {% endif %}
+{% endfor %}
+
+{% set allReadsEventsWithAwaitingPriors = data.events | filterEventsByEligibleForReading | filterEventsByNeedsAnyRead | sortEventsByScreeningDate %}
+
+{# Split readable events into awaiting priors and available for reading #}
+{# Events with 'requested' status mammograms are held from reading #}
+{% set allReadsEvents = [] %}
+{% for thisEvent in allReadsEventsWithAwaitingPriors %}
+  {% if not (thisEvent | awaitingPriors) %}
     {% set allReadsEvents = allReadsEvents | push(thisEvent) %}
   {% endif %}
 {% endfor %}
@@ -70,7 +74,7 @@
     </div>
   {% endif %}
 
-  {% set defaultSessionSize = 25 %}
+  {% set defaultSessionSize = data.settings.reading.defaultSessionSize or 25 %}
   {% set maxCases = allReadCount if allReadCount < defaultSessionSize else defaultSessionSize %}
 
   {% set actionLinkHtml %}
@@ -170,6 +174,14 @@
       headingClasses: "nhsuk-heading-s",
       clickable: true,
       href: "/reading/priors"
+    }) }}
+  </li>
+  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    {{ card({
+      heading: "Deferred cases",
+      headingClasses: "nhsuk-heading-s",
+      clickable: true,
+      href: "/reading/deferred"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">

--- a/app/views/reading/index-simple.html
+++ b/app/views/reading/index-simple.html
@@ -7,7 +7,7 @@
 {% set gridColumn = "none" %}
 
 {% set currentUserId = data.currentUser.id %}
-{% set defaultSessionSize = 25 %}
+{% set defaultSessionSize = data.settings.reading.defaultSessionSize or 25 %}
 
 {#
   Build a list of the current user's sessions, most-recent first.
@@ -78,6 +78,13 @@
   {% endif %}
 {% endfor %}
 
+{% set awaitingPriorsCount = 0 %}
+{% for thisEvent in data.events | filterEventsByEligibleForReading %}
+  {% if thisEvent | awaitingPriors %}
+    {% set awaitingPriorsCount = awaitingPriorsCount + 1 %}
+  {% endif %}
+{% endfor %}
+
 {% set newlyArrivedPriorsCount = 2 %}
 
 {% set actionTotal = arbitrationCount + newlyArrivedPriorsCount %}
@@ -122,22 +129,31 @@
 
   {% endif %}
 
-  {% if actionTotal > 0 or deferredCount > 0 %}
+  {# Awaiting priors inset #}
+  {% if awaitingPriorsCount > 0 %}
     {% set insetHtml %}
-      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ actionTotal }} flagged {{ "case" if actionTotal == 1 else "cases" }}</h2>
-      <p>Flagged cases require action before they can be read.</p>
-      <p class="nhsuk-u-margin-bottom-0"><a href="#">Review flagged cases</a></p>
-      {% if deferredCount > 0 %}
-        <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
-          <a href="/reading/deferred">{{ deferredCount }} deferred {{ "case" if deferredCount == 1 else "cases" }}</a>
-        </p>
-      {% endif %}
+      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ awaitingPriorsCount }} {{ "case" if awaitingPriorsCount == 1 else "cases" }} awaiting priors</h2>
+      <p>These cases are on hold pending prior mammogram images.</p>
+      <p class="nhsuk-u-margin-bottom-0"><a href="/reading/priors">Manage prior mammograms</a></p>
     {% endset %}
     {{ insetText({
       html: insetHtml | safe
     }) }}
   {% endif %}
 
+  {# Deferred cases inset #}
+  {% if deferredCount > 0 %}
+    {% set insetHtml %}
+      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ deferredCount }} deferred {{ "case" if deferredCount == 1 else "cases" }}</h2>
+      <p>Deferred cases require review before they can be returned to the reading queue.</p>
+      <p class="nhsuk-u-margin-bottom-0"><a href="/reading/deferred">Review deferred cases</a></p>
+    {% endset %}
+    {{ insetText({
+      html: insetHtml | safe
+    }) }}
+  {% endif %}
+
+  {# Previous sessions inset #}
   {% if previousSessions | length > 0 %}
     <h2>Your previous image reading sessions</h2>
     <ul class="nhsuk-list">
@@ -152,10 +168,8 @@
     <p><a href="/reading/history">See all</a></p>
   {% endif %}
 
-    </div>
-
-    <div class="nhsuk-grid-column-one-third">
-    </div>
   </div>
+
+</div>
 
 {% endblock %}

--- a/app/views/reading/index-simple.html
+++ b/app/views/reading/index-simple.html
@@ -71,6 +71,13 @@
   {% endif %}
 {% endfor %}
 
+{% set deferredCount = 0 %}
+{% for thisEvent in data.events %}
+  {% if thisEvent | isDeferred %}
+    {% set deferredCount = deferredCount + 1 %}
+  {% endif %}
+{% endfor %}
+
 {% set newlyArrivedPriorsCount = 2 %}
 
 {% set actionTotal = arbitrationCount + newlyArrivedPriorsCount %}
@@ -115,11 +122,16 @@
 
   {% endif %}
 
-  {% if actionTotal > 0 %}
+  {% if actionTotal > 0 or deferredCount > 0 %}
     {% set insetHtml %}
       <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ actionTotal }} flagged {{ "case" if actionTotal == 1 else "cases" }}</h2>
       <p>Flagged cases require action before they can be read.</p>
       <p class="nhsuk-u-margin-bottom-0"><a href="#">Review flagged cases</a></p>
+      {% if deferredCount > 0 %}
+        <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
+          <a href="/reading/deferred">{{ deferredCount }} deferred {{ "case" if deferredCount == 1 else "cases" }}</a>
+        </p>
+      {% endif %}
     {% endset %}
     {{ insetText({
       html: insetHtml | safe

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -104,7 +104,7 @@
       {# YOUR READS VIEW - Shows cases from user's perspective #}
       {% set userReadableEvents = [] %}
       {% for event in events %}
-        {% if event | canUserReadEvent or event | userHasReadEvent or event | userRequestedPriors(data.currentUser.id) %}
+        {% if event | canUserReadEvent or event | userHasReadEvent or event | userRequestedPriors(data.currentUser.id) or event | isDeferred %}
           {% set userReadableEvents = userReadableEvents | push(event) %}
         {% endif %}
       {% endfor %}
@@ -118,6 +118,7 @@
         {% set technicalRecallEvents = [] %}
         {% set recallForAssessmentEvents = [] %}
         {% set priorsRequestedEvents = [] %}
+        {% set deferredEvents = [] %}
 
         {% for event in userReadableEvents %}
           {% if event | userHasReadEvent %}
@@ -131,6 +132,8 @@
             {% endif %}
           {% elseif event | userRequestedPriors(data.currentUser.id) %}
             {% set priorsRequestedEvents = priorsRequestedEvents | push(event) %}
+          {% elseif event | isDeferred %}
+            {% set deferredEvents = deferredEvents | push(event) %}
           {% endif %}
         {% endfor %}
 
@@ -139,6 +142,7 @@
         {% set technicalRecallCount = technicalRecallEvents | length %}
         {% set recallForAssessmentCount = recallForAssessmentEvents | length %}
         {% set priorsRequestedCount = priorsRequestedEvents | length %}
+        {% set deferredCount = deferredEvents | length %}
 
         {% set normalPercent = (normalCount / totalCount * 100) | round %}
         {% set technicalRecallPercent = (technicalRecallCount / totalCount * 100) | round %}
@@ -213,10 +217,10 @@
         {% endif %}
 
         <h2>Reading session cases</h2>
-        {% set userSessionRemainingCount = session.targetSize - readingStatus.userReadCount - readingStatus.userAwaitingPriorsCount %}
+        {% set userSessionRemainingCount = session.targetSize - readingStatus.userReadCount - readingStatus.userAwaitingPriorsCount - deferredCount %}
         {% set userSessionRemainingCount = 0 if userSessionRemainingCount < 0 else userSessionRemainingCount %}
-        {% if userSessionRemainingCount > 0 or readingStatus.userAwaitingPriorsCount > 0 %}
-          <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.userReadCount }} read{%- if readingStatus.userAwaitingPriorsCount > 0 -%}, {{ readingStatus.userAwaitingPriorsCount }} awaiting priors{%- endif -%}, {{ userSessionRemainingCount }} remaining</p>
+        {% if userSessionRemainingCount > 0 or readingStatus.userAwaitingPriorsCount > 0 or deferredCount > 0 %}
+          <p class="nhsuk-body app-text-grey">Progress: {{ readingStatus.userReadCount }} read{%- if readingStatus.userAwaitingPriorsCount > 0 -%}, {{ readingStatus.userAwaitingPriorsCount }} awaiting priors{%- endif -%}{%- if deferredCount > 0 -%}, {{ deferredCount }} deferred{%- endif -%}, {{ userSessionRemainingCount }} remaining</p>
         {% endif %}
 
         <table class="nhsuk-table app-reading-session-table">
@@ -288,6 +292,8 @@
                   {% if read.opinion %}
                     {{ read.opinion | toTag }}
                   {% endif %}
+                {% elseif event | isDeferred %}
+                  {{ "Deferred" | toTag }}
                 {% elseif event | userRequestedPriors(data.currentUser.id) %}
                   {{ "Priors requested" | toTag }}
                 {% elseif session.skippedEvents | includes(event.id) %}

--- a/app/views/reading/workflow/defer-case.html
+++ b/app/views/reading/workflow/defer-case.html
@@ -2,7 +2,7 @@
 
 {% extends parentLayout or 'layout-reading.html' %}
 
-{% set pageHeading = "Defer case from reading" %}
+{% set pageHeading = "Defer this case" %}
 {% set formAction = './defer-case-answer' | urlWithReferrer(referrerChain) %}
 {% set back = {
   href: "./opinion",
@@ -24,7 +24,7 @@
       </h1>
 
       <p>
-        This case will be removed from the reading queue and will need to be manually reviewed before it can be read.
+        This case will be removed from the reading queue. It must be manually reviewed before it can be read.
       </p>
 
       {{ textarea({
@@ -35,7 +35,7 @@
           size: "s"
         },
         hint: {
-          text: "Explain why this case cannot be read at this time"
+          text: "Explain why you are unable to give an opinion on this case"
         },
         rows: 4
       }) }}

--- a/app/views/reading/workflow/defer-case.html
+++ b/app/views/reading/workflow/defer-case.html
@@ -1,0 +1,50 @@
+{# app/views/reading/workflow/defer-case.html #}
+
+{% extends parentLayout or 'layout-reading.html' %}
+
+{% set pageHeading = "Defer case from reading" %}
+{% set formAction = './defer-case-answer' | urlWithReferrer(referrerChain) %}
+{% set back = {
+  href: "./opinion",
+  text: "Back"
+} %}
+
+{% block pageContent %}
+
+  {% set caption %}
+    {{ participant | getFullName }}
+  {% endset %}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">
+        <span class="nhsuk-caption-l">{{ caption }}</span>
+        {{ pageHeading }}
+      </h1>
+
+      <p>
+        This case will be removed from the reading queue and will need to be manually reviewed before it can be read.
+      </p>
+
+      {{ textarea({
+        name: "deferralReason",
+        id: "deferralReason",
+        label: {
+          text: "Reason for deferring",
+          size: "s"
+        },
+        hint: {
+          text: "Explain why this case cannot be read at this time"
+        },
+        rows: 4
+      }) }}
+
+      {{ button({
+        text: "Confirm deferral"
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/reading/workflow/existing-read.html
+++ b/app/views/reading/workflow/existing-read.html
@@ -10,12 +10,59 @@
 
   {% set isAwaitingPriors = event | awaitingPriors %}
   {% set hasUserRead = event | userHasReadEvent %}
+  {% set isDeferredCase = event | isDeferred %}
 
   <span class="nhsuk-caption-l">
     {{ participant | getFullName }}
   </span>
 
-  {% if isAwaitingPriors and not hasUserRead %}
+  {% if isDeferredCase and not hasUserRead %}
+    {# Event has been deferred - show deferral summary #}
+    <h1 class="nhsuk-heading-l">Your opinion</h1>
+
+    {% set deferral = event.imageReading.deferral %}
+    {% set canUndo = deferral.deferredBy == data.currentUser.id %}
+
+    {% set deferralSummaryHtml %}
+      {% call appSummaryList() %}
+        {{ appSummaryListRow({
+          key: {
+            text: "Opinion"
+          },
+          value: {
+            html: "Deferred" | toTag
+          },
+          actions: {
+            items: [{
+              href: "./undo-defer",
+              text: "Undo deferral",
+              visuallyHiddenText: "case deferral"
+            }]
+          } if canUndo
+        }) }}
+
+        {% if deferral.reason %}
+          {{ appSummaryListRow({
+            key: {
+              text: "Reason"
+            },
+            value: {
+              text: deferral.reason
+            }
+          }) }}
+        {% endif %}
+
+      {% endcall %}
+    {% endset %}
+
+    {{ card({
+      heading: "Your read",
+      headingLevel: "2",
+      feature: true,
+      descriptionHtml: deferralSummaryHtml
+    }) }}
+
+  {% elseif isAwaitingPriors and not hasUserRead %}
     {# Event is awaiting priors - show as the reader's opinion #}
     <h1 class="nhsuk-heading-l">Your opinion</h1>
 

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -410,7 +410,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
       <p class="nhsuk-u-margin-top-2">
-        {{ appLink({ text: "Defer this case from reading", href: "./defer-case", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
+        {{ appLink({ text: "Defer this case", href: "./defer-case", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
       </p>
     </div>
   </div>

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -153,7 +153,7 @@
             </p>
           {% endfor %}
           <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
-            <a href="./request-priors" class="nhsuk-link--no-visited-state">Request priors</a>
+            {{ appLink({ text: "Request priors", href: "./request-priors", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
           </p>
         {% endset %}
 
@@ -375,6 +375,14 @@
 
   </form>
 
+  {# Defer case option #}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <p class="nhsuk-u-margin-top-2">
+        {{ appLink({ text: "Defer this case from reading", href: "./defer-case", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
+      </p>
+    </div>
+  </div>
 
   {# Image notes - moved above opinion section #}
   {% include "_includes/reading/image-warnings.njk" %}

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -375,15 +375,6 @@
 
   </form>
 
-  {# Defer case option #}
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-      <p class="nhsuk-u-margin-top-2">
-        {{ appLink({ text: "Defer this case from reading", href: "./defer-case", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
-      </p>
-    </div>
-  </div>
-
   {# Image notes - moved above opinion section #}
   {% include "_includes/reading/image-warnings.njk" %}
 
@@ -414,6 +405,15 @@
     ]
   }
   }) }}
+
+  {# Defer case option #}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+      <p class="nhsuk-u-margin-top-2">
+        {{ appLink({ text: "Defer this case from reading", href: "./defer-case", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
+      </p>
+    </div>
+  </div>
 
 {% endblock %}
 

--- a/app/views/reading/workflow/request-priors.html
+++ b/app/views/reading/workflow/request-priors.html
@@ -1,8 +1,9 @@
 {# app/views/reading/workflow/request-priors.html #}
 
-{% extends 'layout-reading.html' %}
+{% extends parentLayout or 'layout-reading.html' %}
 
 {% set pageHeading = "Request prior images" %}
+{% set formAction = './request-priors-answer' | urlWithReferrer(referrerChain) %}
 {% set back = {
   href: "./opinion",
   text: "Back"
@@ -19,12 +20,10 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <form action="./request-priors-answer" method="POST">
-
-        <h1 class="nhsuk-heading-l">
-          <span class="nhsuk-caption-l">{{ caption }}</span>
-          {{ pageHeading }}
-        </h1>
+      <h1 class="nhsuk-heading-l">
+        <span class="nhsuk-caption-l">{{ caption }}</span>
+        {{ pageHeading }}
+      </h1>
 
         <p>
           This case will be put on hold while all available mammogram images for {{ participant | getFullName }} are sourced through the Image Exchange Portal (IEP).
@@ -90,8 +89,6 @@
         {{ button({
           text: "Confirm request and continue"
         }) }}
-
-      </form>
 
     </div>
   </div>

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -76,7 +76,7 @@
   <li>Modal forms: off</li>
   <li>Compare page: off</li>
   <li>Review pages off</li>
-  <li>Annotations mode: inline form (no image markers)</li>
+  <lid>Annotations mode: inline form (no image markers)</li>
 </ul>
 
 


### PR DESCRIPTION
## Description

Adds a new flow / feature to defer reading a case during image reading. This is for unforeseen scenarios where something has gone wrong and the case cannot be read - images or data issues perhaps. It is largely modelled on the request priors flow. We collect a 'reason for the deferral, and remove the case from being possible to read. It then gets listed in a separate dashboard to be actioned.

Link shown at bottom of opinion page
<img width="2126" height="516" alt="Screenshot 2026-06-12 at 09 51 28" src="https://github.com/user-attachments/assets/9acc179c-80d8-4150-aaf9-2e6db22f5e77" />


Deferral info page
<img width="1794" height="1278" alt="Screenshot 2026-06-12 at 09 52 10" src="https://github.com/user-attachments/assets/d53f5950-f463-4d38-b0c5-85600bb899e4" />

Existing read summary
<img width="2136" height="1048" alt="Screenshot 2026-06-12 at 09 52 36" src="https://github.com/user-attachments/assets/cd9ee510-eb73-4255-8754-235971aea7ec" />

Session overview
<img width="2262" height="1218" alt="Screenshot 2026-06-12 at 09 53 04" src="https://github.com/user-attachments/assets/f028b063-36ce-4be4-a336-ff238daaec38" />


Homepage
<img width="1798" height="576" alt="Screenshot 2026-06-12 at 09 53 21" src="https://github.com/user-attachments/assets/7cf2216b-a1a8-4d0e-ad60-5f806f1a1d6b" />


Dashboard
<img width="2274" height="2396" alt="Screenshot 2026-06-12 at 15 14 37" src="https://github.com/user-attachments/assets/57493e82-30cf-430e-a20a-b615d03343d8" />
