### PR TITLE
Image reading empty state bug fixes

### DIFF
--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -1952,6 +1952,7 @@ module.exports = {
   needsSecondRead,
 
   // Sessions
+  getEligibleCandidatesForSession,
   createReadingSession,
   getDefaultSessionName,
   generateSessionId,

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -12,6 +12,7 @@ const {
   canUserReadEvent,
   userHasReadEvent,
   writeReading,
+  getEligibleCandidatesForSession,
   createReadingSession,
   getFirstReadableEventInSession,
   getReadingSession,
@@ -270,16 +271,25 @@ module.exports = (router) => {
       filters.complexOnly = true
     }
 
+    const sessionOptions = {
+      type: type || 'custom',
+      name,
+      clinicId,
+      limit: limit ? parseInt(limit) : null,
+      lazy: lazy !== undefined ? lazy === 'true' : null,
+      filters
+    }
+
+    const candidates = getEligibleCandidatesForSession(data, sessionOptions)
+
+    if (candidates.length === 0) {
+      res.redirect('/reading')
+      return
+    }
+
     // Create the session
     try {
-      const session = createReadingSession(data, {
-        type: type || 'custom',
-        name,
-        clinicId,
-        limit: limit ? parseInt(limit) : null,
-        lazy: lazy !== undefined ? lazy === 'true' : null,
-        filters
-      })
+      const session = createReadingSession(data, sessionOptions)
 
       // Check if the request includes the redirect parameter
       if (redirect === 'list') {

--- a/app/views/reading/index-simple.html
+++ b/app/views/reading/index-simple.html
@@ -124,6 +124,8 @@
       href: "/reading/session/" + inProgressSession.id + "/resume"
     }) }}
 
+    <span class="nhsuk-u-secondary-text-colour app-nowrap nhsuk-body-s">{{ inProgressSession.userReadCount }} of {{ inProgressSession.targetSize }} cases read</span>
+
   {% elif userReadableTotal == 0 %}
 
     <h2>>There are no more cases available</h2>

--- a/app/views/reading/no-more-cases.html
+++ b/app/views/reading/no-more-cases.html
@@ -20,10 +20,10 @@
 
     <div class="nhsuk-button-group">
       {{ button({
-        text: "Review session overview",
+        text: "See session overview",
         href: "/reading/session/" + sessionId
       }) }}
-      <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit reading</a>
+      <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
     </div>
 
   </div>

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -316,13 +316,13 @@
             {# Placeholder rows for pending lazy session slots #}
             {% set placeholderRowsShown = 3 if pendingCount > 3 else pendingCount %}
             {% for i in range(0, placeholderRowsShown) %}
-            <tr class="app-placeholder-row{{ ' app-placeholder-row--with-more' if pendingCount > 3 and loop.last }}">
+            <tr class="app-placeholder-row{{ ' app-placeholder-row--with-more' if resumeEvent and pendingCount > 3 and loop.last }}">
               <td>
                 <span class="app-row-number nhsuk-u-secondary-text-colour app-nowrap nhsuk-body-s">{{ (userReadableEvents | length) + loop.index }}.</span>
               </td>
               <td>
                 <span class="app-placeholder-tag"></span>
-                {% if pendingCount > 3 and loop.last %}
+                {% if resumeEvent and pendingCount > 3 and loop.last %}
                   <span class="app-placeholder-more nhsuk-u-secondary-text-colour nhsuk-body-s">and {{ pendingCount - 3 }} more in this session</span>
                 {% endif %}
               </td>
@@ -553,13 +553,13 @@
           {# Placeholder rows for pending lazy session slots #}
           {% set placeholderRowsShown = 3 if pendingCount > 3 else pendingCount %}
           {% for i in range(0, placeholderRowsShown) %}
-          <tr class="app-placeholder-row{{ ' app-placeholder-row--with-more' if pendingCount > 3 and loop.last }}">
+          <tr class="app-placeholder-row{{ ' app-placeholder-row--with-more' if resumeEvent and pendingCount > 3 and loop.last }}">
             <td>
               <span class="app-row-number nhsuk-u-secondary-text-colour app-nowrap nhsuk-body-s">{{ (events | length) + loop.index }}.</span>
             </td>
             <td>
               <span class="app-placeholder-tag"></span>
-              {% if pendingCount > 3 and loop.last %}
+              {% if resumeEvent and pendingCount > 3 and loop.last %}
                 <span class="app-placeholder-more nhsuk-u-secondary-text-colour nhsuk-body-s">and {{ pendingCount - 3 }} more in this session</span>
               {% endif %}
             </td>


### PR DESCRIPTION
- Restored the in-progress session case-count text on the reading dashboard
- Hid “Start a new session” on the session complete page when no readable cases remain
- Removed “and x more in this session” placeholder text for sessions on session overview when there's no more cases