### PR TITLE
Update symptoms form

### DIFF
--- a/app/lib/generators/medical-information/symptoms-generator.js
+++ b/app/lib/generators/medical-information/symptoms-generator.js
@@ -332,16 +332,16 @@ const generateSymptom = (options = {}) => {
     }
   }
 
-  // 20% chance of additional info
+  // 20% chance of symptom notes
   if (Math.random() < 0.2) {
-    const additionalInfoOptions = [
+    const symptomNotesOptions = [
       'Noticed during self-examination',
       'Partner noticed the change',
       'Gets worse during certain times of month',
       'No family history of breast problems',
       'Concerned as mother had similar symptoms'
     ]
-    symptom.additionalInfo = faker.helpers.arrayElement(additionalInfoOptions)
+    symptom.symptomNotes = faker.helpers.arrayElement(symptomNotesOptions)
   }
 
   return symptom

--- a/app/lib/generators/medical-information/symptoms-generator.js
+++ b/app/lib/generators/medical-information/symptoms-generator.js
@@ -199,7 +199,7 @@ const generateSymptom = (options = {}) => {
   const dateTypeWeights = {
     ...Object.fromEntries(DATE_RANGE_OPTIONS.map((range) => [range, 0.1])),
     dateKnown: 0.3,
-    notSure: 0.1
+    notKnown: 0.1
   }
 
   // Generate basic symptom data matching form structure

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -1142,17 +1142,12 @@ module.exports = (router) => {
         })
       }
 
-      // Validate whether the symptom has been investigated (required)
-      if (!data.event?.symptomTemp?.hasBeenInvestigated) {
-        validationErrors.push({
-          name: 'event[symptomTemp][hasBeenInvestigated]',
-          text: 'Select whether this has been investigated',
-          href: '#hasBeenInvestigated'
-        })
-      } else if (
-        data.event.symptomTemp.hasBeenInvestigated === 'yes' &&
-        !data.event.symptomTemp.investigatedDescription
-      ) {
+      // Validate investigation details if the checkbox is checked
+      const hasBeenInvestigated = data.event?.symptomTemp?.hasBeenInvestigated
+      const isInvestigated = Array.isArray(hasBeenInvestigated)
+        ? hasBeenInvestigated.includes('yes')
+        : hasBeenInvestigated === 'yes'
+      if (isInvestigated && !data.event?.symptomTemp?.investigatedDescription) {
         validationErrors.push({
           name: 'event[symptomTemp][investigatedDescription]',
           text: 'Provide details of the investigation',
@@ -1221,7 +1216,6 @@ module.exports = (router) => {
           id: symptomTemp.id || generateId(),
           type: symptomType,
           dateType: symptomTemp.dateType,
-          hasBeenInvestigated: symptomTemp.hasBeenInvestigated,
           additionalInfo: symptomTemp.additionalInfo
         }
 
@@ -1240,8 +1234,13 @@ module.exports = (router) => {
           }
         }
 
-        // Add investigation details if investigated
-        if (symptomTemp.hasBeenInvestigated === 'yes') {
+        // Normalise checkbox value and add investigation details if checked
+        const savedHasBeenInvestigated = symptomTemp.hasBeenInvestigated
+        const savedIsInvestigated = Array.isArray(savedHasBeenInvestigated)
+          ? savedHasBeenInvestigated.includes('yes')
+          : savedHasBeenInvestigated === 'yes'
+        symptom.hasBeenInvestigated = savedIsInvestigated ? 'yes' : 'no'
+        if (savedIsInvestigated) {
           symptom.investigatedDescription = symptomTemp.investigatedDescription
         }
 

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -1258,7 +1258,7 @@ module.exports = (router) => {
           ].includes(symptomTemp.dateType)
         ) {
           symptom.approximateDuration = symptomTemp.dateType
-        } else if (symptomTemp.dateType === 'notSure') {
+        } else if (symptomTemp.dateType === 'notKnown') {
           delete symptom.approximateDuration
         }
 

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -1216,7 +1216,7 @@ module.exports = (router) => {
           id: symptomTemp.id || generateId(),
           type: symptomType,
           dateType: symptomTemp.dateType,
-          additionalInfo: symptomTemp.additionalInfo
+          symptomNotes: symptomTemp.symptomNotes
         }
 
         // For new symptoms, add the creation timestamp

--- a/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
+++ b/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
@@ -94,26 +94,27 @@
     {% endset %}
     {% set valueLines = valueLines | push(startText) %}
 
-    {# Stop date if applicable #}
+    {# Additional symptom information #}
     {% if symptom.isIntermittent %}
       {% set valueLines = valueLines | push("Symptom is intermittent") %}
     {% endif %}
 
-    {# Stop date if applicable #}
     {% if symptom.hasStopped and symptom.approximateDateStopped %}
-      {% set valueLines = valueLines | push("Stopped: " + symptom.approximateDateStopped) %}
+      {% set valueLines = valueLines | push("Recently resolved (" + symptom.approximateDateStopped + ")") %}
     {% endif %}
 
     {# Investigation status #}
     {% if symptom.hasBeenInvestigated == "yes" %}
-      {% set valueLines = valueLines | push("Has been previously investigated: " + symptom.investigatedDescription) %}
-    {% elseif symptom.hasBeenInvestigated == "no" %}
-      {% set valueLines = valueLines | push("Not investigated") %}
+      {% if symptom.investigatedDescription %}
+        {% set valueLines = valueLines | push("Previously investigated: " + symptom.investigatedDescription) %}
+      {% else %}
+        {% set valueLines = valueLines | push("Previously investigated") %}
+      {% endif %}
     {% endif %}
 
-    {# Additional info #}
-    {% if symptom.additionalInfo %}
-      {% set valueLines = valueLines | push("Additional info: " + symptom.additionalInfo) %}
+    {# Symptom notes #}
+    {% if symptom.symptomNotes %}
+      {% set valueLines = valueLines | push("Notes: " + symptom.symptomNotes) %}
     {% endif %}
 
     {# Join all value lines with line breaks #}

--- a/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
+++ b/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
@@ -105,8 +105,8 @@
     {% endif %}
 
     {# Investigation status #}
-    {% if symptom.hasBeenInvestigated == "yes" and symptom.investigatedDescription %}
-      {% set valueLines = valueLines | push("Investigated: " + symptom.investigatedDescription) %}
+    {% if symptom.hasBeenInvestigated == "yes" %}
+      {% set valueLines = valueLines | push("Has been previously investigated: " + symptom.investigatedDescription) %}
     {% elseif symptom.hasBeenInvestigated == "no" %}
       {% set valueLines = valueLines | push("Not investigated") %}
     {% endif %}

--- a/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
+++ b/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
@@ -86,8 +86,8 @@
         {{ symptom.dateStarted | formatMonthYear }} ({{ symptom.dateStarted | formatRelativeDate }})
       {% elseif symptom.approximateDuration %}
         {{ symptom.approximateDuration }} ago
-      {% elseif symptom.dateType == 'notSure' %}
-        not sure
+      {% elseif symptom.dateType == 'notKnown' %}
+        not known
       {% else %}
         not provided
       {% endif %}

--- a/app/views/events/medical-information/symptoms/details.html
+++ b/app/views/events/medical-information/symptoms/details.html
@@ -467,13 +467,13 @@
     }) %}
 
     {% set dateRadioItems = dateRadioItems | push({
-      value: "notSure",
-      text: "Not sure"
+      value: "notKnown",
+      text: "Not known"
     }) %}
 
 
 
-    {# Radios for when were they taken - choices 'Date known' and 'Enter approximate date' and 'Not sure'  #}
+    {# Radios for when were they taken - choices 'Date known' and 'Enter approximate date' and 'Not known'  #}
     {{ radios({
       idPrefix: "dateType",
       name: "event[symptomTemp][dateType]",

--- a/app/views/events/medical-information/symptoms/details.html
+++ b/app/views/events/medical-information/symptoms/details.html
@@ -471,8 +471,6 @@
       text: "Not known"
     }) %}
 
-
-
     {# Radios for when were they taken - choices 'Date known' and 'Enter approximate date' and 'Not known'  #}
     {{ radios({
       idPrefix: "dateType",
@@ -503,38 +501,6 @@
       } | populateErrors) }}
     {% endset %}
 
-    {# TODO: don't use br for spacing! #}
-    <br>
-
-    
-
-    {{ checkboxes({
-      idPrefix: "isIntermittent",
-      name: "event[symptomTemp][isIntermittent]",
-      items: [
-        {
-          value: "yes",
-          text: "The symptom is intermittent",
-          checked: true if event.symptomTemp.isIntermittent else false
-        }
-      ]
-    }) }}
-
-    {{ checkboxes({
-      idPrefix: "hasStopped",
-      name: "event[symptomTemp][hasStopped]",
-      items: [
-        {
-          value: "yes",
-          text: "The symptom has recently resolved",
-          checked: true if event.symptomTemp.hasStopped else false,
-          conditional: {
-            html: stymptomStoppedHtml
-          }
-        }
-      ]
-    }) }}
-
   {% set investigatedDescriptionHtml %}
     {{ textarea({
       id: "investigatedDescription",
@@ -549,20 +515,63 @@
     } | populateErrors) }}
   {% endset %}
 
-  {{ checkboxes({
-    idPrefix: "hasBeenInvestigated",
-    name: "event[symptomTemp][hasBeenInvestigated]",
-    values: event.symptomTemp.hasBeenInvestigated,
-    items: [
-      {
-        value: "yes",
-        text: "The symptom has been previously investigated",
-        conditional: {
-          html: investigatedDescriptionHtml
+  {% call fieldset({
+    legend: {
+      text: "Additional symptom information",
+      size: "m",
+      isPageHeading: false
+    }
+  }) %}
+
+    {{ checkboxes({
+      idPrefix: "isIntermittent",
+      name: "event[symptomTemp][isIntermittent]",
+      formGroup: {
+        classes: "nhsuk-u-margin-bottom-3"
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Intermittent",
+          checked: true if event.symptomTemp.isIntermittent else false
         }
-      }
-    ]
-  }) }}
+      ]
+    }) }}
+
+    {{ checkboxes({
+      idPrefix: "hasStopped",
+      name: "event[symptomTemp][hasStopped]",
+      formGroup: {
+        classes: "nhsuk-u-margin-bottom-3"
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Recently resolved",
+          checked: true if event.symptomTemp.hasStopped else false,
+          conditional: {
+            html: stymptomStoppedHtml
+          }
+        }
+      ]
+    }) }}
+
+    {{ checkboxes({
+      idPrefix: "hasBeenInvestigated",
+      name: "event[symptomTemp][hasBeenInvestigated]",
+      values: event.symptomTemp.hasBeenInvestigated,
+      items: [
+        {
+          value: "yes",
+          text: "Investigated by a medical professional",
+          conditional: {
+            html: investigatedDescriptionHtml
+          }
+        }
+      ]
+    }) }}
+
+  {% endcall %}
 
   {# Only show if not significant by default #}
     {% if not symptomType.isSignificantByDefault %}
@@ -603,29 +612,16 @@
         ]
       } | populateErrors) }}
 
-      {# {{ checkboxes({
-        idPrefix: "isSignificant",
-        name: "event[symptomTemp][isSignificant]",
-        items: [
-          {
-            value: "yes",
-            text: "Highlight this symptom to image readers",
-            checked: true if event.symptomTemp.isSignificant else false
-          }
-        ]
-      }) }} #}
     {% endif %}
 
-
-
   {{ textarea({
-    name: "event[symptomTemp][additionalInfo]",
+    name: "event[symptomTemp][symptomNotes]",
     label: {
-      text: "Additional info (optional)",
+      text: "Symptom notes (optional)",
       size: "m"
     },
     rows: 4,
-    value: event.symptomTemp.additionalInfo
+    value: event.symptomTemp.symptomNotes
   }) }}
 
   <div class="nhsuk-button-group">

--- a/app/views/events/medical-information/symptoms/details.html
+++ b/app/views/events/medical-information/symptoms/details.html
@@ -535,42 +535,34 @@
       ]
     }) }}
 
-  {{ radios({
+  {% set investigatedDescriptionHtml %}
+    {{ textarea({
+      id: "investigatedDescription",
+      name: "event[symptomTemp][investigatedDescription]",
+      label: {
+        text: "Provide details"
+      },
+      hint: {
+        text: "Include where, when and the outcome"
+      },
+      value: event.symptomTemp.investigatedDescription
+    } | populateErrors) }}
+  {% endset %}
+
+  {{ checkboxes({
     idPrefix: "hasBeenInvestigated",
     name: "event[symptomTemp][hasBeenInvestigated]",
-    value: event.symptomTemp.hasBeenInvestigated,
-    fieldset: {
-      legend: {
-        text: "Has this been investigated?",
-          size: "m",
-        isPageHeading: false
-      }
-    },
+    values: event.symptomTemp.hasBeenInvestigated,
     items: [
       {
         value: "yes",
-        text: "Yes",
+        text: "The symptom has been previously investigated",
         conditional: {
-          html: textarea({
-            id: "investigatedDescription",
-            name: "event[symptomTemp][investigatedDescription]",
-            label: {
-              text: "Provide details"
-            },
-            hint: {
-              text: "Include where, when and the outcome"
-            },
-            value: event.symptomTemp.investigatedDescription,
-            _classes: "nhsuk-u-width-two-thirds"
-          } | populateErrors)
+          html: investigatedDescriptionHtml
         }
-      },
-      {
-        value: "no",
-        text: "No"
       }
     ]
-  } | populateErrors) }}
+  }) }}
 
   {# Only show if not significant by default #}
     {% if not symptomType.isSignificantByDefault %}


### PR DESCRIPTION
## Description

Makes two changes to the symptoms form following user research:

### Change 'Not sure' to 'Not known'
It was felt that 'not sure' was more applicable to a participant answering rather than a general case where the answer isn't known or the mammographer hasn't answered the question.

<img width="1250" height="814" alt="Screenshot 2026-06-17 at 15 50 32" src="https://github.com/user-attachments/assets/a27a8aca-80c7-4b8b-968e-28c8fcb705e1" />

### Change symptom investigation question
This question was required, but in one case it wasn't answered. The form currently forces an answer. We considered marking as optional or having a 'not known' option, but by adopting a checkbox we can make it more of an 'opt in' question like the two above it. As there are already two checkboxes above it, we've combined them in to one fieldset question.

<img width="1516" height="1146" alt="Screenshot 2026-06-17 at 15 50 37" src="https://github.com/user-attachments/assets/902306e4-d237-4050-aa12-ce833bcca4d4" />

### Changed wording on freetext
The final freetext is updated to `Symptom notes (optional)` from `Additional information (optional)`
 
<img width="1502" height="380" alt="Screenshot 2026-06-17 at 15 50 41" src="https://github.com/user-attachments/assets/1cdfbc39-3d8b-4909-ae98-b307567b215c" />

### Summary list
Wording tweaked on summary list to match the options

<img width="1752" height="546" alt="Screenshot 2026-06-17 at 15 51 12" src="https://github.com/user-attachments/assets/803bb126-f339-4ed8-933c-cc23f1d671db" />
