### PR TITLE
Remove instances of 'reported' relating to prior mammos and symptoms

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -78,6 +78,6 @@ module.exports = {
   generation: {
     numberOfParticipants: 1000,
     bookingProbability: 0.8, // 80% of slots are booked
-    previousMammogramRate: 0.05 // Rate of completed events with reported previous mammograms
+    previousMammogramRate: 0.05 // Rate of completed events with recorded previous mammograms
   }
 }

--- a/app/lib/generators/event-generator.js
+++ b/app/lib/generators/event-generator.js
@@ -311,7 +311,7 @@ const generateEvent = ({
         }
       }
 
-      // Generate previous mammograms (reported mammograms from other facilities)
+      // Generate previous mammograms (recorded mammograms from other facilities)
       const previousMammograms = generatePreviousMammograms({
         eventDate: event.timing.actualEndTime || event.timing.actualStartTime,
         addedByUserId: event.sessionDetails.startedBy,

--- a/app/lib/generators/previous-mammogram-generator.js
+++ b/app/lib/generators/previous-mammogram-generator.js
@@ -259,7 +259,7 @@ const generatePreviousMammograms = ({ eventDate, addedByUserId, rate }) => {
       ? rate
       : (config.generation?.previousMammogramRate ?? 0.2)
 
-  // Decide whether this event has reported mammograms
+  // Decide whether this event has recorded mammograms
   if (Math.random() > effectiveRate) {
     return null
   }

--- a/app/lib/generators/reading-generator.js
+++ b/app/lib/generators/reading-generator.js
@@ -23,11 +23,11 @@ const DEFAULT_READ_WEIGHTS = {
 
 // Normal opinion freetext reasons when participant has symptoms
 const NORMAL_DETAILS_WITH_SYMPTOMS = [
-  'Images reviewed carefully in the context of reported symptoms. No mammographic abnormality identified. Clinical follow-up recommended for symptoms.',
+  'Images reviewed carefully in the context of disclosed symptoms. No mammographic abnormality identified. Clinical follow-up recommended for symptoms.',
   'Thorough review of all views performed. No significant mammographic findings. Symptoms noted but no corresponding imaging abnormality detected.',
   'Normal mammographic appearance bilaterally. Symptoms have been considered in this assessment. No imaging correlate found.',
-  'Careful assessment undertaken given reported symptoms. Mammographic appearances are within normal limits. Clinical assessment advised.',
-  'No mammographic abnormality detected on careful review. Reported symptoms do not have a mammographic correlate. Recommend clinical follow-up.'
+  'Careful assessment undertaken given disclosed symptoms. Mammographic appearances are within normal limits. Clinical assessment advised.',
+  'No mammographic abnormality detected on careful review. Disclosed symptoms do not have a mammographic correlate. Recommend clinical follow-up.'
 ]
 
 // Normal opinion freetext reasons without symptoms (used for a small proportion)

--- a/app/lib/utils/prior-mammograms.js
+++ b/app/lib/utils/prior-mammograms.js
@@ -1,13 +1,13 @@
 // app/lib/utils/prior-mammograms.js
 //
-// Utility functions for working with prior mammograms (previously reported
+// Utility functions for working with prior mammograms (previously recorded
 // mammograms from other facilities). These derive event-level state from
 // per-mammogram request tracking on event.previousMammograms[].
 
 const { formatDate, formatRelativeDate } = require('./dates')
 
-/** Returns true if the event has any previously reported mammograms */
-const hasReportedMammograms = (event) => {
+/** Returns true if the event has any previously recorded mammograms */
+const hasRecordedMammograms = (event) => {
   if (!event) return false
   return (
     Array.isArray(event.previousMammograms) &&
@@ -17,7 +17,7 @@ const hasReportedMammograms = (event) => {
 
 /** Returns true if any prior mammogram has requestStatus 'pending' or 'requested' (holds case from reading) */
 const awaitingPriors = (event) => {
-  if (!hasReportedMammograms(event)) return false
+  if (!hasRecordedMammograms(event)) return false
   return event.previousMammograms.some(
     (m) => m.requestStatus === 'pending' || m.requestStatus === 'requested'
   )
@@ -25,7 +25,7 @@ const awaitingPriors = (event) => {
 
 /** Returns true if any prior mammogram has requestStatus 'not_requested' */
 const hasUnrequestedPriors = (event) => {
-  if (!hasReportedMammograms(event)) return false
+  if (!hasRecordedMammograms(event)) return false
   return event.previousMammograms.some(
     (m) => m.requestStatus === 'not_requested'
   )
@@ -38,7 +38,7 @@ const hasUnrequestedPriors = (event) => {
  * @returns {{total: number, counts: object, hasAwaiting: boolean, hasUnrequested: boolean, allResolved: boolean}}
  */
 const getPriorsSummary = (event) => {
-  if (!hasReportedMammograms(event)) {
+  if (!hasRecordedMammograms(event)) {
     return {
       total: 0,
       counts: {},
@@ -82,7 +82,7 @@ const getPriorsSummary = (event) => {
 
 /** Get priors with requestStatus 'not_requested' (for the request priors UI) */
 const getUnrequestedPriors = (event) => {
-  if (!hasReportedMammograms(event)) return []
+  if (!hasRecordedMammograms(event)) return []
   return event.previousMammograms.filter(
     (m) => m.requestStatus === 'not_requested'
   )
@@ -90,7 +90,7 @@ const getUnrequestedPriors = (event) => {
 
 /** Get priors with requestStatus 'pending' or 'requested' (awaiting arrival) */
 const getAwaitingPriors = (event) => {
-  if (!hasReportedMammograms(event)) return []
+  if (!hasRecordedMammograms(event)) return []
   return event.previousMammograms.filter(
     (m) => m.requestStatus === 'pending' || m.requestStatus === 'requested'
   )
@@ -101,7 +101,7 @@ const getAwaitingPriors = (event) => {
  * Only 'pending' is checked — once admin moves to 'requested', the reader can no longer undo.
  */
 const userRequestedPriors = (event, userId) => {
-  if (!hasReportedMammograms(event)) return false
+  if (!hasRecordedMammograms(event)) return false
   return event.previousMammograms.some(
     (m) => m.requestStatus === 'pending' && m.requestedBy === userId
   )
@@ -179,14 +179,14 @@ const summarisePriorMammogram = (mammogram, options = {}) => {
  * @returns {Array<string>} Array of summary strings
  */
 const summarisePriorMammograms = (event, options = {}) => {
-  if (!hasReportedMammograms(event)) return []
+  if (!hasRecordedMammograms(event)) return []
   return event.previousMammograms
     .map((m) => summarisePriorMammogram(m, options))
     .filter(Boolean)
 }
 
 module.exports = {
-  hasReportedMammograms,
+  hasRecordedMammograms,
   awaitingPriors,
   hasUnrequestedPriors,
   getPriorsSummary,

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -1957,7 +1957,7 @@ module.exports = (router) => {
         }
 
         // Show combined success message
-        req.flash('success', 'Breast implants recorded and consent recorded')
+        req.flash('success', 'Breast implants added and consent recorded')
 
         // Continue to next step in the flow
         const returnUrl = getReturnUrl(

--- a/app/views/_includes/cards/medical-information/symptoms.njk
+++ b/app/views/_includes/cards/medical-information/symptoms.njk
@@ -7,7 +7,7 @@
 
   {% if not hasSymptoms %}
     {% set insetHtml %}
-      <p>No symptoms have been recorded for this participant.</p>
+      <p>No symptoms have been added for this participant.</p>
     {% endset %}
     {{ insetText({
       html: insetHtml

--- a/app/views/_includes/medical-information/breast-features.njk
+++ b/app/views/_includes/medical-information/breast-features.njk
@@ -8,7 +8,7 @@
 {% if hasBreastFeatures %}
 
   <p>
-    {{ breastFeaturesCount }} breast {{ "feature" | pluralise(breastFeaturesCount) }} recorded
+    {{ breastFeaturesCount }} breast {{ "feature" | pluralise(breastFeaturesCount) }} added
   </p>
 
   <script>
@@ -38,7 +38,7 @@
 {% else %}
   {% set insetHtml %}
     <p>
-      No breast features have been recorded for this participant.
+      No breast features have been added for this participant.
     </p>
   {% endset %}
   {{ insetText({

--- a/app/views/_includes/medical-information/index.njk
+++ b/app/views/_includes/medical-information/index.njk
@@ -12,7 +12,7 @@
 
 {# Mammogram history #}
 {% set sectionHeading = "Mammogram history" %}
-{% set subHeading = "Previous mammograms from screening records and any disclosed by the participant" %}
+{% set subHeading = "The last confirmed mammogram and any added manually since then" %}
 {% set sectionId = sectionHeading | kebabCase %}
 {% set scrollTo = sectionId %}
 

--- a/app/views/_includes/medical-information/index.njk
+++ b/app/views/_includes/medical-information/index.njk
@@ -12,7 +12,7 @@
 
 {# Mammogram history #}
 {% set sectionHeading = "Mammogram history" %}
-{% set subHeading = "Previous mammograms from screening records and any reported by the participant" %}
+{% set subHeading = "Previous mammograms from screening records and any disclosed by the participant" %}
 {% set sectionId = sectionHeading | kebabCase %}
 {% set scrollTo = sectionId %}
 
@@ -32,9 +32,9 @@
 {% endset %}
 
 {% if hasAdditionalMammograms %}
-  {% set mammogramHistoryContentsSummary = (event.previousMammograms | length) ~ " reported " + ("mammogram" | pluralise(event.previousMammograms | length)) + " added" %}
+  {% set mammogramHistoryContentsSummary = (event.previousMammograms | length) ~ " " ~ ("mammogram" | pluralise(event.previousMammograms | length)) ~ " added" %}
 {% else %}
-  {% set mammogramHistoryContentsSummary = "No reported mammograms added" %}
+  {% set mammogramHistoryContentsSummary = "No mammograms added" %}
 {% endif %}
 
 

--- a/app/views/_includes/medical-information/index.njk
+++ b/app/views/_includes/medical-information/index.njk
@@ -136,7 +136,7 @@
 {% set scrollTo = sectionId %}
 
 {% set symptomsCount = event.medicalInformation.symptoms and event.medicalInformation.symptoms | length %}
-{% set symptomsContentsSummaryText %}{{ symptomsCount or "No" }} {{ "symptom" | pluralise(symptomsCount) }} recorded{% endset %}
+{% set symptomsContentsSummaryText %}{{ symptomsCount or "No" }} {{ "symptom" | pluralise(symptomsCount) }} added{% endset %}
 
 {% set symptomsCardContent %}
   {% include "_includes/medical-information/symptoms-card-content.njk" %}
@@ -183,7 +183,7 @@
 {% set hasBreastFeatures = breastFeaturesCount > 0 %}
 
 {% set breastFeaturesContentsSummaryText %}
-  {{ breastFeaturesCount or "No" }} breast {{ "feature" | pluralise(breastFeaturesCount) }} recorded
+  {{ breastFeaturesCount or "No" }} breast {{ "feature" | pluralise(breastFeaturesCount) }} added
 {% endset %}
 
 {% set breastFeaturesHtml %}
@@ -244,9 +244,9 @@
 {% endif %}
 
 {% if otherRelevantInformationCount > 0 %}
-  {% set otherRelevantInformationSummary = otherRelevantInformationCount ~ " other relevant information recorded" %}
+  {% set otherRelevantInformationSummary = otherRelevantInformationCount ~ " other relevant information added" %}
 {% else %}
-  {% set otherRelevantInformationSummary = "No other relevant information recorded" %}
+  {% set otherRelevantInformationSummary = "No other relevant information added" %}
 {% endif %}
 
 {% switch displayFormat %}

--- a/app/views/_includes/medical-information/mammogram-history.njk
+++ b/app/views/_includes/medical-information/mammogram-history.njk
@@ -31,7 +31,7 @@
 
 {# User-added unverified mammograms #}
 {% if hasAdditionalMammograms %}
-  <h3 class="nhsuk-heading-s">Recorded mammograms</h3>
+  <h3 class="nhsuk-heading-s">Disclosed mammograms</h3>
   {% set userMammogramRows = [] %}
 
   {% for previousMammogram in event.previousMammograms %}
@@ -91,7 +91,7 @@
     {% set mammogramValueHtml = mammogramValueLines | join('<br>') %}
 
     {% set keyHtml %}
-      Recorded {{ previousMammogram.dateAdded | formatDate }}
+      Added {{ previousMammogram.dateAdded | formatDate }}
       {% if previousMammogram.addedBy %}
         <span class="nhsuk-u-secondary-text-colour app-nowrap nhsuk-body-s nhsuk-u-font-weight-normal nhsuk-u-margin-bottom-0 ">by {{ previousMammogram.addedBy
           | getUsername({

--- a/app/views/_includes/medical-information/mammogram-history.njk
+++ b/app/views/_includes/medical-information/mammogram-history.njk
@@ -31,7 +31,7 @@
 
 {# User-added unverified mammograms #}
 {% if hasAdditionalMammograms %}
-  <h3 class="nhsuk-heading-s">Reported mammograms</h3>
+  <h3 class="nhsuk-heading-s">Recorded mammograms</h3>
   {% set userMammogramRows = [] %}
 
   {% for previousMammogram in event.previousMammograms %}
@@ -113,7 +113,7 @@
           {
             href: contextUrl + "/previous-mammograms/edit/" + previousMammogram.id | urlWithReferrer(referrerChain | appendReferrer(currentUrl), scrollTo),
             text: "Change",
-            visuallyHiddenText: "Participant reported mammogram"
+            visuallyHiddenText: "Participant disclosed mammogram"
           }
         ]
       } if allowEdits

--- a/app/views/_includes/medical-information/medical-history/index.njk
+++ b/app/views/_includes/medical-information/medical-history/index.njk
@@ -237,7 +237,7 @@
           {{ breastItemsList(historyItem.proceduresRightBreast, "No procedure") }}
         {% endset %}
         {% set leftBreastContent %}
-          {{ breastItemsList(historyItem.proceduresLeftBreast, "No procedures recorded") }}
+          {{ breastItemsList(historyItem.proceduresLeftBreast, "No procedures added") }}
         {% endset %}
         {{ leftRightBreastDisplay(rightBreastContent, leftBreastContent) }}
 

--- a/app/views/_includes/medical-information/symptoms-card-content.njk
+++ b/app/views/_includes/medical-information/symptoms-card-content.njk
@@ -5,7 +5,7 @@
 {% set hasSymptoms = symptomsCount > 0 %}
 
 {% set symptomsContentsSummaryText %}
-  {{ symptomsCount or "No" }} {{ 'symptom' | pluralise(symptomsCount) }} recorded
+  {{ symptomsCount or "No" }} {{ 'symptom' | pluralise(symptomsCount) }} added
 {% endset %}
 
 
@@ -13,7 +13,7 @@
 
 {% if not hasSymptoms %}
   {% set insetHtml %}
-    <p>No symptoms have been recorded for this participant.</p>
+    <p>No symptoms have been added for this participant.</p>
   {% endset %}
   {{ insetText({
     html: insetHtml

--- a/app/views/_includes/summary-lists/medical-info-summary.njk
+++ b/app/views/_includes/summary-lists/medical-info-summary.njk
@@ -153,13 +153,13 @@
   {% set mammogramsAction = {
     href: "./previous-mammograms/add" | urlWithReferrer(mammogramsAddReferrerChain),
     text: "Add a mammogram",
-    visuallyHiddenText: "reported mammograms"
+    visuallyHiddenText: "recorded mammograms"
   } | openInModal %}
 {% else %}
   {% set mammogramsAction = {
     href: "./confirm-information/previous-mammograms" | urlWithReferrer(currentUrl),
     text: "View or change",
-    visuallyHiddenText: "reported mammograms"
+    visuallyHiddenText: "recorded mammograms"
   } %}
 {% endif %}
 
@@ -203,7 +203,7 @@
 {% if not showOnlyPopulated or additionalMammogramsCount > 0 %}
   {% set rows = rows | push({
     key: {
-      text: "Reported mammograms"
+      text: "Recorded mammograms"
     },
     value: {
       html: previousMammogramsHtml

--- a/app/views/_includes/summary-lists/medical-info-summary.njk
+++ b/app/views/_includes/summary-lists/medical-info-summary.njk
@@ -45,7 +45,7 @@
 {# Build symptoms HTML #}
 {% set symptomsHtml %}
   {% if symptomsCount == 0 %}
-    <p>No symptoms recorded</p>
+    <p>No symptoms added</p>
   {% elif symptomsCount == 1 %}
     <p>{{ symptomSummaries[0] }}</p>
   {% else %}
@@ -72,7 +72,7 @@
 {# Build breast features HTML #}
 {% set breastFeaturesHtml %}
   {% if breastFeaturesCount == 0 %}
-    <p>No breast features recorded</p>
+    <p>No breast features added</p>
   {% elseif breastFeaturesCount == 1 %}
     <p>{{ breastFeatureSummaries[0] }}</p>
   {% else %}
@@ -153,13 +153,13 @@
   {% set mammogramsAction = {
     href: "./previous-mammograms/add" | urlWithReferrer(mammogramsAddReferrerChain),
     text: "Add a mammogram",
-    visuallyHiddenText: "recorded mammograms"
+    visuallyHiddenText: "mammograms added"
   } | openInModal %}
 {% else %}
   {% set mammogramsAction = {
     href: "./confirm-information/previous-mammograms" | urlWithReferrer(currentUrl),
     text: "View or change",
-    visuallyHiddenText: "recorded mammograms"
+    visuallyHiddenText: "mammograms added"
   } %}
 {% endif %}
 
@@ -203,7 +203,7 @@
 {% if not showOnlyPopulated or additionalMammogramsCount > 0 %}
   {% set rows = rows | push({
     key: {
-      text: "Recorded mammograms"
+      text: "Mammograms added"
     },
     value: {
       html: previousMammogramsHtml
@@ -285,7 +285,7 @@
 {% endif %}
 
 {% if rows | length == 0 %}
-  <p class="nhsuk-body">No medical information recorded.</p>
+  <p class="nhsuk-body">No medical information added.</p>
 {% else %}
   {{ summaryList({
     rows: rows | removeLastRowBorder

--- a/app/views/_includes/summary-lists/questionnaire.njk
+++ b/app/views/_includes/summary-lists/questionnaire.njk
@@ -227,14 +227,14 @@
       <li>Details: {{questionnaire.skinChangeDetails}}</li>
     </ul>
   {% else %}
-    {{ questionnaire.skinChanges | formatAnswer({ noText: "No changes reported" }) }}
+    {{ questionnaire.skinChanges | formatAnswer({ noText: "No changes disclosed" }) }}
   {% endif %}
 {% endset %}
 
 {% set nippleSymptomsValue %}
   {% if questionnaire.nippleSymptoms %}
     {% if questionnaire.nippleSymptoms.includes("none") %}
-      No symptoms reported
+      No symptoms disclosed
     {% else %}
       <ul class="nhsuk-list nhsuk-list--bullet">
       {% for symptom in questionnaire.nippleSymptoms %}
@@ -282,7 +282,7 @@
       value: {
         text: questionnaire.lumpsNoticed | formatAnswer({
           yesValue: questionnaire.lumpDetails,
-          noText: "No lumps reported"
+          noText: "No lumps disclosed"
         })
       },
       actions: {
@@ -302,7 +302,7 @@
       value: {
         text: questionnaire.shapeChanges | formatAnswer({
           yesValue: questionnaire.shapeChangeDetails,
-          noText: "No changes reported"
+          noText: "No changes disclosed"
         })
       },
       actions: {

--- a/app/views/_includes/symptomsWarningCard.njk
+++ b/app/views/_includes/symptomsWarningCard.njk
@@ -7,7 +7,7 @@
   {% endset %}
 
   {{ warningCallout({
-    heading: 'Significant symptoms reported',
+    heading: 'Significant symptoms',
     html: warningCalloutHtml,
     classes: "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4"
   }) }}

--- a/app/views/events/check-information.html
+++ b/app/views/events/check-information.html
@@ -156,7 +156,7 @@
   <h1>{{ pageHeading }}</h1>
 
   <p class="nhsuk-u-reading-width">
-    Before concluding this appointment, confirm that the information recorded is correct.
+    To conclude this appointment, confirm this information is correct.
   </p>
   {# {{ button({
     text: "Complete screening and return to clinic"

--- a/app/views/events/medical-information/medical-history/consent.html
+++ b/app/views/events/medical-information/medical-history/consent.html
@@ -63,7 +63,7 @@
     {{ pageHeading }}
   </h1>
 
-  <p>You have recorded {{ implantDescription }}. You must get the participant's permission to continue.</p>
+  <p>You have added {{ implantDescription }}. You must get the participant's permission to continue.</p>
 
   <p>There is no medical reason for people with breast implants to avoid the procedure.</p>
 

--- a/app/views/events/medical-information/symptoms/details.html
+++ b/app/views/events/medical-information/symptoms/details.html
@@ -30,7 +30,7 @@
   {% if symptomType.isSignificantByDefault %}
     {# Special case for lumps, otherwise all other types work with '[name] is a' #}
     {% set insetTextHtml %}
-      <p>{{ "Lumps are" if event.symptomTemp.type == "Lump" else (event.symptomTemp.type + " is ")}} a recognised symptom of breast cancer. Information recorded here will be highlighted during image reading.</p>
+      <p>{{ "Lumps are" if event.symptomTemp.type == "Lump" else (event.symptomTemp.type + " is ")}} a recognised symptom of breast cancer. Information added here will be highlighted during image reading.</p>
     {% endset %}
 
     {{ insetText({
@@ -587,7 +587,7 @@
           },
           {
             value: "no",
-            text: "No, just record information",
+            text: "No, just add information",
             checked: true if event.symptomTemp.isSignificant == false
           }
         ]

--- a/app/views/reading/batch.html
+++ b/app/views/reading/batch.html
@@ -251,7 +251,7 @@
                   {% endif %}
                 </span>
                 {% if (data.settings.debugMode | falsify) %}
-                  {% if event | hasReportedMammograms %}
+                  {% if event | hasRecordedMammograms %}
                     <br>{{ "Has priors" | toTag }}
                   {% endif %}
                   {% if event.mammogramData.metadata.hasAdditionalImages %}
@@ -440,7 +440,7 @@
                   {{ "Awaiting priors" | toTag }}
                 {% endif %}
                 {% if (data.settings.debugMode | falsify) %}
-                  {% if event | hasReportedMammograms %}
+                  {% if event | hasRecordedMammograms %}
                     <br>{{ "Has priors" | toTag }}
                   {% endif %}
                   {% if event.mammogramData.metadata.hasAdditionalImages %}

--- a/app/views/reading/priors.html
+++ b/app/views/reading/priors.html
@@ -12,7 +12,7 @@
 
 {% block pageContent %}
 
-  {# Get all eligible events with reported mammograms, sorted by screening date #}
+  {# Get all eligible events with recorded mammograms, sorted by screening date #}
   {% set eligibleEvents = data.events | filterEventsByEligibleForReading | sortEventsByScreeningDate %}
 
   {# Build flat list of mammogram rows with their parent event #}
@@ -23,7 +23,7 @@
   {% set resolvedRows = [] %}
 
   {% for thisEvent in eligibleEvents %}
-    {% if thisEvent | hasReportedMammograms %}
+    {% if thisEvent | hasRecordedMammograms %}
       {% for mammogram in thisEvent.previousMammograms %}
         {% set row = { event: thisEvent, mammogram: mammogram } %}
         {% if mammogram.requestStatus == "not_requested" %}

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -259,7 +259,7 @@
                   {% endif %}
                 </span>
                 {% if (data.settings.debugMode | falsify) %}
-                  {% if event | hasReportedMammograms %}
+                  {% if event | hasRecordedMammograms %}
                     <br>{{ "Has priors" | toTag }}
                   {% endif %}
                   {% if event.mammogramData.metadata.hasAdditionalImages %}
@@ -450,7 +450,7 @@
                   {{ "Awaiting priors" | toTag }}
                 {% endif %}
                 {% if (data.settings.debugMode | falsify) %}
-                  {% if event | hasReportedMammograms %}
+                  {% if event | hasRecordedMammograms %}
                     <br>{{ "Has priors" | toTag }}
                   {% endif %}
                   {% if event.mammogramData.metadata.hasAdditionalImages %}

--- a/app/views/reading/workflow/normal-details.html
+++ b/app/views/reading/workflow/normal-details.html
@@ -52,7 +52,7 @@
           items: [
             {
               value: "true",
-              text: "I acknowledge that the disclosed symptoms have been considered in my decision"
+              text: "I acknowledge that the symptoms have been considered in my decision"
             }
           ],
           values: data.imageReadingTemp.symptomsAcknowledged

--- a/app/views/reading/workflow/normal-details.html
+++ b/app/views/reading/workflow/normal-details.html
@@ -52,7 +52,7 @@
           items: [
             {
               value: "true",
-              text: "I acknowledge that the reported symptoms have been considered in my decision"
+              text: "I acknowledge that the disclosed symptoms have been considered in my decision"
             }
           ],
           values: data.imageReadingTemp.symptomsAcknowledged

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -114,7 +114,7 @@
       {% endif %}
 
       {% if (data.settings.debugMode | falsify) %}
-        {% if event | hasReportedMammograms %}
+        {% if event | hasRecordedMammograms %}
           {{ "Has priors" | toTag }}
         {% endif %}
         {% if event.mammogramData.metadata.hasAdditionalImages %}
@@ -138,10 +138,10 @@
     </div>
   </div>
 
-  {# Reported mammograms banners - shown if there are unrequested or received priors #}
+  {# Recorded mammograms banners - shown if there are unrequested or received priors #}
   {% set priorsSummary = event | getPriorsSummary %}
 
-  {# Warning: priors reported but not yet requested #}
+  {# Warning: priors recorded but not yet requested #}
   {% if priorsSummary.hasUnrequested %}
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
@@ -160,7 +160,7 @@
         {% call insetText({
           classes: "app-inset-text--compact" if data.settings.compactMode in ["true", true]
         }) %}
-          <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammograms reported</p>
+          <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammograms recorded</p>
           {{ unrequestedHtml | safe }}
         {% endcall %}
       </div>

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -160,7 +160,7 @@
         {% call insetText({
           classes: "app-inset-text--compact" if data.settings.compactMode in ["true", true]
         }) %}
-          <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammograms recorded</p>
+          <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammogram added</p>
           {{ unrequestedHtml | safe }}
         {% endcall %}
       </div>

--- a/app/views/style-guide/notification-banner.html
+++ b/app/views/style-guide/notification-banner.html
@@ -94,14 +94,14 @@
   {{ appNotificationBanner({
     size: "compact",
     type: "warning",
-    titleText: "Priors reported — not yet requested",
+    titleText: "Priors recorded — not yet requested",
     html: "<p>Most recent mammogram: St Thomas' Hospital, June 2022</p><p class='nhsuk-u-margin-bottom-0'><a href='#' class='nhsuk-link--no-visited-state'>Request priors</a></p>"
   }) }}
 </div>
 <pre class="sg-snippet"><code>{% raw %}{{ appNotificationBanner({
   size: "compact",
   type: "warning",
-  titleText: "Priors reported",
+  titleText: "Priors recorded",
   html: "<p>...</p>"
 }) }}{% endraw %}</code></pre>
 

--- a/docs/utils-filter-reference.md
+++ b/docs/utils-filter-reference.md
@@ -248,7 +248,7 @@ Prior mammogram request state (awaiting, unrequested, resolved) and one-line sum
 
 | Function | Description | Line |
 |---|---|---|
-| `hasReportedMammograms(event)` | Returns true if the event has any previously reported mammograms | 9 |
+| `hasRecordedMammograms(event)` | Returns true if the event has any previously recorded mammograms | 9 |
 | `awaitingPriors(event)` | Returns true if any prior mammogram has requestStatus 'requested' (holds case from reading) | 18 |
 | `hasUnrequestedPriors(event)` | Returns true if any prior mammogram has requestStatus 'not_requested' | 24 |
 | `getPriorsSummary(event)` | Get a summary of prior mammogram statuses for display | 32 |


### PR DESCRIPTION
## Description

Addressing this ticket - https://nhsd-jira.digital.nhs.uk/browse/DTOSS-13177

"In various places our ui refers to 'reported mammograms' to mean the mammograms that the participant has told us about. 'Reported' already has a specific meaning in screening, so this risks being confusing or ambiguous or misleading."

Expanded to cover 'reported symptoms' as well. Have updated all identified instances from this search:

[https://github.com/search?q=repo%3ANHSDigital%2Fmanage-breast-screening-prototype+[…]8%3F%3Asympt%5Cw*%7Cmammogram%5Cw*%7Cprior%5Cw*%29%2F&type=code](https://github.com/search?q=repo%3ANHSDigital%2Fmanage-breast-screening-prototype+%2F%28%3Fi%29%28%3F%3Asympt%5Cw*%7Cmammogram%5Cw*%7Cprior%5Cw*%29.%7B0%2C50%7Dreport%5Cw*%7Creport%5Cw*.%7B0%2C50%7D%28%3F%3Asympt%5Cw*%7Cmammogram%5Cw*%7Cprior%5Cw*%29%2F&type=code)

Also need to avoid 'record' or 'recorded' within UI as this could create confusion with 'screening record'

Primary changes are:

- Reported mammogram > Mammogram added
- Reported symptom > Disclosed symptom
