### PR TITLE
Add ability to limit the number of readable cases

### DIFF
--- a/app/lib/generators/reading-generator.js
+++ b/app/lib/generators/reading-generator.js
@@ -337,6 +337,105 @@ const generatePlaceholderAnnotation = (side, breastData) => {
 }
 
 /**
+ * Apply reads when a backlogLimit is set.
+ *
+ * All eligible events except the last `backlogLimit` are fully read (2 reads
+ * by non-current users). Of the remaining `backlogLimit` events:
+ *   - The first `floor(backlogLimit × partialReadRatio)` get 1 read by a
+ *     non-current user (second read still available to current user)
+ *   - The rest get no reads (first read available to current user)
+ *
+ * @param {Array} allEvents - Full events array
+ * @param {Array} eligibleEvents - Events eligible for reading
+ * @param {object} readers - { firstReader, secondReader, thirdReader }
+ * @param {object} options - { backlogLimit, backlogPartialReadRatio, alignmentProbability }
+ * @returns {Array} Updated events array
+ */
+const generateReadingDataWithBacklogLimit = (
+  allEvents,
+  eligibleEvents,
+  { firstReader, secondReader, thirdReader },
+  { backlogLimit, backlogPartialReadRatio, alignmentProbability }
+) => {
+  // Sort oldest first so the oldest cases become fully read (they appear in history)
+  const sorted = [...eligibleEvents].sort(
+    (a, b) => new Date(a.timing.startTime) - new Date(b.timing.startTime)
+  )
+
+  const clampedLimit = Math.min(backlogLimit, sorted.length)
+  const fullyReadEvents = sorted.slice(0, sorted.length - clampedLimit)
+  const backlogEvents = sorted.slice(sorted.length - clampedLimit)
+  const partialCount = Math.floor(backlogEvents.length * backlogPartialReadRatio)
+  const partialEvents = backlogEvents.slice(0, partialCount)
+  const unreadEvents = backlogEvents.slice(partialCount)
+
+  console.log(
+    `Backlog limit: ${backlogLimit} cases — ` +
+    `${fullyReadEvents.length} fully read, ` +
+    `${partialEvents.length} partially read, ` +
+    `${unreadEvents.length} unread`
+  )
+
+  const updatedEvents = [...allEvents]
+
+  let baseTime = dayjs().subtract(72, 'hours')
+
+  // Fully read: 2 reads by secondReader and thirdReader
+  fullyReadEvents.forEach((event) => {
+    const index = updatedEvents.findIndex((e) => e.id === event.id)
+    if (index === -1) return
+    if (!updatedEvents[index].imageReading) {
+      updatedEvents[index].imageReading = { reads: {} }
+    }
+
+    baseTime = baseTime.add(1, 'minute')
+    const firstRead = generateSingleRead(
+      updatedEvents[index],
+      secondReader.id,
+      secondReader.role,
+      baseTime.toISOString(),
+      { readNumber: 1, alignmentProbability }
+    )
+    updatedEvents[index].imageReading.reads[secondReader.id] = firstRead
+
+    const secondRead = generateSingleRead(
+      updatedEvents[index],
+      thirdReader.id,
+      thirdReader.role,
+      baseTime.add(15, 'minutes').toISOString(),
+      { forceOpinion: firstRead.opinion, readNumber: 2, alignmentProbability }
+    )
+    updatedEvents[index].imageReading.reads[thirdReader.id] = secondRead
+  })
+
+  baseTime = dayjs().subtract(24, 'hours')
+
+  // Partially read: 1 read by firstReader (the current user) — so the current
+  // user has already read these and cannot read them again
+  partialEvents.forEach((event) => {
+    const index = updatedEvents.findIndex((e) => e.id === event.id)
+    if (index === -1) return
+    if (!updatedEvents[index].imageReading) {
+      updatedEvents[index].imageReading = { reads: {} }
+    }
+
+    baseTime = baseTime.add(1, 'minute')
+    const firstRead = generateSingleRead(
+      updatedEvents[index],
+      firstReader.id,
+      firstReader.role,
+      baseTime.toISOString(),
+      { readNumber: 1, alignmentProbability }
+    )
+    updatedEvents[index].imageReading.reads[firstReader.id] = firstRead
+  })
+
+  // Unread events: no reads added
+
+  return updatedEvents
+}
+
+/**
  * Generate sample image reading data to simulate first and second reads
  *
  * @param {Array} events - Array of screening events
@@ -362,6 +461,22 @@ const generateReadingData = (events, users, seedProfile = {}) => {
   )
 
   const recentEvents = events.filter((event) => eligibleForReading(event))
+
+  // If a backlog limit is set, use a simplified reading pattern instead of the
+  // default clinic-by-clinic pattern. backlogLimit=0 means empty backlog.
+  const backlogLimit = seedProfile?.reading?.backlogLimit ?? null
+  if (backlogLimit !== null) {
+    return generateReadingDataWithBacklogLimit(
+      events,
+      recentEvents,
+      { firstReader, secondReader, thirdReader },
+      {
+        backlogLimit,
+        backlogPartialReadRatio: seedProfile?.reading?.backlogPartialReadRatio ?? 0.5,
+        alignmentProbability
+      }
+    )
+  }
 
   // Sort by date (oldest first)
   const sortedEvents = [...recentEvents].sort(

--- a/app/lib/generators/seed-profiles.js
+++ b/app/lib/generators/seed-profiles.js
@@ -33,6 +33,13 @@ const SEED_DATA_PROFILE_DEFAULTS = {
   imageReading: {
     probabilityFirstReaderOpinionMatchesImages: 0.95
   },
+  reading: {
+    // null = no limit (use default clinic-pattern behaviour)
+    // 0 = empty backlog, n = limit backlog to n cases
+    backlogLimit: null,
+    // Of backlog cases, what fraction have already been read once by someone else
+    backlogPartialReadRatio: 0.5
+  },
   medicalInformation: {
     probabilityOfSymptoms: 0.05,
     probabilityOfHRT: 0.2,
@@ -274,6 +281,43 @@ const SEED_DATA_PROFILE_DEFINITIONS = [
             technical: 0.4
           }
         }
+      }
+    }
+  },
+  {
+    divider: true,
+    label: 'Reading backlog'
+  },
+  {
+    key: 'emptyBacklog',
+    label: 'Empty backlog',
+    description: 'No cases left to read',
+    settings: {
+      reading: {
+        backlogLimit: 0,
+        backlogPartialReadRatio: 0.5
+      }
+    }
+  },
+  {
+    key: 'smallBacklog',
+    label: 'Small backlog',
+    description: '20 cases to read, half already partially read',
+    settings: {
+      reading: {
+        backlogLimit: 20,
+        backlogPartialReadRatio: 0.5
+      }
+    }
+  },
+  {
+    key: 'mediumBacklog',
+    label: 'Medium backlog',
+    description: '50 cases to read, half already partially read',
+    settings: {
+      reading: {
+        backlogLimit: 50,
+        backlogPartialReadRatio: 0.5
       }
     }
   }

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -53,7 +53,7 @@ const getCustomOverridesFromBody = (body = {}, fallbackProfile = {}) => {
     imageSetSelection: body.imageSetSelection
   }
 
-  return convertPercentageOverrides(rawOverrides, {
+  const converted = convertPercentageOverrides(rawOverrides, {
     imageReading: fallbackProfile.imageReading,
     medicalInformation: fallbackProfile.medicalInformation,
     specialAppointment: fallbackProfile.specialAppointment,
@@ -61,6 +61,23 @@ const getCustomOverridesFromBody = (body = {}, fallbackProfile = {}) => {
     mammogram: fallbackProfile.mammogram,
     imageSetSelection: fallbackProfile.imageSetSelection
   })
+
+  // reading.backlogLimit is a plain integer (not a probability), so handle separately
+  const readingBody = body.reading || {}
+  const rawLimit = readingBody.backlogLimit
+  const parsedLimit = rawLimit === '' || rawLimit === undefined || rawLimit === null
+    ? null
+    : Number(rawLimit)
+
+  converted.reading = {
+    backlogLimit: Number.isNaN(parsedLimit) ? null : parsedLimit,
+    backlogPartialReadRatio: parsePercentageAsProbability(
+      readingBody.backlogPartialReadRatio,
+      fallbackProfile?.reading?.backlogPartialReadRatio
+    )
+  }
+
+  return converted
 }
 
 module.exports = (router) => {

--- a/app/views/settings/seed-profiles/custom.html
+++ b/app/views/settings/seed-profiles/custom.html
@@ -51,6 +51,33 @@
       value: formProfile.imageReading.probabilityFirstReaderOpinionMatchesImages * 100
     }) }}
 
+    <h2>Reading backlog</h2>
+    {{ input({
+      id: "backlogLimit",
+      name: "settings[seedProfiles][customForm][reading][backlogLimit]",
+      type: "number",
+      value: formProfile.reading.backlogLimit,
+      classes: "nhsuk-input--width-5",
+      label: {
+        text: "Backlog limit"
+      },
+      hint: {
+        text: "Maximum number of cases left unread. Leave blank for no limit (default behaviour)"
+      },
+      attributes: {
+        "min": "0",
+        "step": "1",
+        "inputmode": "numeric"
+      }
+    }) }}
+    {{ seedProfilePercentageInput({
+      id: "backlogPartialReadRatio",
+      name: "settings[seedProfiles][customForm][reading][backlogPartialReadRatio]",
+      label: "Already read by current user",
+      hint: "Of backlog cases, percentage already read by the current user (so unavailable to read again)",
+      value: formProfile.reading.backlogPartialReadRatio * 100
+    }) }}
+
     <h2>Medical information</h2>
     {{ seedProfilePercentageInput({ id: "probabilityOfSymptoms", name: "settings[seedProfiles][customForm][medicalInformation][probabilityOfSymptoms]", label: "Symptoms present", value: formProfile.medicalInformation.probabilityOfSymptoms * 100 }) }}
     {{ seedProfilePercentageInput({ id: "probabilityOfHRT", name: "settings[seedProfiles][customForm][medicalInformation][probabilityOfHRT]", label: "Hormone replacement therapy", value: formProfile.medicalInformation.probabilityOfHRT * 100 }) }}


### PR DESCRIPTION
## Description

Adds the ability to limit the number of readable cases - so we can more easily test empty states / scenarios where there are very few cases to read. 

For whatever limit is set, 50% of those cases will already have a first read by the current user. This lets us test scenarios where there are outstanding cases, but the current user can't do them.

## New seed profiles
Let you pick with some default limits
<img width="693" height="237" alt="Screenshot 2026-06-25 at 10 57 07" src="https://github.com/user-attachments/assets/f2c97d36-100e-44cc-8071-8271ad23d570" />

## Custom seed profile
<img width="425" height="271" alt="Screenshot 2026-06-25 at 10 57 17" src="https://github.com/user-attachments/assets/10f27f4b-0705-41f6-a4f6-a9abfa9ab9d4" />
