### PR TITLE
Fix backlog count on start page for image reading

### DIFF
--- a/app/views/reading/index-simple.html
+++ b/app/views/reading/index-simple.html
@@ -112,7 +112,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h1>{{ pageHeading }}</h1>
-      <p class="nhsuk-u-secondary-text-colour nhsuk-body-l">{{ userReadableTotal }} {{ "case" | pluralise(userReadableTotal) }} are awaiting an outcome</p>
+      <p class="nhsuk-u-secondary-text-colour nhsuk-body-l">{{ backlogTotal }} {{ "case" | pluralise(backlogTotal) }} are awaiting an outcome</p>
 
   {% if inProgressSession %}
 


### PR DESCRIPTION
Show total backlog of cases rather than user-readable cases