### PR TITLE
Don't tie phone numbers to mobile and home

### DIFF
--- a/app/lib/generators/participant-generator.js
+++ b/app/lib/generators/participant-generator.js
@@ -103,20 +103,20 @@ const generatePhoneNumbers = () => {
   })
 
   const result = {
-    mobilePhone: null,
-    homePhone: null
+    phone1: null,
+    phone2: null
   }
 
   switch (phoneConfig) {
     case 'mobile_only':
-      result.mobilePhone = generateUKMobileNumber()
+      result.phone1 = generateUKMobileNumber()
       break
     case 'both':
-      result.mobilePhone = generateUKMobileNumber()
-      result.homePhone = generateUKHomeNumber()
+      result.phone1 = generateUKMobileNumber()
+      result.phone2 = generateUKHomeNumber()
       break
     case 'home_only':
-      result.homePhone = generateUKHomeNumber()
+      result.phone2 = generateUKHomeNumber()
       break
   }
 
@@ -216,8 +216,8 @@ const generateParticipant = ({
       lastName: faker.person.lastName(),
       dateOfBirth: generateDateOfBirth(participantRiskLevel),
       address: generateBSUAppropriateAddress(assignedBSU),
-      mobilePhone: phoneNumbers.mobilePhone,
-      homePhone: phoneNumbers.homePhone,
+      phone1: phoneNumbers.phone1,
+      phone2: phoneNumbers.phone2,
       email: `${faker.internet.username().toLowerCase()}@example.com`,
       ethnicGroup: ethnicityData.ethnicGroup,
       ethnicBackground: ethnicityData.ethnicBackground

--- a/app/lib/utils/strings.js
+++ b/app/lib/utils/strings.js
@@ -325,6 +325,8 @@ const formatPhoneNumber = (phoneNumber) => {
   if (!phoneNumber) return ''
   if (typeof phoneNumber !== 'string') return phoneNumber
 
+  phoneNumber = phoneNumber.replace(/\s/g, '')
+
   if (phoneNumber.startsWith('07')) {
     return `${phoneNumber.slice(0, 5)} ${phoneNumber.slice(5)}`
   }

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -3353,6 +3353,17 @@ module.exports = (router) => {
       res.redirect(modalBreakout(returnUrl))
     }
   )
+  // Save participant data when contact details are updated from the participant tab.
+  // The contact-details form posts back to the participant tab URL via referrerChain,
+  // so we need this POST handler to persist the temp participant to the participants array.
+  router.post('/clinics/:clinicId/events/:eventId/participant', (req, res) => {
+    const { clinicId, eventId } = req.params
+    const data = req.session.data
+    saveTempParticipantToParticipant(data)
+    req.flash('success', 'Participant details updated')
+    res.redirect(`/clinics/${clinicId}/events/${eventId}/participant`)
+  })
+
   // General purpose dynamic template route for events
   // This should come after any more specific routes
   router.get(

--- a/app/views/_includes/forms/contact-details.njk
+++ b/app/views/_includes/forms/contact-details.njk
@@ -74,24 +74,24 @@
 
 {{ input({
   label: {
-    text: "Mobile (optional)",
+    text: "Phone number 1 (optional)",
     _classes: "nhsuk-label--m"
   },
-  value: participant.demographicInformation.mobilePhone,
-  id: "mobile-phone-number",
-  name: "participant[demographicInformation][mobilePhone]",
+  value: participant.demographicInformation.phone1,
+  id: "phone-number-1",
+  name: "participant[demographicInformation][phone1]",
   classes: "nhsuk-u-width-one-half"
 }) }}
 
 
 {{ input({
   label: {
-    text: "Home (optional)",
+    text: "Phone number 2 (optional)",
     _classes: "nhsuk-label--m"
   },
-  value: participant.demographicInformation.homePhone,
-  id: "home-phone-number",
-  name: "participant[demographicInformation][homePhone]",
+  value: participant.demographicInformation.phone2,
+  id: "phone-number-2",
+  name: "participant[demographicInformation][phone2]",
   classes: "nhsuk-u-width-one-half"
 }) }}
 

--- a/app/views/_includes/summary-lists/rows/phone-numbers.njk
+++ b/app/views/_includes/summary-lists/rows/phone-numbers.njk
@@ -1,6 +1,6 @@
 {# /app/views/_includes/summary-lists/rows/phone-numbers.njk #}
 
-{% set phoneNumbers = [participant.demographicInformation.mobilePhone, participant.demographicInformation.homePhone] | removeEmpty %}
+{% set phoneNumbers = [participant.demographicInformation.phone1, participant.demographicInformation.phone2] | removeEmpty %}
 
 {% set phoneNumbersHtml %}
   {{ phoneNumbers | map("formatPhoneNumber") | join("<br>") | safe }}


### PR DESCRIPTION
## Description

For our first live tests the source data for participant phone numbers doesn't distinguish between mobile and home phone. For now, swap to calling these by more generic names. We may want to revisit this in the future if wanting to use this for sms communication.

<img width="1090" height="514" alt="Screenshot 2026-06-16 at 12 37 50" src="https://github.com/user-attachments/assets/23deea4b-46ed-43f4-a99f-61bbaeec25c5" />

<img width="1456" height="812" alt="Screenshot 2026-06-16 at 12 38 00" src="https://github.com/user-attachments/assets/24b187e4-ad41-461a-b59b-724a3ebfab98" />
