### PR TITLE
Pre-set abnormality type from details page

### DIFF
--- a/app/assets/sass/components/_annotation-list.scss
+++ b/app/assets/sass/components/_annotation-list.scss
@@ -13,7 +13,7 @@
 .app-annotation-list__empty {
   @include nhsuk-font(19);
   color: $nhsuk-secondary-text-colour;
-  margin: 0;
+  // margin: 0;
 }
 
 // ─── OL reset ─────────────────────────────────────────────────────────────────

--- a/app/assets/sass/components/_modal.scss
+++ b/app/assets/sass/components/_modal.scss
@@ -1,6 +1,6 @@
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
 
-$app-modal-width: 800px !default;
+$app-modal-width: 900px !default;
 
 // Prevent background scrolling when modal is open
 body.app-modal-open {

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -1056,9 +1056,13 @@ module.exports = (router) => {
       const totalAnnotations = leftAnnotations.length + rightAnnotations.length
       const annotationNumber = totalAnnotations + 1
 
+      // Pre-populate abnormality type if passed from per-type button
+      const { abnormalityType } = req.query
+
       data.imageReadingTemp.annotationTemp = {
         side: side,
-        annotationNumber: annotationNumber
+        annotationNumber: annotationNumber,
+        abnormalityTypes: abnormalityType ? [abnormalityType] : undefined
       }
 
       res.redirect(
@@ -1475,6 +1479,26 @@ module.exports = (router) => {
         return res.redirect(
           `/reading/session/${sessionId}/events/${eventId}/annotation/add?side=${addAnnotationSide}`
         )
+      }
+
+      // Per-type annotation button — value is "side|abnormality type"
+      const addAnnotationSideType = req.body.addAnnotationSideType
+      if (addAnnotationSideType) {
+        const pipeIndex = addAnnotationSideType.indexOf('|')
+        const side =
+          pipeIndex > -1
+            ? addAnnotationSideType.slice(0, pipeIndex)
+            : addAnnotationSideType
+        const abnormalityType =
+          pipeIndex > -1 ? addAnnotationSideType.slice(pipeIndex + 1) : ''
+        if (['left', 'right'].includes(side)) {
+          const typeParam = abnormalityType
+            ? `&abnormalityType=${encodeURIComponent(abnormalityType)}`
+            : ''
+          return res.redirect(
+            `/reading/session/${sessionId}/events/${eventId}/annotation/add?side=${side}${typeParam}`
+          )
+        }
       }
 
       res.redirect(

--- a/app/views/reading/workflow/annotation.html
+++ b/app/views/reading/workflow/annotation.html
@@ -107,19 +107,17 @@
             value: "save"
           }
         }) }}
-      </div>
 
-      {# Only show delete link if this is a previously saved annotation #}
-      {% if annotation.id %}
-        {% set deleteHref %}
-          ./annotation/delete/{{ annotation.id }}
-        {% endset %}
-        <p class="nhsuk-u-margin-top-4">
+        {# Only show delete link if this is a previously saved annotation #}
+        {% if annotation.id %}
+          {% set deleteHref %}
+            ./annotation/delete/{{ annotation.id }}
+          {% endset %}
           <a href="{{ deleteHref }}" class="nhsuk-link app-link--warning">
             Delete this annotation
           </a>
-        </p>
-      {% endif %}
+        {% endif %}
+      </div>
 
       {# Hidden fields #}
       {{ appHiddenInput({

--- a/app/views/reading/workflow/recall-for-assessment-details.html
+++ b/app/views/reading/workflow/recall-for-assessment-details.html
@@ -171,7 +171,8 @@
             annotations: sideAnnotations,
             editable: true,
             editHrefPrefix: "./annotation/edit/",
-            useModals: data.settings.modalForms == 'true'
+            useModals: data.settings.modalForms == 'true',
+            classes: "nhsuk-u-margin-bottom-3" if sideAnnotations | length > 0
           }) }}
 
           <span hidden data-annotation-count="{{ breastSide }}" data-count="{{ sideAnnotations | length }}"></span>
@@ -181,6 +182,9 @@
            Submitting the form (rather than following a link) ensures all radio selections
            are saved to session before navigating to the annotation page. #}
         {% set sideAnnotationsButtonHtml %}
+
+          {# Original single button — commented out in favour of per-type buttons below #}
+          {#
           {{ button({
             text: "Add another annotation" if sideAnnotations | length > 0 else "Add annotation",
             variant: "secondary",
@@ -190,6 +194,27 @@
             value: breastSide,
             attributes: { "data-modal-submit": "" } if data.settings.modalForms == 'true'
           }) }}
+          #}
+
+          {# Per-type annotation buttons — one per abnormality type.
+             The value encodes side and type separated by "|", parsed in the route. #}
+          {# <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible nhsuk-u-margin-top-3"> #}
+          {% if sideAnnotations | length > 0 %}
+            <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">Add another annotation</h4>
+          {% endif %}
+          <div class="nhsuk-button-group app-button-group--small">
+            {% for abnormalityType in data.abnormalityTypes %}
+              {{ button({
+                text: abnormalityType,
+                variant: "secondary",
+                small: true,
+                name: "addAnnotationSideType",
+                value: breastSide + "|" + abnormalityType,
+                attributes: { "data-modal-submit": "" } if data.settings.modalForms == 'true'
+              }) }}
+            {% endfor %}
+          </div>
+
         {% endset %}
 
       {% endif %}


### PR DESCRIPTION
## Description

Swaps the 'Add annotation' button for a selection of buttons so a user starts by picking the abnormality type and then adds the details. This saves a click of our users and leads them towards telling us about what they see. 

At the moment this just pre-checks the appropriate checkbox on the annotation form. In the future we could perahps collapse this area and provide some mechanism to add additional items.

If an annotation for that breast has already been added, then a heading is added 'Add another annotation' so users can add more (though rare).

<img width="2576" height="2238" alt="Screenshot 2026-07-03 at 15 39 10" src="https://github.com/user-attachments/assets/151ddfb1-60cc-476b-8261-6b02ccd16544" />
