### PR TITLE
Update opinion page

### DIFF
--- a/app/assets/javascript/breast-features.js
+++ b/app/assets/javascript/breast-features.js
@@ -1284,3 +1284,13 @@ window.addEventListener('load', function () {
     initializeBreastFeatures()
   }
 })
+
+// Re-initialize when a modal loads content that includes the breast diagram.
+// Module scripts are cached by the browser and do not re-execute when the modal
+// re-creates the <script> element, so we rely on the app:init event instead.
+document.addEventListener('app:init', function () {
+  if (document.querySelector('.breast-features__diagram')) {
+    window.breastFeaturesInitialized = false
+    initializeBreastFeatures()
+  }
+})

--- a/app/assets/sass/_app-styles.scss
+++ b/app/assets/sass/_app-styles.scss
@@ -13,6 +13,7 @@
 @forward "components/secondary-navigation";
 @forward "components/secondary-navigation-overrides";
 @forward "components/count";
+@forward "components/card";
 @forward "components/forward-link";
 @forward "components/status";
 @forward "components/status-bar";

--- a/app/assets/sass/_misc.scss
+++ b/app/assets/sass/_misc.scss
@@ -53,6 +53,46 @@ body.js-enabled .app-no-js-only {
   width: 100%;
 }
 
+// Taller button variant — used for primary action buttons on the reading opinion page
+.app-button--tall {
+  padding-top: nhsuk-spacing(3);
+  padding-bottom: nhsuk-spacing(3);
+}
+
+// Equal-width button group — CSS Grid places 3 buttons in row 1 (uniform height)
+// and the optional sub-action link in row 2 col 1. Used on the reading opinion page.
+.app-button-group--equal {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: nhsuk-spacing(3);
+
+  .nhsuk-button {
+    margin-bottom: 0;
+    width: 100%;
+  }
+}
+
+// Sub-action link (e.g. "Normal, but add details") — pinned to row 2 col 1 in the grid,
+// constrained to the same width as the Normal button above it.
+.app-button-group__sub-action {
+  grid-column: 1;
+  grid-row: 2;
+  margin-bottom: 0;
+}
+
+// Opinion button layout switching — stacked shown on mobile, horizontal shown on tablet+
+.app-opinion-buttons--horizontal {
+  @include nhsuk-media-query($until: tablet) {
+    display: none;
+  }
+}
+
+.app-opinion-buttons--stacked {
+  @include nhsuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
 // Reduce space taken by card
 .nhsuk-card {
   @include nhsuk-responsive-margin(4, "bottom");

--- a/app/assets/sass/_misc.scss
+++ b/app/assets/sass/_misc.scss
@@ -53,12 +53,6 @@ body.js-enabled .app-no-js-only {
   width: 100%;
 }
 
-// Taller button variant — used for primary action buttons on the reading opinion page
-.app-button--tall {
-  padding-top: nhsuk-spacing(3);
-  padding-bottom: nhsuk-spacing(3);
-}
-
 // Equal-width button group — CSS Grid places 3 buttons in row 1 (uniform height)
 // and the optional sub-action link in row 2 col 1. Used on the reading opinion page.
 .app-button-group--equal {

--- a/app/assets/sass/components/_card.scss
+++ b/app/assets/sass/components/_card.scss
@@ -1,0 +1,6 @@
+@use "nhsuk-frontend/dist/nhsuk/core" as *;
+
+.nhsuk-card--feature.app-card--feature-subtle .nhsuk-card__heading {
+  background-color: nhsuk-colour("grey-4");
+  color: $nhsuk-text-colour;
+}

--- a/app/assets/sass/components/_card.scss
+++ b/app/assets/sass/components/_card.scss
@@ -1,6 +1,10 @@
+@use "sass:color";
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
 
-.nhsuk-card--feature.app-card--feature-subtle .nhsuk-card__heading {
-  background-color: nhsuk-colour("grey-4");
-  color: $nhsuk-text-colour;
+.nhsuk-card--feature.app-card--feature-grey {
+  background-color: color.scale(nhsuk-colour("grey-4"), $alpha: -50%) !important;
+}
+.nhsuk-card--feature.app-card--feature-grey .nhsuk-card__heading {
+  background-color: nhsuk-colour("grey-1");
+  color: nhsuk-colour("white");
 }

--- a/app/assets/sass/components/_mammogram-images.scss
+++ b/app/assets/sass/components/_mammogram-images.scss
@@ -53,6 +53,10 @@
 
   @include nhsuk-media-query($from: 900px) {
     flex: 1;
+    // Pull the column up to counteract the feature card's nhsuk-responsive-margin(7)
+    // top margin (48px at this breakpoint), reducing the gap below the h1.
+    // The images column is offset by the remainder to maintain alignment.
+    margin-top: -(nhsuk-spacing(5)); // -32px
   }
 }
 
@@ -64,6 +68,9 @@
     flex: 0 0 auto;
     width: 100%;
     max-width: 300px;
+    // Offset to align the images card with the top edge of the opinion feature card:
+    // feature card margin-top (48px) minus the main column pull-up (32px) = 16px.
+    margin-top: nhsuk-spacing(3); // 16px
   }
 }
 

--- a/app/assets/sass/components/_mammogram-images.scss
+++ b/app/assets/sass/components/_mammogram-images.scss
@@ -41,40 +41,30 @@
 }
 
 // Two-column layout for the reading opinion page: main content + images sidebar.
-// Flexbox approach so the images column has a fixed max-width and main takes the rest.
+// Float-based layout — main column takes remaining space via calc, images column is fixed width.
 .app-reading-opinion-columns {
-  @include nhsuk-media-query($from: 900px) {
-    display: flex;
-    gap: $nhsuk-gutter;
-    align-items: flex-start;
+  @include nhsuk-media-query($from: large-desktop) {
+    @include nhsuk-clearfix;
   }
 }
 
 .app-grid-column-main {
-  min-width: 0;
-
-  @include nhsuk-media-query($from: 900px) {
-    flex: 1;
+  @include nhsuk-media-query($from: large-desktop) {
+    float: left;
+    box-sizing: border-box;
+    width: calc(100% - 300px);
+    padding-right: $nhsuk-gutter;
   }
 }
 
 .app-grid-column-images {
   display: none;
 
-  @include nhsuk-media-query($from: 900px) {
+  @include nhsuk-media-query($from: large-desktop) {
     display: block;
-    flex: 0 0 auto;
-    width: 100%;
-    max-width: 300px;
-  }
-
-  .nhsuk-card {
-    background-color: color.scale(nhsuk-colour("grey-4"), $alpha: -50%);
-  }
-
-  .nhsuk-card__heading {
-    background-color: $nhsuk-secondary-text-colour !important;
-    color: nhsuk-colour("white");
+    float: right;
+    box-sizing: border-box;
+    width: 300px;
   }
 }
 

--- a/app/assets/sass/components/_mammogram-images.scss
+++ b/app/assets/sass/components/_mammogram-images.scss
@@ -187,7 +187,7 @@
   width: 100%;
   height: 100%;
   border: 2px dashed nhsuk-colour("grey-2");
-  background-color: nhsuk-colour("grey-5");
+  background-color: nhsuk-colour("grey-4");
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/assets/sass/components/_mammogram-images.scss
+++ b/app/assets/sass/components/_mammogram-images.scss
@@ -38,6 +38,35 @@
   text-align: right;
 }
 
+// Two-column layout for the reading opinion page: main content + images sidebar.
+// Flexbox approach so the images column has a fixed max-width and main takes the rest.
+.app-reading-opinion-columns {
+  @include nhsuk-media-query($from: 900px) {
+    display: flex;
+    gap: $nhsuk-gutter;
+    align-items: flex-start;
+  }
+}
+
+.app-grid-column-main {
+  min-width: 0;
+
+  @include nhsuk-media-query($from: 900px) {
+    flex: 1;
+  }
+}
+
+.app-grid-column-images {
+  display: none;
+
+  @include nhsuk-media-query($from: 900px) {
+    display: block;
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: 300px;
+  }
+}
+
 // Thumbnail grid for the reading opinion page
 .app-mammogram-thumbnails {
   display: grid;

--- a/app/assets/sass/components/_mammogram-images.scss
+++ b/app/assets/sass/components/_mammogram-images.scss
@@ -40,13 +40,19 @@
 
 // Thumbnail grid for the reading opinion page
 .app-mammogram-thumbnails {
-  display: inline-grid;
-  grid-template-columns: auto auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
   gap: 8px;
 
   // Match the tighter grid gap for same-view images within the reading layout
   .app-mammogram-thumbnail {
     gap: 8px;
+  }
+
+  // Allow thumbnails to scale to fill the available column width
+  .app-mammogram-thumbnail__image-wrapper {
+    max-width: none;
   }
 }
 
@@ -121,7 +127,7 @@
   background-color: nhsuk-colour("blue");
   color: #fff;
   padding: 2px 6px;
-  font-size: 11px;
+  font-size: 14px;
   font-weight: 600;
   z-index: 1;
 }

--- a/app/assets/sass/components/_mammogram-images.scss
+++ b/app/assets/sass/components/_mammogram-images.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @use "nhsuk-frontend/dist/nhsuk/core" as *;
 
 // app/assets/sass/components/_mammogram-images.scss
@@ -53,10 +55,6 @@
 
   @include nhsuk-media-query($from: 900px) {
     flex: 1;
-    // Pull the column up to counteract the feature card's nhsuk-responsive-margin(7)
-    // top margin (48px at this breakpoint), reducing the gap below the h1.
-    // The images column is offset by the remainder to maintain alignment.
-    margin-top: -(nhsuk-spacing(5)); // -32px
   }
 }
 
@@ -68,9 +66,15 @@
     flex: 0 0 auto;
     width: 100%;
     max-width: 300px;
-    // Offset to align the images card with the top edge of the opinion feature card:
-    // feature card margin-top (48px) minus the main column pull-up (32px) = 16px.
-    margin-top: nhsuk-spacing(3); // 16px
+  }
+
+  .nhsuk-card {
+    background-color: color.scale(nhsuk-colour("grey-4"), $alpha: -50%);
+  }
+
+  .nhsuk-card__heading {
+    background-color: $nhsuk-secondary-text-colour !important;
+    color: nhsuk-colour("white");
   }
 }
 

--- a/app/assets/sass/components/_modal.scss
+++ b/app/assets/sass/components/_modal.scss
@@ -64,6 +64,7 @@ body.app-modal-open {
 // Close button — black square with white ×, flush with top-right of modal border
 .app-modal__close {
   position: absolute;
+  z-index: 1; // stay above scrollable content (cards etc.) inside the modal
   top: -$nhsuk-focus-width;
   right: -$nhsuk-focus-width;
   display: flex;

--- a/app/assets/sass/components/_reading.scss
+++ b/app/assets/sass/components/_reading.scss
@@ -302,7 +302,7 @@
 
 // Force shortcut hint onto its own line inside buttons
 .nhsuk-button .app-shortcut-hint {
-  display: block;
+  // display: block;
 }
 
 // Compare opinions: card colours by read opinion

--- a/app/assets/sass/components/_reading.scss
+++ b/app/assets/sass/components/_reading.scss
@@ -300,6 +300,11 @@
   opacity: 0.8;
 }
 
+// Force shortcut hint onto its own line inside buttons
+.nhsuk-button .app-shortcut-hint {
+  display: block;
+}
+
 // Compare opinions: card colours by read opinion
 .app-reading-compare-card.nhsuk-card--feature {
   outline: 2px solid nhsuk-colour("grey-3");
@@ -390,5 +395,3 @@
     padding-top: nhsuk-spacing(4);
   }
 }
-
-

--- a/app/assets/sass/components/_status-bar.scss
+++ b/app/assets/sass/components/_status-bar.scss
@@ -45,7 +45,7 @@
 }
 
 .app-status-bar__key {
-  @include nhsuk-typography-weight-bold($important: true);
+  @include nhsuk-font-weight-bold($important: true);
   opacity: 0.9;
 }
 

--- a/app/assets/sass/components/_summary-card.scss
+++ b/app/assets/sass/components/_summary-card.scss
@@ -73,7 +73,7 @@
 
 .nhsuk-summary-card__actions {
   @include nhsuk-font-size($size: 19);
-  @include nhsuk-typography-weight-bold;
+  @include nhsuk-font-weight-bold;
   display: flex;
   flex-wrap: wrap;
   row-gap: 10px;
@@ -133,7 +133,7 @@
   border: none;
 
   .nhsuk-summary-card__actions {
-    @include nhsuk-typography-weight-normal;
+    @include nhsuk-font-weight-normal;
   }
 
   .nhsuk-summary-card__action {

--- a/app/assets/sass/main-compact.scss
+++ b/app/assets/sass/main-compact.scss
@@ -6,6 +6,8 @@
 @forward "nhsuk-frontend/dist/nhsuk/nhsuk" with (
   $nhsuk-page-width: 960px,
 
+  $nhsuk-gutter: 24px,
+
   // Reduce layout spacing points (5–9). Points 0–4 stay at NHS defaults.
   // Note: checkbox and radio input sizes are decoupled from the spacing scale
   // since nhsuk-frontend 10.5 (fix #1934), so spacing(6) no longer affects input geometry.

--- a/app/lib/generators/seed-profiles.js
+++ b/app/lib/generators/seed-profiles.js
@@ -285,6 +285,16 @@ const SEED_DATA_PROFILE_DEFINITIONS = [
     }
   },
   {
+    key: 'highPriorMammograms',
+    label: 'High prior mammograms',
+    description: 'All participants have prior mammogram images to request',
+    settings: {
+      previousMammograms: {
+        rate: 1
+      }
+    }
+  },
+  {
     divider: true,
     label: 'Reading backlog'
   },

--- a/app/lib/utils/prior-mammograms.js
+++ b/app/lib/utils/prior-mammograms.js
@@ -118,49 +118,76 @@ const userRequestedPriors = (event, userId) => {
  * @param {Object} [options] - Optional config
  * @param {string} [options.unitName] - Display name for the current BSU (used when location === 'currentBsu')
  * @param {boolean} [options.includeAdditionalInfo] - Whether to append otherDetails (default: false)
- * @returns {string} One-line summary, e.g. "St James's Hospital (March 2018, 8 years ago)"
+ * @param {boolean} [options.includeDate] - Whether to append the parenthesised date detail (default: true)
+ * @param {string} [options.prefix] - Optional leading verb, e.g. "Taken"; the location phrase then reads lower case after it
+ * @returns {string} One-line summary, e.g. "At another BSU: St James's Hospital (March 2018)"
  */
 const summarisePriorMammogram = (mammogram, options = {}) => {
   if (!mammogram) return ''
 
-  const { unitName = null, includeAdditionalInfo = false } = options
+  const {
+    unitName = null,
+    includeAdditionalInfo = false,
+    includeDate = true,
+    prefix = null
+  } = options
 
-  // Location part (primary label)
-  let location = ''
+  // Location: a generic category phrase, plus the specific place the
+  // participant named where we have one, e.g. "at another BSU: St James's".
+  // Phrases are lower case so they read after a prefix ("Taken at another
+  // BSU…"); when there's no prefix the first letter is capitalised so the
+  // phrase reads at the start of a line or list item.
+  let place = ''
+  let specificPlace = ''
   switch (mammogram.location) {
     case 'bsu':
-      location = 'At another BSU'
+      place = 'at another BSU'
+      specificPlace = mammogram.bsu
       break
     case 'otherUk':
-      location = 'Elsewhere in the UK'
+      place = 'elsewhere in the UK'
+      specificPlace = mammogram.otherUk
       break
     case 'otherNonUk':
-      location = 'Outside the UK'
+      place = 'outside the UK'
+      specificPlace = mammogram.otherNonUk
       break
     case 'currentBsu':
-      location = `At ${unitName || 'this BSU'}`
+      place = `at ${unitName || 'this BSU'}`
       break
     case 'preferNotToSay':
-      location = 'Location not provided'
+      place = 'at an undisclosed location'
       break
     default:
-      location = ''
+      place = ''
   }
 
-  // Date detail — combine formatted date and relative time into parenthesised suffix
+  let location = specificPlace ? `${place}: ${specificPlace}` : place
+
+  if (location) {
+    if (prefix) {
+      location = `${prefix} ${location}`
+    } else {
+      location = location.charAt(0).toUpperCase() + location.slice(1)
+    }
+  }
+
+  // Date detail — parenthesised suffix. Uses the participant's approximate
+  // wording when they didn't give an exact date.
   const dateParts = []
   if (mammogram.dateType === 'dateKnown' && mammogram.dateTaken) {
-    dateParts.push(formatDate(mammogram.dateTaken, 'MMM YYYY'))
+    dateParts.push(formatDate(mammogram.dateTaken, 'MMMM YYYY'))
     if (mammogram._rawDate) {
       dateParts.push(formatRelativeDate(mammogram._rawDate))
     }
   } else if (mammogram.dateType === 'moreThanSixMonths') {
-    dateParts.push('over 6 months ago')
+    dateParts.push(mammogram.approximateDate || 'over 6 months ago')
   } else if (mammogram.dateType === 'lessThanSixMonths') {
     dateParts.push('less than 6 months ago')
   }
 
-  const dateDetail = dateParts.length > 0 ? `(${dateParts.join(', ')})` : ''
+  const dateDetail =
+    includeDate && dateParts.length > 0 ? `(${dateParts.join(', ')})` : ''
 
   // Optional additional information appended as a separate sentence
   const additionalInfo =

--- a/app/views/_includes/mammogram-image-display.njk
+++ b/app/views/_includes/mammogram-image-display.njk
@@ -9,6 +9,54 @@
   - hideAdditionalDetails: boolean - suppress repeat/extra image details
 #}
 
+{% set additionalDetailsHtml %}
+  {% if not hideAdditionalDetails and (viewItem.repeatCount > 0 or imageCount > 1) %}
+    {% set repeatCount = viewItem.repeatCount or 0 %}
+    {% set extraCount = (imageCount - 1) - repeatCount %}
+    
+    {% set additionalDetailsHtml %}
+      {# Show repeat information #}
+      {% if repeatCount > 0 %}
+        <p class="nhsuk-u-margin-bottom-2">
+          {{ repeatCount }} {{ 'repeat' | pluralise(repeatCount) }} taken
+        </p>
+        {% if viewItem.repeatReasons and viewItem.repeatReasons | length > 0 %}
+          {% if viewItem.repeatReasons | length == 1 %}
+            <p class="nhsuk-u-margin-bottom-2">
+              {{ viewItem.repeatReasons[0] }}
+            </p>
+          {% else %}
+            <p class="nhsuk-u-margin-bottom-2"><strong>Repeat reasons:</strong></p>
+            <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-margin-bottom-2">
+              {% for reason in viewItem.repeatReasons %}
+                <li>{{ reason }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endif %}
+      {% endif %}
+      
+      {# Show extra image information #}
+      {% if extraCount > 0 %}
+        <p class="nhsuk-u-margin-bottom-0">
+          {% if extraCount == 1 %}
+            An extra image was taken to capture the complete view.
+          {% else %}
+            {{ extraCount }} extra images were taken to capture the complete view.
+          {% endif %}
+        </p>
+      {% endif %}
+    {% endset %}
+    
+    <div class="nhsuk-u-margin-top-3">
+      {{ details({
+        summaryText: "Additional image details",
+        html: additionalDetailsHtml
+      }) }}
+    </div>
+  {% endif %}
+{% endset %}
+
 <div class="app-mammogram-view--{{ viewItem.side }}">
 
   {% if isManualEntry %}
@@ -69,51 +117,8 @@
       </div>
 
       {# Additional image details (repeats and extras) #}
-      {% if not hideAdditionalDetails and (viewItem.repeatCount > 0 or imageCount > 1) %}
-        {% set repeatCount = viewItem.repeatCount or 0 %}
-        {% set extraCount = (imageCount - 1) - repeatCount %}
-        
-        {% set additionalDetailsHtml %}
-          {# Show repeat information #}
-          {% if repeatCount > 0 %}
-            <p class="nhsuk-u-margin-bottom-2">
-              {{ repeatCount }} {{ 'repeat' | pluralise(repeatCount) }} taken
-            </p>
-            {% if viewItem.repeatReasons and viewItem.repeatReasons | length > 0 %}
-              {% if viewItem.repeatReasons | length == 1 %}
-                <p class="nhsuk-u-margin-bottom-2">
-                  {{ viewItem.repeatReasons[0] }}
-                </p>
-              {% else %}
-                <p class="nhsuk-u-margin-bottom-2"><strong>Repeat reasons:</strong></p>
-                <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-margin-bottom-2">
-                  {% for reason in viewItem.repeatReasons %}
-                    <li>{{ reason }}</li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
-            {% endif %}
-          {% endif %}
-          
-          {# Show extra image information #}
-          {% if extraCount > 0 %}
-            <p class="nhsuk-u-margin-bottom-0">
-              {% if extraCount == 1 %}
-                An extra image was taken to capture the complete view.
-              {% else %}
-                {{ extraCount }} extra images were taken to capture the complete view.
-              {% endif %}
-            </p>
-          {% endif %}
-        {% endset %}
-        
-        <div class="nhsuk-u-margin-top-3">
-          {{ details({
-            summaryText: "Additional image details",
-            html: additionalDetailsHtml
-          }) }}
-        </div>
-      {% endif %}
+      {# {{ additionalDetailsHtml | safe }} #}
+
     {% endif %}
 
   {% endif %}

--- a/app/views/_includes/reading/image-warnings.njk
+++ b/app/views/_includes/reading/image-warnings.njk
@@ -78,16 +78,7 @@
   }) %}
 {% endif %}
 
-{# Render feature card if any rows #}
+{# Render summary list if any rows #}
 {% if imageWarningRows | length %}
-  {% set imageWarningSummaryHtml %}
-    {{ summaryList({ rows: imageWarningRows, lastRowBorder: false }) }}
-  {% endset %}
-  {{ card({
-    heading: "Image notes",
-    headingLevel: "2",
-    feature: true,
-    classes: "app-card--feature-subtle",
-    descriptionHtml: imageWarningSummaryHtml
-  }) }}
+  {{ summaryList({ rows: imageWarningRows, lastRowBorder: false }) }}
 {% endif %}

--- a/app/views/_includes/reading/image-warnings.njk
+++ b/app/views/_includes/reading/image-warnings.njk
@@ -86,7 +86,7 @@
   {{ card({
     heading: "Image notes",
     headingLevel: "2",
-    feature: true,
+    feature: false,
     descriptionHtml: imageWarningSummaryHtml
   }) }}
 {% endif %}

--- a/app/views/_includes/reading/image-warnings.njk
+++ b/app/views/_includes/reading/image-warnings.njk
@@ -86,7 +86,8 @@
   {{ card({
     heading: "Image notes",
     headingLevel: "2",
-    feature: false,
+    feature: true,
+    classes: "app-card--feature-subtle",
     descriptionHtml: imageWarningSummaryHtml
   }) }}
 {% endif %}

--- a/app/views/_includes/reading/image-warnings.njk
+++ b/app/views/_includes/reading/image-warnings.njk
@@ -1,40 +1,36 @@
 {# app/views/_includes/reading/image-warnings.njk #}
-{# Displays warnings and notes for the reader inside an inset text component #}
+{# Displays image warnings and notes for the reader in a feature card with summary list #}
 
-{% set warningsHtml = "" %}
+{% set imageWarningRows = [] %}
 
-{# 1. Imperfect #}
+{# 1. Image quality (imperfect but best possible) #}
 {% if event.mammogramData.isImperfectButBestPossible and event.mammogramData.isImperfectButBestPossible | includes("yes") %}
-  {% set warningsHtml %}
-    {{ warningsHtml | safe }}
-    <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Image quality</h3>
-    <p>Imperfect, but best possible images</p>
-  {% endset %}
+  {% set imageWarningRows = imageWarningRows | push({
+    key: { text: "Image quality" },
+    value: { text: "Imperfect, but best possible images" }
+  }) %}
 {% endif %}
 
 {# 2. Additional images (repeats or extra images for large breasts) #}
 {% if event.mammogramData.metadata.hasAdditionalImages %}
-  {% set additionalImagesDetail %}
-    {% if event.mammogramData.metadata.hasRepeat and event.mammogramData.metadata.hasExtraImages %}
-      Some views were retaken. Extra images were also taken for large breasts.
-    {% elseif event.mammogramData.metadata.hasRepeat %}
-      Some views were retaken due to technical issues.
-    {% elseif event.mammogramData.metadata.hasExtraImages %}
-      Extra images were taken to ensure full coverage for large breasts.
-    {% else %}
-      Some views have additional images.
-    {% endif %}
-  {% endset %}
-  {% set warningsHtml %}
-    {{ warningsHtml | safe }}
-    <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2 {{ 'nhsuk-u-margin-top-0' if warningsHtml }}">Additional images</h3>
-    <p>{{ additionalImagesDetail | trim }}</p>
-  {% endset %}
+  {% if event.mammogramData.metadata.hasRepeat and event.mammogramData.metadata.hasExtraImages %}
+    {% set additionalImagesText = "Some views were retaken. Extra images were also taken for large breasts." %}
+  {% elseif event.mammogramData.metadata.hasRepeat %}
+    {% set additionalImagesText = "Some views were retaken due to technical issues." %}
+  {% elseif event.mammogramData.metadata.hasExtraImages %}
+    {% set additionalImagesText = "Extra images were taken to ensure full coverage for large breasts." %}
+  {% else %}
+    {% set additionalImagesText = "Some views have additional images." %}
+  {% endif %}
+  {% set imageWarningRows = imageWarningRows | push({
+    key: { text: "Additional images" },
+    value: { text: additionalImagesText }
+  }) %}
 {% endif %}
 
-{# 3. Incomplete #}
+{# 3. Incomplete mammography #}
 {% if event.mammogramData.isIncompleteMammography and event.mammogramData.isIncompleteMammography | includes("yes") %}
-  {% set incompleteDetails %}
+  {% set incompleteValueHtml %}
     {% if event.mammogramData.incompleteMammographyReasons and event.mammogramData.incompleteMammographyReasons | length > 0 %}
       {% if event.mammogramData.incompleteMammographyReasons | length == 1 %}
         <p class="nhsuk-u-margin-bottom-2">Reason: {{ event.mammogramData.incompleteMammographyReasons[0] | lower }}</p>
@@ -55,46 +51,42 @@
       {% if followUpValue.startsWith("No") %}
         {{ tag({
           text: "Partial mammography",
-          colour: "orange",
-          classes: "nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2"
+          colour: "orange"
         }) }}
       {% else %}
         {{ tag({
           text: "Recall requested",
-          colour: "orange",
-          classes: "nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-2"
+          colour: "orange"
         }) }}
         {% if event.mammogramData.incompleteMammographyFollowUpAppointmentDetails %}
-          <p class="nhsuk-u-margin-bottom-0">Note for scheduling recall appointment:<br>{{ event.mammogramData.incompleteMammographyFollowUpAppointmentDetails }}</p>
+          <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">Note for scheduling recall appointment:<br>{{ event.mammogramData.incompleteMammographyFollowUpAppointmentDetails }}</p>
         {% endif %}
       {% endif %}
     {% endif %}
   {% endset %}
-
-  {% set warningsHtml %}
-    {{ warningsHtml | safe }}
-    <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2 {{ 'nhsuk-u-margin-top-0' if warningsHtml }}">Not all mammograms taken</h3>
-    {{ incompleteDetails | safe }}
-  {% endset %}
+  {% set imageWarningRows = imageWarningRows | push({
+    key: { text: "Not all images taken" },
+    value: { html: incompleteValueHtml }
+  }) %}
 {% endif %}
 
 {# 4. Notes for reader #}
 {% if event.mammogramData.notesForReader %}
-  {% set warningsHtml %}
-    {{ warningsHtml | safe }}
-    <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2 {{ 'nhsuk-u-margin-top-0' if warningsHtml }}">Notes for reader</h3>
-    <p>{{ event.mammogramData.notesForReader }}</p>
-  {% endset %}
+  {% set imageWarningRows = imageWarningRows | push({
+    key: { text: "Notes for reader" },
+    value: { text: event.mammogramData.notesForReader }
+  }) %}
 {% endif %}
 
-{# Render inInset Text if content exists #}
-{% if warningsHtml %}
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-two-thirds">
-      {{ insetText({
-        html: warningsHtml,
-        classes: ""
-      }) }}
-    </div>
-  </div>
+{# Render feature card if any rows #}
+{% if imageWarningRows | length %}
+  {% set imageWarningSummaryHtml %}
+    {{ summaryList({ rows: imageWarningRows, lastRowBorder: false }) }}
+  {% endset %}
+  {{ card({
+    heading: "Image notes",
+    headingLevel: "2",
+    feature: true,
+    descriptionHtml: imageWarningSummaryHtml
+  }) }}
 {% endif %}

--- a/app/views/_includes/reading/priors-summary.njk
+++ b/app/views/_includes/reading/priors-summary.njk
@@ -1,0 +1,81 @@
+{# app/views/_includes/reading/priors-summary.njk #}
+{# Displays previous (prior) mammograms for the reader as a summary list.
+   One row per prior:
+     key   - status tag plus when the mammogram was taken
+     value - where it was taken, any additional details, and the request
+             timeline (when requested / received / updated, and by whom)
+   Priors that have never been requested get a "Request priors" action.
+
+   Expects: event, unit #}
+
+{% set priorsSummary = event | getPriorsSummary %}
+
+{% if priorsSummary.total > 0 %}
+
+  {% set priorRows = [] %}
+  {% for mammogram in event.previousMammograms %}
+
+    {# When the mammogram was taken - full month and year, or the participant's approximate date #}
+    {% set priorDateLabel = (mammogram.approximateDate if mammogram.dateType == "moreThanSixMonths" else (mammogram.dateTaken | formatDate("MMMM YYYY"))) | capitalize %}
+
+    {# Key: when the mammogram was taken (bold), with the status tag beneath #}
+    {% set priorKeyHtml %}
+      {% if priorDateLabel %}{{ priorDateLabel }}{% else %}Date not known{% endif %}
+      <span class="nhsuk-u-display-block nhsuk-u-margin-top-1">{{ ("prior_" + mammogram.requestStatus) | toTag }}</span>
+    {% endset %}
+
+    {# Request timeline - what has happened to the request and when #}
+    {% set requestTimelineHtml %}
+      {% if mammogram.requestStatus == "received" %}
+        Requested {{ mammogram.requestedDate | formatDate("D MMMM YYYY") }}{% if mammogram.requestedBy %} by {{ mammogram.requestedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}{% endif %}<br>
+        Received {{ mammogram.receivedDate | formatDate("D MMMM YYYY") }}
+      {% elif mammogram.requestStatus == "requested" %}
+        Requested {{ mammogram.requestedDate | formatDate("D MMMM YYYY") }}{% if mammogram.requestedBy %} by {{ mammogram.requestedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}{% endif %}
+      {% elif mammogram.requestStatus == "pending" %}
+        Flagged for request {{ mammogram.requestedDate | formatDate("D MMMM YYYY") }}{% if mammogram.requestedBy %} by {{ mammogram.requestedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}{% endif %}
+      {% elif (mammogram.requestStatus == "not_available" or mammogram.requestStatus == "not_needed") and mammogram.statusChangedDate %}
+        Updated {{ mammogram.statusChangedDate | formatDate("D MMMM YYYY") }}{% if mammogram.statusChangedBy %} by {{ mammogram.statusChangedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}{% endif %}
+      {% endif %}
+      {%- if mammogram.requestReason %}<br>Reason: {{ mammogram.requestReason }}{% endif %}
+    {% endset %}
+
+    {# Value: location, any additional details on their own line, then the request timeline #}
+    {% set priorValueHtml %}
+      {{ mammogram | summarisePriorMammogram({ unitName: unit.name, includeDate: false, prefix: "Taken" }) }}
+      {% if mammogram.otherDetails %}
+        <br>{{ mammogram.otherDetails }}
+      {% endif %}
+      {% if requestTimelineHtml | trim %}
+        <br><span class="nhsuk-u-secondary-text-colour">{{ requestTimelineHtml | trim | safe }}</span>
+      {% endif %}
+    {% endset %}
+
+    {# Action: request route only for priors that have never been requested.
+       Multiple unrequested priors each link to the same request page. #}
+    {% set priorActions = null %}
+    {% if mammogram.requestStatus == "not_requested" %}
+      {% set priorActions = {
+        items: [
+          {
+            href: "./request-priors",
+            text: "Request priors",
+            visuallyHiddenText: "for this mammogram"
+          } | openInModal
+        ]
+      } %}
+    {% endif %}
+
+    {% set priorRows = priorRows | push({
+      key: {
+        html: priorKeyHtml
+      },
+      value: {
+        html: priorValueHtml
+      },
+      actions: priorActions
+    }) %}
+  {% endfor %}
+
+  {{ summaryList({ rows: priorRows, lastRowBorder: false }) }}
+
+{% endif %}

--- a/app/views/_includes/summary-lists/medical-info-summary.njk
+++ b/app/views/_includes/summary-lists/medical-info-summary.njk
@@ -200,7 +200,9 @@
 {# Build summary list content #}
 {% set rows = [] %}
 
-{% if not showOnlyPopulated or additionalMammogramsCount > 0 %}
+{# hidePreviousMammograms lets a page suppress this row when priors are shown
+   separately (e.g. the reading opinion page has a dedicated priors summary) #}
+{% if not hidePreviousMammograms and (not showOnlyPopulated or additionalMammogramsCount > 0) %}
   {% set rows = rows | push({
     key: {
       text: "Mammograms added"

--- a/app/views/_includes/symptomsWarningCard.njk
+++ b/app/views/_includes/symptomsWarningCard.njk
@@ -9,6 +9,6 @@
   {{ warningCallout({
     heading: 'Significant symptoms',
     html: warningCalloutHtml,
-    classes: "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4"
+    classes: ""
   }) }}
 {% endif %}

--- a/app/views/clinics/show.html
+++ b/app/views/clinics/show.html
@@ -132,7 +132,7 @@
             <br>
             {% if event | isSpecialAppointment %}
               {{ tag({
-              text: "Special apppointment",
+              text: "Special appointment",
               colour: "yellow",
               classes: "nhsuk-u-margin-top-2 app-nowrap"
               })}}

--- a/app/views/events/medical-information/symptoms/details.html
+++ b/app/views/events/medical-information/symptoms/details.html
@@ -9,7 +9,7 @@
   {% set pageHeading = "Symptom details" %}
 {% endif %}
 
-{% set gridColumn = "nhsuk-grid-column-two-thirds" %}
+{% set gridColumn = "nhsuk-grid-column-full" %}
 
 {% set formAction = './save' | urlWithReferrer(referrerChain, query.scrollTo) %}
 
@@ -63,7 +63,8 @@
 
   {% endif %}
 
-  
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-one-half">
 
   {# Location #}
 
@@ -496,6 +497,9 @@
     } | populateErrors) }}
   {% endset %}
 
+    </div>
+    <div class="nhsuk-grid-column-one-half">
+
   {% call fieldset({
     legend: {
       text: "Additional symptom information",
@@ -604,6 +608,9 @@
     rows: 4,
     value: event.symptomTemp.symptomNotes
   }) }}
+
+    </div>
+  </div>
 
   <div class="nhsuk-button-group">
     {{ button({

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -236,19 +236,21 @@
       {# Both layouts are rendered; CSS shows the appropriate one per breakpoint.
          This ensures the link always appears in the correct position (stacked layout
          has it between Normal and Technical recall in DOM order). #}
-      {% call card({
+      {# {% call card({
         heading: questionText,
         headingLevel: 2,
         headingSize: "m",
-        feature: true
-      }) %}
+        feature: false
+      }) %} #}
+        <h2 class="nhsuk-u-margin-top-4">{{ questionText }}</h2>
         <div class="app-opinion-buttons--stacked">
+          
           {{ opinionButtonsStackedHtml | safe }}
         </div>
-        <div class="app-opinion-buttons--horizontal">
+        <div class="app-opinion-buttons--horizontal {{- " nhsuk-u-margin-bottom-6" if hasSymptoms -}}">
           {{ opinionButtonsHorizontalHtml | safe }}
         </div>
-      {% endcall %}
+      {# {% endcall %} #}
 
     {% endif %}
   {% endset %}
@@ -267,7 +269,7 @@
       heading: "Medical summary",
       headingLevel: "2",
       feature: true,
-      classes: "app-card--feature-subtle",
+      classes: "_app-card--feature-subtle",
       descriptionHtml: medicalSummaryListHtml,
       actions: {
       items: [
@@ -283,7 +285,18 @@
 
   {# Image warnings (captured so we can check if content exists) #}
   {% set imageWarningsHtml %}
-    {% include "_includes/reading/image-warnings.njk" %}
+    {% set imageWarningSummaryHtml %}
+      {% include "_includes/reading/image-warnings.njk" %}
+    {% endset %}
+    {% if imageWarningSummaryHtml | trim %}
+      {{ card({
+        heading: "Image notes",
+        headingLevel: "2",
+        feature: true,
+        classes: "_app-card--feature-subtle",
+        descriptionHtml: imageWarningSummaryHtml
+      }) }}
+    {% endif %}
   {% endset %}
 
   {# Symptoms warning #}
@@ -335,7 +348,7 @@
         heading: "Previous mammograms disclosed",
         headingLevel: "2",
         feature: true,
-        classes: "app-card--feature-subtle",
+        classes: "_app-card--feature-subtle",
         descriptionHtml: priorsBodyHtml
       }) }}
     {% endif %}
@@ -346,7 +359,8 @@
     {% call card({
       heading: "Images (" + imageCount + ")",
       headingLevel: 2,
-      headingSize: "s"
+      headingSize: "s",
+      feature: "true"
     }) %}
     <div class="app-mammogram-thumbnails">
       {% for view in viewOrder %}
@@ -503,25 +517,20 @@
 
         {# Conditional stuff #}
         {{ symptomsWarningHtml | safe }}
-        {{ priorsWarningHtml | safe }}
 
         {# Main opinion stuff #}
         {{ opinionOptionsHtml | safe }}
 
-        {# Image notes and medical summary — 50/50 if both present, full width otherwise #}
-        {# {% if (imageWarningsHtml | trim) and (medicalSummaryHtml | trim) %}
-          <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-one-half">
-              {{ imageWarningsHtml | safe }}
-            </div>
-            <div class="nhsuk-grid-column-one-half">
-              {{ medicalSummaryHtml | safe }}
-            </div>
-          </div>
-        {% else %} #}
-          {{ imageWarningsHtml | safe }}
-          {{ medicalSummaryHtml | safe }}
-        {# {% endif %} #}
+        <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
+        
+        {# Conditional priors #}
+        {{ priorsWarningHtml | safe }}
+
+        {# Conditional image warnings #}
+        {{ imageWarningsHtml | safe }}
+
+        {# Shows regardless of medical info being present #}
+        {{ medicalSummaryHtml | safe }}
 
         {# Defer case option #}
         <p class="nhsuk-u-margin-top-2">

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -210,7 +210,6 @@
     {{ card({
       heading: "Medical summary",
       headingLevel: "2",
-      classes: "nhsuk-u-margin-top-4",
       feature: true,
       descriptionHtml: medicalSummaryListHtml,
       actions: {

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -239,7 +239,8 @@
       {% call card({
         heading: questionText,
         headingLevel: 2,
-        headingSize: "m"
+        headingSize: "m",
+        feature: true
       }) %}
         <div class="app-opinion-buttons--stacked">
           {{ opinionButtonsStackedHtml | safe }}
@@ -265,7 +266,8 @@
     {{ card({
       heading: "Medical summary",
       headingLevel: "2",
-      feature: false,
+      feature: true,
+      classes: "app-card--feature-subtle",
       descriptionHtml: medicalSummaryListHtml,
       actions: {
       items: [
@@ -494,12 +496,12 @@
     {% endif %}
 
     {# Opinion and thumbnails #}
-    <div class="nhsuk-grid-row">
+    <div class="app-reading-opinion-columns">
 
 
 
       {# Opinion buttons/radios #}
-      <div class="nhsuk-grid-column-three-quarters">
+      <div class="app-grid-column-main">
 
         {# Conditional stuff #}
         {{ symptomsWarningHtml | safe }}
@@ -530,7 +532,7 @@
       </div>
 
       {# Mammogram thumbnails #}
-      <div class="nhsuk-grid-column-one-quarter">
+      <div class="app-grid-column-images">
         {{ thumbnailsHtml | safe }}
       </div>
 

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -186,7 +186,7 @@
               value: "recall_for_assessment",
               name: "imageReadingTemp[opinion]",
               variant: "warning",
-              classes: "app-button-full-width",
+              classes: "app-button-full-width nhsuk-u-margin-bottom-1",
               attributes: { "data-shortcut": "r" }
             } | openInModal) }}
           </div>
@@ -224,10 +224,17 @@
     }) }}
   {% endset %}
 
+  {# Image warnings (captured so we can check if content exists) #}
+  {% set imageWarningsHtml %}
+    {% include "_includes/reading/image-warnings.njk" %}
+  {% endset %}
+
   {# Symptoms warning #}
   {% set symptomsWarningHtml %}
-    {% set symptoms = event.medicalInformation.symptoms %}
-    {% include "_includes/symptomsWarningCard.njk" %}
+    {% if event.medicalInformation.symptoms | length %}
+      {% set symptoms = event.medicalInformation.symptoms %}
+      {% include "_includes/symptomsWarningCard.njk" %}
+    {% endif %}
   {% endset %}
 
   {# Reported mammograms banners #}
@@ -417,17 +424,11 @@
     {# Hidden field to track previous opinion for opinion change detection #}
     <input type="hidden" name="imageReadingTemp[previousOpinion]" value="{{ currentOpinion }}">
 
-    {# Symptoms warning and priors banners - full width, only if content exists #}
+    {# Symptoms warning and priors banners - full width #}
     {% if (symptomsWarningHtml | trim) or (priorsWarningHtml | trim) %}
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
-          {% if symptomsWarningHtml | trim %}
-            {{ symptomsWarningHtml | safe }}
-          {% endif %}
-
-          {% if priorsWarningHtml | trim %}
-            {{ priorsWarningHtml | safe }}
-          {% endif %}
+          
         </div>
       </div>
     {% endif %}
@@ -435,34 +436,44 @@
     {# Opinion and thumbnails #}
     <div class="nhsuk-grid-row">
 
-      {# Mammogram thumbnails #}
-      <div class="nhsuk-grid-column-one-third">
-        {{ thumbnailsHtml | safe }}
-      </div>
+
 
       {# Opinion buttons/radios #}
-      <div class="nhsuk-grid-column-two-thirds">
+      <div class="nhsuk-grid-column-three-quarters">
+
+        {# Conditional stuff #}
+        {{ symptomsWarningHtml | safe }}
+        {{ priorsWarningHtml | safe }}
+
+        {# Main opinion stuff #}
         {{ opinionOptionsHtml | safe }}
-      </div>
 
-    </div>
-
-    {# Image notes, medical summary and defer - full width #}
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
-
-        {# Image notes #}
-        {% include "_includes/reading/image-warnings.njk" %}
-
-        {# Medical information summary #}
-        {{ medicalSummaryHtml | safe }}
+        {# Image notes and medical summary — 50/50 if both present, full width otherwise #}
+        {# {% if (imageWarningsHtml | trim) and (medicalSummaryHtml | trim) %}
+          <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-one-half">
+              {{ imageWarningsHtml | safe }}
+            </div>
+            <div class="nhsuk-grid-column-one-half">
+              {{ medicalSummaryHtml | safe }}
+            </div>
+          </div>
+        {% else %} #}
+          {{ imageWarningsHtml | safe }}
+          {{ medicalSummaryHtml | safe }}
+        {# {% endif %} #}
 
         {# Defer case option #}
         <p class="nhsuk-u-margin-top-2">
           {{ appLink({ text: "Defer this case", href: "./defer-case", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
         </p>
-
       </div>
+
+      {# Mammogram thumbnails #}
+      <div class="nhsuk-grid-column-one-quarter">
+        {{ thumbnailsHtml | safe }}
+      </div>
+
     </div>
 
   </form>

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -425,6 +425,7 @@
   </div>
 
   {# Opinion form with thumbnails #}
+
   {# Todo: do we need a form here? is the parent layout's form not enough? #}
   <form action="./opinion-answer" method="POST" class="app-reading-opinion" data-reading-opinion-form="true" data-reading-opinion-locked="{{ opinionDelayLocked }}" data-event-id="{{ event.id }}" data-session-id="{{ session.id if session }}">
 
@@ -443,8 +444,6 @@
     {# Opinion and thumbnails #}
     <div class="app-reading-opinion-columns">
 
-
-
       {# Opinion buttons/radios #}
       <div class="app-grid-column-main">
 
@@ -459,16 +458,17 @@
         {# Combined information card with priors, image notes, and medical summary as sections #}
         {% set combinedInfoHtml %}
           {% if priorsWarningHtml | trim %}
-            <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Previous mammograms disclosed</h3>
+            <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">Previous mammograms disclosed</h3>
             {{ priorsWarningHtml | safe }}
           {% endif %}
           {% if imageWarningsHtml | trim %}
-            <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2{% if priorsWarningHtml | trim %} nhsuk-u-margin-top-4{% endif %}">Image notes</h3>
+            <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-1{% if priorsWarningHtml | trim %} nhsuk-u-margin-top-4{% endif %}">Image notes</h3>
             {{ imageWarningsHtml | safe }}
           {% endif %}
-          <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2{% if (priorsWarningHtml | trim) or (imageWarningsHtml | trim) %} nhsuk-u-margin-top-4{% endif %}">Medical summary</h3>
+          <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-1{% if (priorsWarningHtml | trim) or (imageWarningsHtml | trim) %} nhsuk-u-margin-top-4{% endif %}">Medical summary</h3>
           {{ medicalSummaryHtml | safe }}
         {% endset %}
+
         {{ card({
           headingLevel: "2",
           heading: "Additional information",
@@ -484,6 +484,7 @@
       </div>
 
       {# Mammogram thumbnails #}
+      {# Using custom grid/class so that they have fixed width rather than % #}
       <div class="app-grid-column-images">
         {{ thumbnailsHtml | safe }}
       </div>
@@ -492,11 +493,11 @@
 
   </form>
 
-
-
 {% endblock %}
 
 {% block pageScripts %}
+
+{# TODO: can this be removed? don't think we have zoom on these any more #}
 <script>
 // Thumbnail zoom functionality
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -6,7 +6,7 @@
 {% set pageHeading = participant | getFullName %}
 {% set gridColumn = "none" %}
 {% set showWorkflowNav = true %}
-{% set bodyClasses = (bodyClasses or "") + " _app-page-width--wide" %}
+{% set bodyClasses = (bodyClasses or "") + " app-page-width--wide" %}
 
 {# Reduce default top padding of main on opinion page to save on scrolling #}
 {% set mainClasses = "nhsuk-u-padding-top-1" %}
@@ -279,6 +279,54 @@
     {% endif %}
   {% endset %}
 
+  {# Mammogram thumbnails #}
+  {% set thumbnailsHtml %}
+    <h2 class="nhsuk-heading-s">Image thumbnails ({{ imageCount }})</h2>
+    <div class="app-mammogram-thumbnails nhsuk-u-margin-bottom-4">
+      {% for view in viewOrder %}
+        <div class="app-mammogram-thumbnail app-mammogram-thumbnail--{{ view.side }}">
+          {% set allPaths = mammogramImages.allPaths[view.key] if mammogramImages and mammogramImages.allPaths else null %}
+
+          {% if allPaths %}
+            {# Handle both single path (string) and multiple paths (array) #}
+            {% if allPaths is string %}
+              <div class="app-mammogram-thumbnail__image-wrapper">
+                <span class="app-mammogram-thumbnail__label">{{ view.label }}</span>
+                <img
+                  class="app-mammogram-thumbnail__image{% if mammogramImageSource == 'diagrams' %} app-mammogram-thumbnail__image--diagram{% endif %}"
+                  src="{{ allPaths }}"
+                  alt="{{ view.label }} view"
+                  data-view="{{ view.label }}"
+                >
+              </div>
+            {% else %}
+              {# Multiple images - each with its own wrapper and label #}
+              {% for imagePath in allPaths %}
+                <div class="app-mammogram-thumbnail__image-wrapper">
+                  <span class="app-mammogram-thumbnail__label">{{ view.label }}</span>
+                  <img
+                    class="app-mammogram-thumbnail__image{% if mammogramImageSource == 'diagrams' %} app-mammogram-thumbnail__image--diagram{% endif %}"
+                    src="{{ imagePath }}"
+                    alt="{{ view.label }} view ({{ loop.index }} of {{ loop.length }})"
+                    data-view="{{ view.label }}"
+                  >
+                </div>
+              {% endfor %}
+            {% endif %}
+          {% else %}
+            {# Missing image placeholder #}
+            <div class="app-mammogram-thumbnail__image-wrapper">
+              <span class="app-mammogram-thumbnail__label">{{ view.label }}</span>
+              <div class="app-mammogram-thumbnail__missing">
+                <span class="app-mammogram-thumbnail__missing-text">No image</span>
+              </div>
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endset %}
+
   {# =========================================================
      Page layout
      ========================================================= #}
@@ -389,50 +437,7 @@
 
       {# Mammogram thumbnails #}
       <div class="nhsuk-grid-column-one-third">
-        <h2 class="nhsuk-heading-s">Image thumbnails ({{ imageCount }})</h2>
-        <div class="app-mammogram-thumbnails nhsuk-u-margin-bottom-4">
-          {% for view in viewOrder %}
-            <div class="app-mammogram-thumbnail app-mammogram-thumbnail--{{ view.side }}">
-              {% set allPaths = mammogramImages.allPaths[view.key] if mammogramImages and mammogramImages.allPaths else null %}
-
-              {% if allPaths %}
-                {# Handle both single path (string) and multiple paths (array) #}
-                {% if allPaths is string %}
-                  <div class="app-mammogram-thumbnail__image-wrapper">
-                    <span class="app-mammogram-thumbnail__label">{{ view.label }}</span>
-                    <img
-                      class="app-mammogram-thumbnail__image{% if mammogramImageSource == 'diagrams' %} app-mammogram-thumbnail__image--diagram{% endif %}"
-                      src="{{ allPaths }}"
-                      alt="{{ view.label }} view"
-                      data-view="{{ view.label }}"
-                    >
-                  </div>
-                {% else %}
-                  {# Multiple images - each with its own wrapper and label #}
-                  {% for imagePath in allPaths %}
-                    <div class="app-mammogram-thumbnail__image-wrapper">
-                      <span class="app-mammogram-thumbnail__label">{{ view.label }}</span>
-                      <img
-                        class="app-mammogram-thumbnail__image{% if mammogramImageSource == 'diagrams' %} app-mammogram-thumbnail__image--diagram{% endif %}"
-                        src="{{ imagePath }}"
-                        alt="{{ view.label }} view ({{ loop.index }} of {{ loop.length }})"
-                        data-view="{{ view.label }}"
-                      >
-                    </div>
-                  {% endfor %}
-                {% endif %}
-              {% else %}
-                {# Missing image placeholder #}
-                <div class="app-mammogram-thumbnail__image-wrapper">
-                  <span class="app-mammogram-thumbnail__label">{{ view.label }}</span>
-                  <div class="app-mammogram-thumbnail__missing">
-                    <span class="app-mammogram-thumbnail__missing-text">No image</span>
-                  </div>
-                </div>
-              {% endif %}
-            </div>
-          {% endfor %}
-        </div>
+        {{ thumbnailsHtml | safe }}
       </div>
 
       {# Opinion buttons/radios #}

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -261,42 +261,17 @@
     {% set showOnlyPopulated = true %}
     {# No edits allowed in image reading #}
     {% set allowEdits = false %}
-    {% set medicalSummaryListHtml %}
-      {% include "_includes/summary-lists/medical-info-summary.njk" %}
-    {% endset %}
-
-    {{ card({
-      heading: "Medical summary",
-      headingLevel: "2",
-      feature: true,
-      classes: "_app-card--feature-subtle",
-      descriptionHtml: medicalSummaryListHtml,
-      actions: {
-      items: [
-        {
-          text: "View full medical information",
-          href: "./medical-information",
-          classes: "nhsuk-link--no-visited-state"
-        } | openInModal
-      ]
-    }
-    }) }}
+    {# Priors are shown separately in the dedicated priors summary above #}
+    {% set hidePreviousMammograms = true %}
+    {% include "_includes/summary-lists/medical-info-summary.njk" %}
+    <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
+      {{ appLink({ text: "View full medical information", href: "./medical-information", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
+    </p>
   {% endset %}
 
   {# Image warnings (captured so we can check if content exists) #}
   {% set imageWarningsHtml %}
-    {% set imageWarningSummaryHtml %}
-      {% include "_includes/reading/image-warnings.njk" %}
-    {% endset %}
-    {% if imageWarningSummaryHtml | trim %}
-      {{ card({
-        heading: "Image notes",
-        headingLevel: "2",
-        feature: true,
-        classes: "_app-card--feature-subtle",
-        descriptionHtml: imageWarningSummaryHtml
-      }) }}
-    {% endif %}
+    {% include "_includes/reading/image-warnings.njk" %}
   {% endset %}
 
   {# Symptoms warning #}
@@ -307,51 +282,9 @@
     {% endif %}
   {% endset %}
 
-  {# Reported mammograms banners #}
+  {# Previous (prior) mammograms - summary list with status and request route #}
   {% set priorsWarningHtml %}
-    {% set priorsBodyHtml %}
-
-      {# Warning: priors reported but not yet requested #}
-      {% if priorsSummary.hasUnrequested %}
-        {% set unrequestedPriors = event.previousMammograms | where("requestStatus", "not_requested") %}
-        <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammogram added</p>
-        {% for mammogram in unrequestedPriors %}
-          <p class="nhsuk-u-margin-bottom-1">
-            {{ mammogram | summarisePriorMammogram({ unitName: unit.name }) }}
-          </p>
-        {% endfor %}
-        <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
-          {{ appLink({ text: "Request priors", href: "./request-priors", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
-        </p>
-      {% endif %}
-
-      {# Info: received priors #}
-      {% if priorsSummary.counts.received > 0 %}
-        {% set receivedMammograms = event.previousMammograms | where("requestStatus", "received") %}
-        <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1{% if priorsSummary.hasUnrequested %} nhsuk-u-margin-top-4{% endif %}">Priors received</p>
-        {% for mammogram in receivedMammograms %}
-          <p class="nhsuk-u-margin-bottom-1">
-            {{ mammogram | summarisePriorMammogram({ unitName: unit.name }) }}
-            {% if mammogram.requestedBy %}
-              – requested by {{ mammogram.requestedBy | getUsername({ format: "short", identifyCurrentUser: true }) }}{% if mammogram.requestReason %}: {{ mammogram.requestReason }}{% endif %}
-            {% elseif mammogram.requestReason %}
-              – {{ mammogram.requestReason }}
-            {% endif %}
-          </p>
-        {% endfor %}
-      {% endif %}
-
-    {% endset %}
-
-    {% if priorsBodyHtml | trim %}
-      {{ card({
-        heading: "Previous mammograms disclosed",
-        headingLevel: "2",
-        feature: true,
-        classes: "_app-card--feature-subtle",
-        descriptionHtml: priorsBodyHtml
-      }) }}
-    {% endif %}
+    {% include "_includes/reading/priors-summary.njk" %}
   {% endset %}
 
   {# Mammogram thumbnails #}
@@ -523,14 +456,26 @@
 
         <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
         
-        {# Conditional priors #}
-        {{ priorsWarningHtml | safe }}
-
-        {# Conditional image warnings #}
-        {{ imageWarningsHtml | safe }}
-
-        {# Shows regardless of medical info being present #}
-        {{ medicalSummaryHtml | safe }}
+        {# Combined information card with priors, image notes, and medical summary as sections #}
+        {% set combinedInfoHtml %}
+          {% if priorsWarningHtml | trim %}
+            <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Previous mammograms disclosed</h3>
+            {{ priorsWarningHtml | safe }}
+          {% endif %}
+          {% if imageWarningsHtml | trim %}
+            <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2{% if priorsWarningHtml | trim %} nhsuk-u-margin-top-4{% endif %}">Image notes</h3>
+            {{ imageWarningsHtml | safe }}
+          {% endif %}
+          <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2{% if (priorsWarningHtml | trim) or (imageWarningsHtml | trim) %} nhsuk-u-margin-top-4{% endif %}">Medical summary</h3>
+          {{ medicalSummaryHtml | safe }}
+        {% endset %}
+        {{ card({
+          headingLevel: "2",
+          heading: "Additional information",
+          feature: true,
+          classes: "_app-card--feature-subtle",
+          descriptionHtml: combinedInfoHtml
+        }) }}
 
         {# Defer case option #}
         <p class="nhsuk-u-margin-top-2">

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -135,64 +135,119 @@
       } | openInModal) }}
 
     {% else %}
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-full">
-          {# Show buttons for initial assessment - vertically stacked #}
-          <h2 class="nhsuk-heading-m">{{ questionText }}</h2>
 
-          <div class="nhsuk-u-margin-bottom-4">
-            {% if hasSymptoms %}
-              {{ button({
-                html: "Normal, and add details <span class='app-shortcut-hint'>(N)</span>",
-                value: "normal_with_details",
-                name: "imageReadingTemp[opinion]",
-                classes: "app-button-full-width nhsuk-u-margin-bottom-3",
-                attributes: { "data-shortcut": "n" }
-              } | openInModal) }}
-            {% else %}
-              {{ button({
-                html: "Normal <span class='app-shortcut-hint'>(N)</span>",
-                value: "normal",
-                name: "imageReadingTemp[opinion]",
-                classes: "app-button-full-width nhsuk-u-margin-bottom-3",
-                attributes: { "data-shortcut": "n" }
-              }) }}
+      {# Stacked (vertical) button layout #}
+      {% set opinionButtonsStackedHtml %}
+        {% if hasSymptoms %}
+          {{ button({
+            html: "Normal, and add details <span class='app-shortcut-hint'>(N)</span>",
+            value: "normal_with_details",
+            name: "imageReadingTemp[opinion]",
+            classes: "app-button-full-width nhsuk-u-margin-bottom-3",
+            attributes: { "data-shortcut": "n" }
+          } | openInModal) }}
+        {% else %}
+          {{ button({
+            html: "Normal <span class='app-shortcut-hint'>(N)</span>",
+            value: "normal",
+            name: "imageReadingTemp[opinion]",
+            classes: "app-button-full-width nhsuk-u-margin-bottom-3",
+            attributes: { "data-shortcut": "n" }
+          }) }}
+          <p class="nhsuk-u-margin-bottom-4">
+            {# Raw button element intentional — app-button-link styles it as a link,
+              which doesn't work with the NHS button macro (adds conflicting styles).
+              data-modal-submit added manually for modal support. #}
+            <button type="submit" name="imageReadingTemp[opinion]" value="normal_with_details" class="app-button-link"{% if data.settings.modalForms == 'true' %} data-modal-submit="true" data-modal-id="app-form-modal"{% endif %}>
+              Normal, but add details
+            </button>
+          </p>
+        {% endif %}
+        {{ button({
+          html: "Technical recall <span class='app-shortcut-hint'>(T)</span>",
+          value: "technical_recall",
+          name: "imageReadingTemp[opinion]",
+          variant: "secondary",
+          classes: "app-button-full-width nhsuk-u-margin-bottom-3",
+          attributes: { "data-shortcut": "t" }
+        } | openInModal) }}
+        {{ button({
+          html: "Recall for assessment <span class='app-shortcut-hint'>(R)</span>",
+          value: "recall_for_assessment",
+          name: "imageReadingTemp[opinion]",
+          variant: "warning",
+          classes: "app-button-full-width nhsuk-u-margin-bottom-1",
+          attributes: { "data-shortcut": "r" }
+        } | openInModal) }}
+      {% endset %}
 
-              <p class="nhsuk-u-margin-bottom-4">
-                {# Raw button element intentional — app-button-link styles it as a link,
-                  which doesn't work with the NHS button macro (adds conflicting styles).
-                  data-modal-submit added manually for modal support. #}
-                <button type="submit" name="imageReadingTemp[opinion]" value="normal_with_details" class="app-button-link"{% if data.settings.modalForms == 'true' %} data-modal-submit="true" data-modal-id="app-form-modal"{% endif %}>
-                  Normal, but add details
-                </button>
-              </p>
-            {% endif %}
-          </div>
-
-          <div class="nhsuk-u-margin-bottom-4">
+      {# Horizontal equal-width button layout #}
+      {# Horizontal equal-width button layout.
+         CSS Grid places the three buttons in row 1 (uniform height) and the
+         sub-action link in row 2 col 1 via explicit placement — no wrapper needed. #}
+      {% set opinionButtonsHorizontalHtml %}
+        <div class="app-button-group--equal">
+          {% if hasSymptoms %}
             {{ button({
-              html: "Technical recall <span class='app-shortcut-hint'>(T)</span>",
-              value: "technical_recall",
+              html: "Normal, and add details <span class='app-shortcut-hint'>(N)</span>",
+              value: "normal_with_details",
               name: "imageReadingTemp[opinion]",
-              variant: "secondary",
-              classes: "app-button-full-width nhsuk-u-margin-bottom-3",
-              attributes: { "data-shortcut": "t" }
+              classes: "app-button--tall",
+              attributes: { "data-shortcut": "n" }
             } | openInModal) }}
-          </div>
-
-          <div class="nhsuk-u-margin-bottom-0">
+          {% else %}
             {{ button({
-              html: "Recall for assessment <span class='app-shortcut-hint'>(R)</span>",
-              value: "recall_for_assessment",
+              html: "Normal <span class='app-shortcut-hint'>(N)</span>",
+              value: "normal",
               name: "imageReadingTemp[opinion]",
-              variant: "warning",
-              classes: "app-button-full-width nhsuk-u-margin-bottom-1",
-              attributes: { "data-shortcut": "r" }
-            } | openInModal) }}
-          </div>
+              classes: "app-button--tall",
+              attributes: { "data-shortcut": "n" }
+            }) }}
+            {# Sub-action placed between Normal and Technical recall in DOM so it auto-flows
+               after Normal on mobile (stacked layout); CSS pins it to row 2 col 1 on desktop. #}
+            <p class="app-button-group__sub-action">
+              {# Raw button element intentional — app-button-link styles it as a link,
+                which doesn't work with the NHS button macro (adds conflicting styles).
+                data-modal-submit added manually for modal support. #}
+              <button type="submit" name="imageReadingTemp[opinion]" value="normal_with_details" class="app-button-link"{% if data.settings.modalForms == 'true' %} data-modal-submit="true" data-modal-id="app-form-modal"{% endif %}>
+                Normal, but add details
+              </button>
+            </p>
+          {% endif %}
+          {{ button({
+            html: "Technical recall <span class='app-shortcut-hint'>(T)</span>",
+            value: "technical_recall",
+            name: "imageReadingTemp[opinion]",
+            variant: "secondary",
+            classes: "app-button--tall",
+            attributes: { "data-shortcut": "t" }
+          } | openInModal) }}
+          {{ button({
+            html: "Recall for assessment <span class='app-shortcut-hint'>(R)</span>",
+            value: "recall_for_assessment",
+            name: "imageReadingTemp[opinion]",
+            variant: "warning",
+            classes: "app-button--tall",
+            attributes: { "data-shortcut": "r" }
+          } | openInModal) }}
         </div>
+      {% endset %}
 
-      </div>
+      {# Both layouts are rendered; CSS shows the appropriate one per breakpoint.
+         This ensures the link always appears in the correct position (stacked layout
+         has it between Normal and Technical recall in DOM order). #}
+      {% call card({
+        heading: questionText,
+        headingLevel: 2,
+        headingSize: "m"
+      }) %}
+        <div class="app-opinion-buttons--stacked">
+          {{ opinionButtonsStackedHtml | safe }}
+        </div>
+        <div class="app-opinion-buttons--horizontal">
+          {{ opinionButtonsHorizontalHtml | safe }}
+        </div>
+      {% endcall %}
 
     {% endif %}
   {% endset %}
@@ -210,7 +265,7 @@
     {{ card({
       heading: "Medical summary",
       headingLevel: "2",
-      feature: true,
+      feature: false,
       descriptionHtml: medicalSummaryListHtml,
       actions: {
       items: [
@@ -345,7 +400,7 @@
 
   {# Page header with status tags #}
   <div class="nhsuk-grid-row app-header-with-status">
-    <div class="nhsuk-grid-column-two-thirds">
+    <div class="nhsuk-grid-column-three-quarters">
       <span class="nhsuk-caption-l">
         {{ opinionHeading }}
       </span>
@@ -353,7 +408,7 @@
         {{ participant | getFullName }}
       </h1>
     </div>
-    <div class="nhsuk-grid-column-one-third app-header-with-status__status-tag">
+    <div class="nhsuk-grid-column-one-quarter app-header-with-status__status-tag">
 
       {# Urgency tags #}
       {% set eventAge = event.timing.startTime | daysSince %}
@@ -444,7 +499,7 @@
 
 
       {# Opinion buttons/radios #}
-      <div class="nhsuk-grid-column-two-thirds">
+      <div class="nhsuk-grid-column-three-quarters">
 
         {# Conditional stuff #}
         {{ symptomsWarningHtml | safe }}
@@ -475,7 +530,7 @@
       </div>
 
       {# Mammogram thumbnails #}
-      <div class="nhsuk-grid-column-one-third">
+      <div class="nhsuk-grid-column-one-quarter">
         {{ thumbnailsHtml | safe }}
       </div>
 

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -192,7 +192,6 @@
               html: "Normal, and add details <span class='app-shortcut-hint'>(N)</span>",
               value: "normal_with_details",
               name: "imageReadingTemp[opinion]",
-              classes: "app-button--tall",
               attributes: { "data-shortcut": "n" }
             } | openInModal) }}
           {% else %}
@@ -200,7 +199,6 @@
               html: "Normal <span class='app-shortcut-hint'>(N)</span>",
               value: "normal",
               name: "imageReadingTemp[opinion]",
-              classes: "app-button--tall",
               attributes: { "data-shortcut": "n" }
             }) }}
             {# Sub-action placed between Normal and Technical recall in DOM so it auto-flows
@@ -219,7 +217,6 @@
             value: "technical_recall",
             name: "imageReadingTemp[opinion]",
             variant: "secondary",
-            classes: "app-button--tall",
             attributes: { "data-shortcut": "t" }
           } | openInModal) }}
           {{ button({
@@ -227,7 +224,6 @@
             value: "recall_for_assessment",
             name: "imageReadingTemp[opinion]",
             variant: "warning",
-            classes: "app-button--tall",
             attributes: { "data-shortcut": "r" }
           } | openInModal) }}
         </div>

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -288,8 +288,12 @@
 
   {# Mammogram thumbnails #}
   {% set thumbnailsHtml %}
-    <h2 class="nhsuk-heading-s">Image thumbnails ({{ imageCount }})</h2>
-    <div class="app-mammogram-thumbnails nhsuk-u-margin-bottom-4">
+    {% call card({
+      heading: "Images (" + imageCount + ")",
+      headingLevel: 2,
+      headingSize: "s"
+    }) %}
+    <div class="app-mammogram-thumbnails">
       {% for view in viewOrder %}
         <div class="app-mammogram-thumbnail app-mammogram-thumbnail--{{ view.side }}">
           {% set allPaths = mammogramImages.allPaths[view.key] if mammogramImages and mammogramImages.allPaths else null %}
@@ -332,6 +336,7 @@
         </div>
       {% endfor %}
     </div>
+    {% endcall %}
   {% endset %}
 
   {# =========================================================
@@ -439,7 +444,7 @@
 
 
       {# Opinion buttons/radios #}
-      <div class="nhsuk-grid-column-three-quarters">
+      <div class="nhsuk-grid-column-two-thirds">
 
         {# Conditional stuff #}
         {{ symptomsWarningHtml | safe }}
@@ -470,7 +475,7 @@
       </div>
 
       {# Mammogram thumbnails #}
-      <div class="nhsuk-grid-column-one-quarter">
+      <div class="nhsuk-grid-column-one-third">
         {{ thumbnailsHtml | safe }}
       </div>
 

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -242,7 +242,7 @@
         headingSize: "m",
         feature: false
       }) %} #}
-        <h2 class="nhsuk-u-margin-top-4">{{ questionText }}</h2>
+        <h2 class="nhsuk-u-margin-top-5">{{ questionText }}</h2>
         <div class="app-opinion-buttons--stacked">
           
           {{ opinionButtonsStackedHtml | safe }}
@@ -293,6 +293,7 @@
       heading: "Images (" + imageCount + ")",
       headingLevel: 2,
       headingSize: "s",
+      classes: "app-card--feature-grey",
       feature: "true"
     }) %}
     <div class="app-mammogram-thumbnails">

--- a/app/views/reading/workflow/opinion.html
+++ b/app/views/reading/workflow/opinion.html
@@ -296,10 +296,12 @@
 
   {# Reported mammograms banners #}
   {% set priorsWarningHtml %}
-    {# Warning: priors reported but not yet requested #}
-    {% if priorsSummary.hasUnrequested %}
-      {% set unrequestedPriors = event.previousMammograms | where("requestStatus", "not_requested") %}
-      {% set unrequestedHtml %}
+    {% set priorsBodyHtml %}
+
+      {# Warning: priors reported but not yet requested #}
+      {% if priorsSummary.hasUnrequested %}
+        {% set unrequestedPriors = event.previousMammograms | where("requestStatus", "not_requested") %}
+        <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammogram added</p>
         {% for mammogram in unrequestedPriors %}
           <p class="nhsuk-u-margin-bottom-1">
             {{ mammogram | summarisePriorMammogram({ unitName: unit.name }) }}
@@ -308,20 +310,12 @@
         <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
           {{ appLink({ text: "Request priors", href: "./request-priors", classes: "nhsuk-link--no-visited-state" } | openInModal) }}
         </p>
-      {% endset %}
+      {% endif %}
 
-      {% call insetText({
-        classes: "app-inset-text--compact" if data.settings.compactMode in ["true", true]
-      }) %}
-        <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Recent mammogram added</p>
-        {{ unrequestedHtml | safe }}
-      {% endcall %}
-    {% endif %}
-
-    {# Info: received priors #}
-    {% if priorsSummary.counts.received > 0 %}
-      {% set receivedMammograms = event.previousMammograms | where("requestStatus", "received") %}
-      {% set receivedHtml %}
+      {# Info: received priors #}
+      {% if priorsSummary.counts.received > 0 %}
+        {% set receivedMammograms = event.previousMammograms | where("requestStatus", "received") %}
+        <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1{% if priorsSummary.hasUnrequested %} nhsuk-u-margin-top-4{% endif %}">Priors received</p>
         {% for mammogram in receivedMammograms %}
           <p class="nhsuk-u-margin-bottom-1">
             {{ mammogram | summarisePriorMammogram({ unitName: unit.name }) }}
@@ -332,14 +326,18 @@
             {% endif %}
           </p>
         {% endfor %}
-      {% endset %}
+      {% endif %}
 
-      {% call insetText({
-        classes: "app-inset-text--compact" if data.settings.compactMode in ["true", true]
-      }) %}
-        <p class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-1">Priors received</p>
-        {{ receivedHtml | safe }}
-      {% endcall %}
+    {% endset %}
+
+    {% if priorsBodyHtml | trim %}
+      {{ card({
+        heading: "Previous mammograms disclosed",
+        headingLevel: "2",
+        feature: true,
+        classes: "app-card--feature-subtle",
+        descriptionHtml: priorsBodyHtml
+      }) }}
     {% endif %}
   {% endset %}
 

--- a/docs/nhs-frontend-component-reference.md
+++ b/docs/nhs-frontend-component-reference.md
@@ -3,10 +3,10 @@
 ---
 **Auto-generated Documentation**
 
-- **NHS Frontend Version:** 10.5.1
+- **NHS Frontend Version:** 10.5.2
 - **Git Branch:** detached
-- **Git Commit:** ddd8147
-- **Generated:** 2026-06-04 14:46:25 UTC
+- **Git Commit:** 67bf2f6
+- **Generated:** 2026-07-06 12:50:21 UTC
 - **Source:** [NHS Frontend Repository](https://github.com/nhsuk/nhsuk-frontend)
 
 *This documentation is automatically extracted from NHS Frontend component definitions. Do not edit manually.*
@@ -19,46 +19,46 @@ Use the component reference table below to find the line number for any componen
 
 | Component | Macro | Category | Line |
 |-----------|-------|----------|------|
-| Character count | `characterCount()` | Form Inputs | 2074 |
-| Checkboxes | `checkboxes()` | Form Inputs | 2558 |
-| Date input | `dateInput()` | Form Inputs | 3801 |
-| File upload | `fileUpload()` | Form Inputs | 5385 |
-| Input | `input()` | Form Inputs | 7154 |
-| Password input | `passwordInput()` | Form Inputs | 8428 |
-| Radios | `radios()` | Form Inputs | 8734 |
-| Search input | `searchInput()` | Form Inputs | 9624 |
-| Select | `select()` | Form Inputs | 10075 |
-| Textarea | `textarea()` | Form Inputs | 13279 |
+| Character count | `characterCount()` | Form Inputs | 2123 |
+| Checkboxes | `checkboxes()` | Form Inputs | 2617 |
+| Date input | `dateInput()` | Form Inputs | 3732 |
+| File upload | `fileUpload()` | Form Inputs | 5326 |
+| Input | `input()` | Form Inputs | 7082 |
+| Password input | `passwordInput()` | Form Inputs | 8303 |
+| Radios | `radios()` | Form Inputs | 8609 |
+| Search input | `searchInput()` | Form Inputs | 9338 |
+| Select | `select()` | Form Inputs | 9789 |
+| Textarea | `textarea()` | Form Inputs | 12701 |
 | Button | `button()` | Form Controls | 311 |
-| Error message | `errorMessage()` | Form Controls | 5116 |
-| Fieldset | `fieldset()` | Form Controls | 5275 |
-| Hint text | `hint()` | Form Controls | 7053 |
-| Label | `label()` | Form Controls | 7748 |
+| Error message | `errorMessage()` | Form Controls | 5055 |
+| Fieldset | `fieldset()` | Form Controls | 5214 |
+| Hint text | `hint()` | Form Controls | 6979 |
+| Label | `label()` | Form Controls | 7672 |
 | Back link | `backLink()` | Navigation | 109 |
 | Breadcrumb | `breadcrumb()` | Navigation | 162 |
-| Contents list | `contentsList()` | Navigation | 3689 |
-| Pagination | `pagination()` | Navigation | 8006 |
-| Skip link | `skipLink()` | Navigation | 10650 |
+| Contents list | `contentsList()` | Navigation | 3620 |
+| Pagination | `pagination()` | Navigation | 7904 |
+| Skip link | `skipLink()` | Navigation | 10358 |
 | Action link | `actionLink()` | Content | 66 |
 | Card | `card()` | Content | 1084 |
-| Code | `code()` | Content | 3556 |
-| Details | `details()` | Content | 4671 |
-| Do and Don't list | `list()` | Content | 4894 |
-| Hero | `hero()` | Content | 6978 |
-| Images | `image()` | Content | 7081 |
-| Inset text | `insetText()` | Content | 7718 |
-| Legend | `legend()` | Content | 7821 |
-| Panel | `panel()` | Content | 8315 |
-| Summary list | `summaryList()` | Content | 10698 |
-| Tables | `table()` | Content | 11762 |
-| Tabs | `tabs()` | Content | 12773 |
-| Tag | `tag()` | Content | 13086 |
-| Task list | `taskList()` | Content | 13135 |
-| Footer | `footer()` | Layout | 5605 |
-| Header | `header()` | Layout | 6201 |
-| Error summary | `errorSummary()` | Notifications | 5145 |
-| Notification banner | `notificationBanner()` | Notifications | 7840 |
-| Warning callout | `warningCallout()` | Notifications | 13450 |
+| Code | `code()` | Content | 3485 |
+| Details | `details()` | Content | 4602 |
+| Do and Don't list | `list()` | Content | 4833 |
+| Hero | `hero()` | Content | 6908 |
+| Images | `image()` | Content | 7007 |
+| Inset text | `insetText()` | Content | 7640 |
+| Legend | `legend()` | Content | 7745 |
+| Panel | `panel()` | Content | 8213 |
+| Summary list | `summaryList()` | Content | 10406 |
+| Tables | `table()` | Content | 11412 |
+| Tabs | `tabs()` | Content | 12415 |
+| Tag | `tag()` | Content | 12508 |
+| Task list | `taskList()` | Content | 12557 |
+| Footer | `footer()` | Layout | 5546 |
+| Header | `header()` | Layout | 6131 |
+| Error summary | `errorSummary()` | Notifications | 5084 |
+| Notification banner | `notificationBanner()` | Notifications | 7764 |
+| Warning callout | `warningCallout()` | Notifications | 12872 |
 
 
 ---
@@ -1136,16 +1136,19 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   heading: "If you need help now, but it's not an emergency",
   headingLevel: 3
-}) %}
-  <p class="nhsuk-card__description">Go to <a href="#">NHS 111 online</a> or <a href="#">call 111</a>.</p>
-{% endcall %}
+}) -%}
+
+<p class="nhsuk-card__description">Go to <a href="#">NHS 111 online</a> or <a href="#">call 111</a>.</p>
+
+{%- endcall %}
 ```
 
 #### basic without heading
 
 ```njk
 {{ card({
-  description: "A quick guide for people who have care and support needs and their carers"
+  description:
+    "A quick guide for people who have care and support needs and their carers"
 }) }}
 ```
 
@@ -1157,7 +1160,8 @@ Use the component reference table below to find the line number for any componen
   heading: "Introduction to care and support",
   headingSize: "m",
   headingLevel: 3,
-  description: "A quick guide for people who have care and support needs and their carers"
+  description:
+    "A quick guide for people who have care and support needs and their carers"
 }) }}
 ```
 
@@ -1167,11 +1171,13 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   heading: "Help from NHS 111",
   headingLevel: 3
-}) %}
-  <p class="nhsuk-body">If you're worried about a symptom and not sure what help you need, NHS 111 can tell you what to do next.</p>
-  <p class="nhsuk-body">Go to <a href="#">111.nhs.uk</a> or <a href="#">call 111</a>.</p>
-  <p class="nhsuk-body">For a life-threatening emergency call 999.</p>
-{% endcall %}
+}) -%}
+
+<p class="nhsuk-body">If you're worried about a symptom and not sure what help you need, NHS 111 can tell you what to do next.</p>
+<p class="nhsuk-body">Go to <a href="#">111.nhs.uk</a> or <a href="#">call 111</a>.</p>
+<p class="nhsuk-body">For a life-threatening emergency call 999.</p>
+
+{%- endcall %}
 ```
 
 #### basic with summary list
@@ -1180,26 +1186,28 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   heading: "Regional Manager",
   headingLevel: 3
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### basic with summary lists
@@ -1208,48 +1216,50 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   heading: "Regional Managers",
   headingLevel: 3
-}) %}
-  <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">East</h4>
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-  
-  
-  <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">West</h4>
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Sarah Philips
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        5 January 1978
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">East</h4>
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+
+<h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">West</h4>
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Sarah Philips
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      5 January 1978
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### basic with summary list and button
@@ -1258,31 +1268,33 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   heading: "Regional Manager",
   headingLevel: 3
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-  
-  
-  <button class="nhsuk-button nhsuk-button--secondary" data-module="nhsuk-button" type="submit">
-    Add role
-  </button>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+
+<button class="nhsuk-button nhsuk-button--secondary" data-module="nhsuk-button" type="submit">
+  Add role
+</button>
+
+{%- endcall %}
 ```
 
 #### basic with summary list and actions
@@ -1303,26 +1315,28 @@ Use the component reference table below to find the line number for any componen
       }
     ]
   }
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### basic with summary list and actions, without heading
@@ -1343,26 +1357,28 @@ Use the component reference table below to find the line number for any componen
       }
     ]
   }
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### basic with summary list and actions (empty items)
@@ -1380,26 +1396,28 @@ Use the component reference table below to find the line number for any componen
       false
     ]
   }
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### basic with summary list and heading link
@@ -1409,26 +1427,28 @@ Use the component reference table below to find the line number for any componen
   href: "#",
   heading: "Regional Manager",
   headingLevel: 3
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### secondary without heading
@@ -1436,7 +1456,8 @@ Use the component reference table below to find the line number for any componen
 ```njk
 {{ card({
   variant: "secondary",
-  description: "A quick guide for people who have care and support needs and their carers"
+  description:
+    "A quick guide for people who have care and support needs and their carers"
 }) }}
 ```
 
@@ -1449,7 +1470,8 @@ Use the component reference table below to find the line number for any componen
   heading: "Introduction to care and support",
   headingSize: "m",
   headingLevel: 3,
-  description: "A quick guide for people who have care and support needs and their carers"
+  description:
+    "A quick guide for people who have care and support needs and their carers"
 }) }}
 ```
 
@@ -1460,11 +1482,13 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Help from NHS 111",
   headingLevel: 3
-}) %}
-  <p class="nhsuk-body">If you're worried about a symptom and not sure what help you need, NHS 111 can tell you what to do next.</p>
-  <p class="nhsuk-body">Go to <a href="#">111.nhs.uk</a> or <a href="#">call 111</a>.</p>
-  <p class="nhsuk-body">For a life-threatening emergency call 999.</p>
-{% endcall %}
+}) -%}
+
+<p class="nhsuk-body">If you're worried about a symptom and not sure what help you need, NHS 111 can tell you what to do next.</p>
+<p class="nhsuk-body">Go to <a href="#">111.nhs.uk</a> or <a href="#">call 111</a>.</p>
+<p class="nhsuk-body">For a life-threatening emergency call 999.</p>
+
+{%- endcall %}
 ```
 
 #### secondary with summary list
@@ -1474,26 +1498,28 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Regional Manager",
   headingLevel: 3
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### secondary with summary lists
@@ -1503,48 +1529,50 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Regional Managers",
   headingLevel: 3
-}) %}
-  <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">East</h4>
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-  
-  
-  <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">West</h4>
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Sarah Philips
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        5 January 1978
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">East</h4>
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+
+<h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">West</h4>
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Sarah Philips
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      5 January 1978
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### secondary with summary list and button
@@ -1554,31 +1582,33 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Regional Manager",
   headingLevel: 3
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-  
-  
-  <button class="nhsuk-button nhsuk-button--secondary" data-module="nhsuk-button" type="submit">
-    Add role
-  </button>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+
+<button class="nhsuk-button nhsuk-button--secondary" data-module="nhsuk-button" type="submit">
+  Add role
+</button>
+
+{%- endcall %}
 ```
 
 #### secondary with summary list and actions
@@ -1600,26 +1630,28 @@ Use the component reference table below to find the line number for any componen
       }
     ]
   }
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### secondary with summary list and actions, without heading
@@ -1641,26 +1673,28 @@ Use the component reference table below to find the line number for any componen
       }
     ]
   }
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### secondary with summary list and actions (empty items)
@@ -1679,26 +1713,28 @@ Use the component reference table below to find the line number for any componen
       false
     ]
   }
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### secondary with summary list and heading link
@@ -1709,26 +1745,28 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Regional Manager",
   headingLevel: 3
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### non-urgent (blue)
@@ -1738,15 +1776,17 @@ Use the component reference table below to find the line number for any componen
   heading: "Speak to a GP if:",
   headingLevel: 3,
   variant: "non-urgent"
-}) %}
-  <ul>
-    <li>you're not sure it's chickenpox</li>
-    <li>the skin around the blisters is red, hot or painful (signs of infection)</li>
-    <li>your child is <a href="https://www.nhs.uk/conditions/dehydration">dehydrated</a></li>
-    <li>you're concerned about your child or they get worse</li>
-  </ul>
-  <p>Tell the receptionist you think it's chickenpox before going in. They may recommend a special appointment time if other patients are at risk.</p>
-{% endcall %}
+}) -%}
+
+<ul>
+  <li>you're not sure it's chickenpox</li>
+  <li>the skin around the blisters is red, hot or painful (signs of infection)</li>
+  <li>your child is <a href="https://www.nhs.uk/conditions/dehydration">dehydrated</a></li>
+  <li>you're concerned about your child or they get worse</li>
+</ul>
+<p>Tell the receptionist you think it's chickenpox before going in. They may recommend a special appointment time if other patients are at risk.</p>
+
+{%- endcall %}
 ```
 
 #### urgent (red)
@@ -1756,15 +1796,17 @@ Use the component reference table below to find the line number for any componen
   heading: "Ask for an urgent GP appointment if:",
   headingLevel: 3,
   variant: "urgent"
-}) %}
-  <ul>
-    <li>you're an adult and have chickenpox</li>
-    <li>you're pregnant and haven't had chickenpox before and you've been near someone with it</li>
-    <li>you have a weakened immune system and you've been near someone with chickenpox</li>
-    <li>you think your newborn baby has chickenpox</li>
-  </ul>
-  <p>In these situations, your GP can prescribe medicine to prevent complications. You need to take it within 24 hours of the spots coming out.</p>
-{% endcall %}
+}) -%}
+
+<ul>
+  <li>you're an adult and have chickenpox</li>
+  <li>you're pregnant and haven't had chickenpox before and you've been near someone with it</li>
+  <li>you have a weakened immune system and you've been near someone with chickenpox</li>
+  <li>you think your newborn baby has chickenpox</li>
+</ul>
+<p>In these situations, your GP can prescribe medicine to prevent complications. You need to take it within 24 hours of the spots coming out.</p>
+
+{%- endcall %}
 ```
 
 #### emergency (red and black)
@@ -1774,14 +1816,16 @@ Use the component reference table below to find the line number for any componen
   heading: "Call 999 if you have sudden chest pain that:",
   headingLevel: 3,
   variant: "emergency"
-}) %}
-  <ul>
-    <li>spreads to your arms, back, neck or jaw</li>
-    <li>makes your chest feel tight or heavy</li>
-    <li>also started with shortness of breath, sweating and feeling or being sick</li>
-  </ul>
-  <p>You could be having a heart attack. Call 999 immediately as you need immediate treatment in hospital.</p>
-{% endcall %}
+}) -%}
+
+<ul>
+  <li>spreads to your arms, back, neck or jaw</li>
+  <li>makes your chest feel tight or heavy</li>
+  <li>also started with shortness of breath, sweating and feeling or being sick</li>
+</ul>
+<p>You could be having a heart attack. Call 999 immediately as you need immediate treatment in hospital.</p>
+
+{%- endcall %}
 ```
 
 #### emergency (red and black) with action link
@@ -1791,19 +1835,21 @@ Use the component reference table below to find the line number for any componen
   heading: "Call 999 or go to A&E now if:",
   headingLevel: 3,
   variant: "emergency"
-}) %}
-  <ul>
-    <li>you're coughing up more than just a few spots or streaks of blood – this could be a sign of serious bleeding in your lungs</li>
-    <li>you have severe difficulty breathing – you're gasping, choking or not able to get words out</li>
-  </ul>
-  
-  <a class="nhsuk-action-link nhsuk-action-link--reverse" href="#">
-    <svg class="nhsuk-icon nhsuk-icon--arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
-      <path d="M12 2a10 10 0 0 0-10 9h11.7l-4-4a1 1 0 0 1 1.5-1.4l5.6 5.7a1 1 0 0 1 0 1.4l-5.6 5.7a1 1 0 0 1-1.5 0 1 1 0 0 1 0-1.4l4-4H2A10 10 0 1 0 12 2z"/>
-    </svg>
-    <span class="nhsuk-action-link__text">Find your nearest A&amp;E</span>
-  </a>
-{% endcall %}
+}) -%}
+
+<ul>
+  <li>you're coughing up more than just a few spots or streaks of blood – this could be a sign of serious bleeding in your lungs</li>
+  <li>you have severe difficulty breathing – you're gasping, choking or not able to get words out</li>
+</ul>
+
+<a class="nhsuk-action-link nhsuk-action-link--reverse" href="#">
+  <svg class="nhsuk-icon nhsuk-icon--arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+    <path d="M12 2a10 10 0 0 0-10 9h11.7l-4-4a1 1 0 0 1 1.5-1.4l5.6 5.7a1 1 0 0 1 0 1.4l-5.6 5.7a1 1 0 0 1-1.5 0 1 1 0 0 1 0-1.4l4-4H2A10 10 0 1 0 12 2z"/>
+  </svg>
+  <span class="nhsuk-action-link__text">Find your nearest A&amp;E</span>
+</a>
+
+{%- endcall %}
 ```
 
 #### primary (with chevron)
@@ -1827,7 +1873,8 @@ Use the component reference table below to find the line number for any componen
   clickable: true,
   heading: "Introduction to care and support",
   headingSize: "m",
-  description: "A quick guide for people who have care and support needs and their carers"
+  description:
+    "A quick guide for people who have care and support needs and their carers"
 }) }}
 ```
 
@@ -1839,7 +1886,8 @@ Use the component reference table below to find the line number for any componen
   clickable: true,
   heading: "Introduction to care and support",
   headingSize: "m",
-  description: "A quick guide for people who have care and support needs and their carers"
+  description:
+    "A quick guide for people who have care and support needs and their carers"
 }) }}
 ```
 
@@ -1852,7 +1900,8 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Urgent and emergency care services",
   headingSize: "m",
-  description: "Services the NHS provides if you need urgent or emergency medical help"
+  description:
+    "Services the NHS provides if you need urgent or emergency medical help"
 }) }}
 ```
 
@@ -1864,8 +1913,8 @@ Use the component reference table below to find the line number for any componen
   variant: "secondary",
   heading: "Why we are reinvesting in the NHS Prototype kit",
   headingClasses: "nhsuk-u-font-size-22 nhsuk-u-margin-bottom-2",
-  descriptionHtml: "<p class="nhsuk-body-s nhsuk-u-margin-bottom-2">21 July 2025</p>
-<p class="nhsuk-card__description">Frankie and Mike explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it.</p>"
+  descriptionHtml:
+    '<p class="nhsuk-body-s nhsuk-u-margin-bottom-2">21 July 2025</p>\n<p class="nhsuk-card__description">Frankie and Mike explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it.</p>'
 }) }}
 ```
 
@@ -1887,11 +1936,8 @@ Use the component reference table below to find the line number for any componen
   heading: "A",
   headingId: "a",
   headingSize: "m",
-  descriptionHtml: "<ul class="nhsuk-list nhsuk-list--border">
-  <li><a href="#/conditions/abdominal-aortic-aneurysm/">AAA, see Abdominal aortic aneurysm</a></li>
-  <li><a href="#/conditions/abdominal-aortic-aneurysm/">Abdominal aortic aneurysm</a></li>
-  <li><a href="#/conditions/abscess/">Abscess</a></li>
-</ul>"
+  descriptionHtml:
+    '<ul class="nhsuk-list nhsuk-list--border">\n  <li><a href="#/conditions/abdominal-aortic-aneurysm/">AAA, see Abdominal aortic aneurysm</a></li>\n  <li><a href="#/conditions/abdominal-aortic-aneurysm/">Abdominal aortic aneurysm</a></li>\n  <li><a href="#/conditions/abscess/">Abscess</a></li>\n</ul>'
 }) }}
 ```
 
@@ -1901,26 +1947,28 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   variant: "feature",
   heading: "Feature card heading"
-}) %}
-  <dl class="nhsuk-summary-list">
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        Karen Francis
-      </dd>
-    </div>
-    <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-      <dt class="nhsuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        15 March 1984
-      </dd>
-    </div>
-  </dl>
-{% endcall %}
+}) -%}
+
+<dl class="nhsuk-summary-list">
+  <div class="nhsuk-summary-list__row">
+    <dt class="nhsuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      Karen Francis
+    </dd>
+  </div>
+  <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+    <dt class="nhsuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="nhsuk-summary-list__value">
+      15 March 1984
+    </dd>
+  </div>
+</dl>
+
+{%- endcall %}
 ```
 
 #### feature with nested card and summary list
@@ -1929,51 +1977,53 @@ Use the component reference table below to find the line number for any componen
 {% call card({
   variant: "feature",
   heading: "Flu: Follow-up requested"
-}) %}
-  <p>Sarah Philips (Mum) would like to speak to a member of the team about other options for their child's vaccination.</p>
-  <a class="nhsuk-button nhsuk-button--secondary" data-module="nhsuk-button" href="#" role="button" draggable="false">
-    Record a new consent response
-  </a>
-  
-  
-  <h3 class="nhsuk-heading-s">Consent responses</h3>
-  
-  <div class="nhsuk-card nhsuk-card--clickable">
-    <div class="nhsuk-card__content">
-      <h4 class="nhsuk-card__heading">
-        <a class="nhsuk-card__link" href="#">Sarah Philips (Mum)</a>
-      </h4>
-      <dl class="nhsuk-summary-list">
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Email address
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            sarah.philips@example.com
-          </dd>
-        </div>
-        <div class="nhsuk-summary-list__row">
-          <dt class="nhsuk-summary-list__key">
-            Date
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            25 August 2025 at 4:04 pm
-          </dd>
-        </div>
-        <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
-          <dt class="nhsuk-summary-list__key">
-            Response
-          </dt>
-          <dd class="nhsuk-summary-list__value">
-            <strong class="nhsuk-tag nhsuk-tag--orange">
-              Follow up requested
-            </strong>
-          </dd>
-        </div>
-      </dl>
-    </div>
+}) -%}
+
+<p>Sarah Philips (Mum) would like to speak to a member of the team about other options for their child's vaccination.</p>
+<a class="nhsuk-button nhsuk-button--secondary" data-module="nhsuk-button" href="#" role="button" draggable="false">
+  Record a new consent response
+</a>
+
+
+<h3 class="nhsuk-heading-s">Consent responses</h3>
+
+<div class="nhsuk-card nhsuk-card--clickable">
+  <div class="nhsuk-card__content">
+    <h4 class="nhsuk-card__heading">
+      <a class="nhsuk-card__link" href="#">Sarah Philips (Mum)</a>
+    </h4>
+    <dl class="nhsuk-summary-list">
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Email address
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          sarah.philips@example.com
+        </dd>
+      </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          Date
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          25 August 2025 at 4:04 pm
+        </dd>
+      </div>
+      <div class="nhsuk-summary-list__row nhsuk-summary-list__row--no-border">
+        <dt class="nhsuk-summary-list__key">
+          Response
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          <strong class="nhsuk-tag nhsuk-tag--orange">
+            Follow up requested
+          </strong>
+        </dd>
+      </div>
+    </dl>
   </div>
-{% endcall %}
+</div>
+
+{%- endcall %}
 ```
 
 #### warning
@@ -1982,7 +2032,8 @@ Use the component reference table below to find the line number for any componen
 {{ card({
   variant: "warning",
   heading: "School, nursery or work",
-  description: "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
+  description:
+    "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
 }) }}
 ```
 
@@ -1992,7 +2043,8 @@ Use the component reference table below to find the line number for any componen
 {{ card({
   variant: "warning",
   heading: "School, nursery or work",
-  description: "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.",
+  description:
+    "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.",
   actions: {
     items: [
       {
@@ -2015,7 +2067,8 @@ Use the component reference table below to find the line number for any componen
   clickable: true,
   heading: "Exercise",
   headingSize: "m",
-  description: "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
+  description:
+    "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
 }) }}
 ```
 
@@ -2024,19 +2077,14 @@ Use the component reference table below to find the line number for any componen
 ```njk
 {{ card({
   image: {
-    html: "<figure class="nhsuk-image">
-  <img class="nhsuk-image__img" src="https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg" alt="">
-  <figcaption class="nhsuk-image__caption">
-    No specific amount of time is recommended, but a typical training session could take less than 20 minutes.
-  </figcaption>
-</figure>
-"
+    html: '<figure class="nhsuk-image">\n  <img class="nhsuk-image__img" src="https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg" alt="">\n  <figcaption class="nhsuk-image__caption">\n    No specific amount of time is recommended, but a typical training session could take less than 20 minutes.\n  </figcaption>\n</figure>\n'
   },
   href: "#",
   clickable: true,
   heading: "Exercise",
   headingSize: "m",
-  description: "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
+  description:
+    "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
 }) }}
 ```
 
@@ -2051,9 +2099,10 @@ Use the component reference table below to find the line number for any componen
   clickable: true,
   heading: "Why we are reinvesting in the NHS prototype kit",
   headingSize: "m",
-  headingHtml: "<p class="nhsuk-body-s nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-0"><span class="nhsuk-u-visually-hidden">Published on: </span>21 July 2025</p>
-<p class="nhsuk-body-s nhsuk-u-font-weight-bold">NHS England Design Matters blog</p>",
-  description: "Frankie Roberto and Mike Gallagher explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it."
+  headingHtml:
+    '<p class="nhsuk-body-s nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-0"><span class="nhsuk-u-visually-hidden">Published on: </span>21 July 2025</p>\n<p class="nhsuk-body-s nhsuk-u-font-weight-bold">NHS England Design Matters blog</p>',
+  description:
+    "Frankie Roberto and Mike Gallagher explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it."
 }) }}
 ```
 
@@ -2180,7 +2229,8 @@ Use the component reference table below to find the line number for any componen
   id: "with-error-message",
   name: "example",
   maxlength: 350,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
 }) }}
 ```
 
@@ -2202,7 +2252,8 @@ Use the component reference table below to find the line number for any componen
   id: "with-error-message",
   name: "example",
   maxlength: 350,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
 }) }}
 ```
 
@@ -2218,7 +2269,8 @@ Use the component reference table below to find the line number for any componen
   id: "with-value",
   name: "example",
   maxlength: 350,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
 }) }}
 ```
 
@@ -2345,7 +2397,8 @@ Use the component reference table below to find the line number for any componen
   name: "example",
   countType: "characters",
   maxlength: 350,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
 }) }}
 ```
 
@@ -2362,7 +2415,8 @@ Use the component reference table below to find the line number for any componen
   name: "example",
   countType: "characters",
   maxlength: 350,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
 }) }}
 ```
 
@@ -2378,7 +2432,8 @@ Use the component reference table below to find the line number for any componen
   id: "with-characters-count-type-threshold",
   name: "example",
   countType: "characters",
-  value: "Type another letter into this field after this message to see the threshold feature",
+  value:
+    "Type another letter into this field after this message to see the threshold feature",
   maxlength: 112,
   threshold: 75
 }) }}
@@ -2416,7 +2471,8 @@ Use the component reference table below to find the line number for any componen
   name: "example",
   countType: "words",
   maxlength: 51,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
 }) }}
 ```
 
@@ -2432,7 +2488,8 @@ Use the component reference table below to find the line number for any componen
   id: "with-words-count-type-threshold",
   name: "example",
   countType: "words",
-  value: "Type another word into this field after this message to see the threshold feature",
+  value:
+    "Type another word into this field after this message to see the threshold feature",
   maxlength: 51,
   threshold: 30
 }) }}
@@ -2451,7 +2508,8 @@ Use the component reference table below to find the line number for any componen
   name: "example",
   countType: "words",
   maxlength: 51,
-  value: "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
+  value:
+    "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
 }) }}
 ```
 
@@ -2466,7 +2524,8 @@ Use the component reference table below to find the line number for any componen
   },
   id: "with-threshold",
   name: "example",
-  value: "Type another letter into this field after this message to see the threshold feature",
+  value:
+    "Type another letter into this field after this message to see the threshold feature",
   maxlength: 112,
   threshold: 75
 }) }}
@@ -2822,48 +2881,27 @@ Use the component reference table below to find the line number for any componen
   },
   idPrefix: "conditional",
   name: "contact",
-  values: [
-    "email",
-    "text"
-  ],
+  values: ["email", "text"],
   items: [
     {
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -3019,29 +3057,15 @@ Use the component reference table below to find the line number for any componen
   items: [
     {
       value: "nullam",
-      text: "Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
-quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
-Maecenas faucibus mollis interdum. Donec id elit non mi porta gravida
-at eget metus."
+      text: "Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo\nquam. Pellentesque ornare sem lacinia quam venenatis vestibulum.\nMaecenas faucibus mollis interdum. Donec id elit non mi porta gravida\nat eget metus."
     },
     {
       value: "aenean",
-      text: "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
-vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
-nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis
-natoque penatibus et magnis dis parturient montes, nascetur ridiculus
-mus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
-venenatis vestibulum. Cras mattis consectetur purus sit amet
-fermentum."
+      text: "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis\nvestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,\nnisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis\nnatoque penatibus et magnis dis parturient montes, nascetur ridiculus\nmus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam\nvenenatis vestibulum. Cras mattis consectetur purus sit amet\nfermentum."
     },
     {
       value: "fusce",
-      text: "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
-nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
-malesuada magna mollis euismod. Praesent commodo cursus magna, vel
-scelerisque nisl consectetur et. Etiam porta sem malesuada magna
-mollis euismod. Etiam porta sem malesuada magna mollis euismod.
-Donec sed odio dui. Sed posuere consectetur est at lobortis."
+      text: "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum\nnibh, ut fermentum massa justo sit amet risus. Etiam porta sem\nmalesuada magna mollis euismod. Praesent commodo cursus magna, vel\nscelerisque nisl consectetur et. Etiam porta sem malesuada magna\nmollis euismod. Etiam porta sem malesuada magna mollis euismod.\nDonec sed odio dui. Sed posuere consectetur est at lobortis."
     }
   ]
 }) }}
@@ -3132,39 +3156,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -3192,39 +3198,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -3255,39 +3243,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -3310,50 +3280,27 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
   },
   idPrefix: "conditional",
   name: "example",
-  values: [
-    "phone"
-  ],
+  values: ["phone"],
   items: [
     {
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group nhsuk-form-group--error">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <span class="nhsuk-error-message" id="contact-by-phone-error">
-    <span class="nhsuk-u-visually-hidden">Error:</span> Enter your phone number
-  </span>
-  <input class="nhsuk-input nhsuk-input--error nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel" aria-describedby="contact-by-phone-error">
-</div>
-"
+        html: '<div class="nhsuk-form-group nhsuk-form-group--error">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <p class="nhsuk-error-message" id="contact-by-phone-error">\n    <span class="nhsuk-u-visually-hidden">Error:</span> Enter your phone number\n  </p>\n  <input class="nhsuk-input nhsuk-input--error nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel" aria-describedby="contact-by-phone-error">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -3416,39 +3363,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     },
     {
@@ -3650,9 +3579,11 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
 ```njk
 {% call code({
   button: true
-}) %}
-  &lt;p&gt;This is a code block.&lt;/p&gt;
-{% endcall %}
+}) -%}
+
+&lt;p&gt;This is a code block.&lt;/p&gt;
+
+{%- endcall %}
 ```
 
 #### with scroll overflow
@@ -4696,17 +4627,19 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
 ```njk
 {% call details({
   summaryText: "How to find your NHS number"
-}) %}
-  <p>An NHS number is a 10 digit number, like <span class="nhsuk-u-nowrap">999 123 4567</span>.</p>
-  <p>You can find your NHS number by logging in to the NHS App or on any document the NHS has sent you, such as your:</p>
-  <ul>
-    <li>prescriptions</li>
-    <li>test results</li>
-    <li>hospital referral letters</li>
-    <li>appointment letters</li>
-  </ul>
-  <p>Ask your GP surgery for help if you cannot find your NHS number.</p>
-{% endcall %}
+}) -%}
+
+<p>An NHS number is a 10 digit number, like <span class="nhsuk-u-nowrap">999 123 4567</span>.</p>
+<p>You can find your NHS number by logging in to the NHS App or on any document the NHS has sent you, such as your:</p>
+<ul>
+  <li>prescriptions</li>
+  <li>test results</li>
+  <li>hospital referral letters</li>
+  <li>appointment letters</li>
+</ul>
+<p>Ask your GP surgery for help if you cannot find your NHS number.</p>
+
+{%- endcall %}
 ```
 
 #### open
@@ -4715,17 +4648,19 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
 {% call details({
   summaryText: "How to find your NHS number",
   open: true
-}) %}
-  <p>An NHS number is a 10 digit number, like <span class="nhsuk-u-nowrap">999 123 4567</span>.</p>
-  <p>You can find your NHS number by logging in to the NHS App or on any document the NHS has sent you, such as your:</p>
-  <ul>
-    <li>prescriptions</li>
-    <li>test results</li>
-    <li>hospital referral letters</li>
-    <li>appointment letters</li>
-  </ul>
-  <p>Ask your GP surgery for help if you cannot find your NHS number.</p>
-{% endcall %}
+}) -%}
+
+<p>An NHS number is a 10 digit number, like <span class="nhsuk-u-nowrap">999 123 4567</span>.</p>
+<p>You can find your NHS number by logging in to the NHS App or on any document the NHS has sent you, such as your:</p>
+<ul>
+  <li>prescriptions</li>
+  <li>test results</li>
+  <li>hospital referral letters</li>
+  <li>appointment letters</li>
+</ul>
+<p>Ask your GP surgery for help if you cannot find your NHS number.</p>
+
+{%- endcall %}
 ```
 
 #### expander
@@ -4734,78 +4669,80 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
 {% call details({
   summaryText: "Opening times",
   classes: "nhsuk-expander"
-}) %}
-  <table class="nhsuk-table">
-    <thead class="nhsuk-table__head">
-      <tr class="nhsuk-table__row">
-        <th scope="col" class="nhsuk-table__header">
-          Day of the week
-        </th>
-        <th scope="col" class="nhsuk-table__header">
-          Opening hours
-        </th>
-      </tr>
-    </thead>
-    <tbody class="nhsuk-table__body">
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Monday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Tuesday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Wednesday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Thursday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Friday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Saturday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 1pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Sunday
-        </th>
-        <td class="nhsuk-table__cell">
-          Closed
-        </td>
-      </tr>
-    </tbody>
-  </table>
-{% endcall %}
+}) -%}
+
+<table class="nhsuk-table">
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th scope="col" class="nhsuk-table__header">
+        Day of the week
+      </th>
+      <th scope="col" class="nhsuk-table__header">
+        Opening hours
+      </th>
+    </tr>
+  </thead>
+  <tbody class="nhsuk-table__body">
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Monday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Tuesday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Wednesday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Thursday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Friday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Saturday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 1pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Sunday
+      </th>
+      <td class="nhsuk-table__cell">
+        Closed
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{%- endcall %}
 ```
 
 #### expander open
@@ -4815,78 +4752,80 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
   summaryText: "Opening times",
   classes: "nhsuk-expander",
   open: true
-}) %}
-  <table class="nhsuk-table">
-    <thead class="nhsuk-table__head">
-      <tr class="nhsuk-table__row">
-        <th scope="col" class="nhsuk-table__header">
-          Day of the week
-        </th>
-        <th scope="col" class="nhsuk-table__header">
-          Opening hours
-        </th>
-      </tr>
-    </thead>
-    <tbody class="nhsuk-table__body">
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Monday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Tuesday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Wednesday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Thursday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Friday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 6pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Saturday
-        </th>
-        <td class="nhsuk-table__cell">
-          9am to 1pm
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <th scope="row" class="nhsuk-table__header">
-          Sunday
-        </th>
-        <td class="nhsuk-table__cell">
-          Closed
-        </td>
-      </tr>
-    </tbody>
-  </table>
-{% endcall %}
+}) -%}
+
+<table class="nhsuk-table">
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th scope="col" class="nhsuk-table__header">
+        Day of the week
+      </th>
+      <th scope="col" class="nhsuk-table__header">
+        Opening hours
+      </th>
+    </tr>
+  </thead>
+  <tbody class="nhsuk-table__body">
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Monday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Tuesday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Wednesday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Thursday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Friday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 6pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Saturday
+      </th>
+      <td class="nhsuk-table__cell">
+        9am to 1pm
+      </td>
+    </tr>
+    <tr class="nhsuk-table__row">
+      <th scope="row" class="nhsuk-table__header">
+        Sunday
+      </th>
+      <td class="nhsuk-table__cell">
+        Closed
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{%- endcall %}
 ```
 
 ---
@@ -5302,35 +5241,37 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
     size: "l",
     isPageHeading: true
   }
-}) %}
-  <div class="nhsuk-form-group">
-    <label class="nhsuk-label" for="address-line1">
-      Address line 1
-    </label>
-    <input class="nhsuk-input" id="address-line1" name="address-line1" type="text" autocomplete="address-line1">
-  </div>
-  
-  <div class="nhsuk-form-group">
-    <label class="nhsuk-label" for="address-line2">
-      Address line 2 (optional)
-    </label>
-    <input class="nhsuk-input" id="address-line2" name="address-line2" type="text" autocomplete="address-line2">
-  </div>
-  
-  <div class="nhsuk-form-group">
-    <label class="nhsuk-label" for="address-town">
-      Town or city
-    </label>
-    <input class="nhsuk-input nhsuk-u-width-two-thirds" id="address-town" name="address-town" type="text" autocomplete="address-level2">
-  </div>
-  
-  <div class="nhsuk-form-group">
-    <label class="nhsuk-label" for="address-postcode">
-      Postcode
-    </label>
-    <input class="nhsuk-input nhsuk-input--width-10" id="address-postcode" name="address-postcode" type="text" autocomplete="postal-code">
-  </div>
-{% endcall %}
+}) -%}
+
+<div class="nhsuk-form-group">
+  <label class="nhsuk-label" for="address-line1">
+    Address line 1
+  </label>
+  <input class="nhsuk-input" id="address-line1" name="address-line1" type="text" autocomplete="address-line1">
+</div>
+
+<div class="nhsuk-form-group">
+  <label class="nhsuk-label" for="address-line2">
+    Address line 2 (optional)
+  </label>
+  <input class="nhsuk-input" id="address-line2" name="address-line2" type="text" autocomplete="address-line2">
+</div>
+
+<div class="nhsuk-form-group">
+  <label class="nhsuk-label" for="address-town">
+    Town or city
+  </label>
+  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="address-town" name="address-town" type="text" autocomplete="address-level2">
+</div>
+
+<div class="nhsuk-form-group">
+  <label class="nhsuk-label" for="address-postcode">
+    Postcode
+  </label>
+  <input class="nhsuk-input nhsuk-input--width-10" id="address-postcode" name="address-postcode" type="text" autocomplete="postal-code">
+</div>
+
+{%- endcall %}
 ```
 
 #### legend
@@ -5758,8 +5699,7 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
     text: ""
   },
   meta: {
-    html: "<p class="nhsuk-body-s">All content is available under the Open Government Licence v3.0, except where otherwise stated.</p>
-<p class="nhsuk-body-s">© Custom copyright</p>",
+    html: '<p class="nhsuk-body-s">All content is available under the Open Government Licence v3.0, except where otherwise stated.</p>\n<p class="nhsuk-body-s">© Custom copyright</p>',
     items: [
       {
         href: "#",
@@ -6003,16 +5943,11 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
     },
     {
       width: "one-half",
-      html: "<p class="nhsuk-body-s nhsuk-u-margin-bottom-6"><strong>Manchester
-University NHS Foundation Trust (MFT)</strong> was formed on 1st
-October 2017 following the merger of Central Manchester University
-Hospitals NHS Foundation Trust (CMFT) and University Hospital of
-South Manchester NHS Foundation Trust (UHSM).</p>"
+      html: '<p class="nhsuk-body-s nhsuk-u-margin-bottom-6"><strong>Manchester\nUniversity NHS Foundation Trust (MFT)</strong> was formed on 1st\nOctober 2017 following the merger of Central Manchester University\nHospitals NHS Foundation Trust (CMFT) and University Hospital of\nSouth Manchester NHS Foundation Trust (UHSM).</p>'
     },
     {
       width: "full",
-      html: "<p class="nhsuk-body-s">Cobbett House, Manchester University NHS
-Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
+      html: '<p class="nhsuk-body-s">Cobbett House, Manchester University NHS\nFoundation Trust, Oxford Road, Manchester, M13 9WL</p>'
     }
   ]
 }) }}
@@ -6164,12 +6099,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
     }
   ],
   meta: {
-    html: "<p class="nhsuk-body-s">
-  <svg class="nhsuk-u-static-margin-right-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41 17" aria-hidden="true" focusable="false" height="17" width="41">
-    <path fill="currentColor" d="M35.77 12.4V.02l-4.3 2.8V16.8H41v-4.4Zm-10.38-.83a3.93 3.93 0 0 1-4.29.64 4.09 4.09 0 0 1-2.35-3.71 3.97 3.97 0 0 1 7.36-2.2l3.63-2.35A8.25 8.25 0 0 0 22.75.02c-3.1 0-5.8 1.74-7.22 4.3A8.3 8.3 0 0 0 8.3.02 8.4 8.4 0 0 0 0 8.5a8.4 8.4 0 0 0 8.3 8.48c3.1 0 5.8-1.75 7.22-4.32a8.17 8.17 0 0 0 12.7 2.2l1.64 1.93h.25V9.18h-6.79Zm-17.1 1.02A4.04 4.04 0 0 1 4.3 8.5c0-2.25 1.8-4.08 4-4.08s4 1.82 4 4.08c0 2.25-1.8 4.09-4 4.09"/>
-  </svg>
-  All content is available under the <a class="nhsuk-footer__list-item-link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated.
-</p>",
+    html: '<p class="nhsuk-body-s">\n  <svg class="nhsuk-u-static-margin-right-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41 17" aria-hidden="true" focusable="false" height="17" width="41">\n    <path fill="currentColor" d="M35.77 12.4V.02l-4.3 2.8V16.8H41v-4.4Zm-10.38-.83a3.93 3.93 0 0 1-4.29.64 4.09 4.09 0 0 1-2.35-3.71 3.97 3.97 0 0 1 7.36-2.2l3.63-2.35A8.25 8.25 0 0 0 22.75.02c-3.1 0-5.8 1.74-7.22 4.3A8.3 8.3 0 0 0 8.3.02 8.4 8.4 0 0 0 0 8.5a8.4 8.4 0 0 0 8.3 8.48c3.1 0 5.8-1.75 7.22-4.32a8.17 8.17 0 0 0 12.7 2.2l1.64 1.93h.25V9.18h-6.79Zm-17.1 1.02A4.04 4.04 0 0 1 4.3 8.5c0-2.25 1.8-4.08 4-4.08s4 1.82 4 4.08c0 2.25-1.8 4.09-4 4.09"/>\n  </svg>\n  All content is available under the <a class="nhsuk-footer__list-item-link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated.\n</p>',
     items: [
       {
         href: "#",
@@ -7040,11 +6970,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   heading: "This is a header for the product or service",
   headingSize: "l",
   headingClasses: "nhsuk-u-margin-top-5",
-  html: "<p class="nhsuk-body-l">This is some more content which explains the product or service.</p>
-<a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">
-  Sign up
-</a>
-"
+  html: '<p class="nhsuk-body-l">This is some more content which explains the product or service.</p>\n<a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">\n  Sign up\n</a>\n'
 }) }}
 ```
 
@@ -7119,7 +7045,8 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 {{ image({
   src: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg",
   sizes: "(max-width: 768px) 100vw, 66vw",
-  srcset: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w",
+  srcset:
+    "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w",
   caption: {
     text: "Stretch marks can be pink, red, brown, black, silver or purple. They usually start off darker and fade over time."
   }
@@ -7132,7 +7059,8 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 {{ image({
   src: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg",
   sizes: "(max-width: 768px) 100vw, 66vw",
-  srcset: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w",
+  srcset:
+    "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w",
   alt: "Close-up of a person's tummy showing a number of creases in the skin under their belly button. Shown on light brown skin.",
   caption: {
     text: "Stretch marks can be pink, red, brown, black, silver or purple. They usually start off darker and fade over time."
@@ -7243,7 +7171,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
     isPageHeading: true
   },
   hint: {
-    html: "This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App"
+    html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
   },
   id: "with-hint",
   name: "example",
@@ -7271,10 +7199,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   spellcheck: false,
   formGroup: {
     afterInput: {
-      html: "<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">
-  Search
-</button>
-"
+      html: '<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">\n  Search\n</button>\n'
     }
   }
 }) }}
@@ -7300,10 +7225,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   spellcheck: false,
   formGroup: {
     afterInput: {
-      html: "<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">
-  Search
-</button>
-"
+      html: '<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">\n  Search\n</button>\n'
     }
   }
 }) }}
@@ -7340,7 +7262,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
     isPageHeading: true
   },
   hint: {
-    html: "This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App"
+    html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
   },
   errorMessage: {
     text: "Enter NHS number"
@@ -7438,7 +7360,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
     isPageHeading: true
   },
   hint: {
-    html: "This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App"
+    html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
   },
   id: "with-code-input-styling",
   name: "example",
@@ -7738,9 +7660,11 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 #### default
 
 ```njk
-{% call insetText({}) %}
-  <p>You can report any suspected side effect using the <a href="#">Yellow Card safety scheme</a>.</p>
-{% endcall %}
+{% call insetText() -%}
+
+<p>You can report any suspected side effect using the <a href="#">Yellow Card safety scheme</a>.</p>
+
+{%- endcall %}
 ```
 
 ---
@@ -7879,7 +7803,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 
 ```njk
 {{ notificationBanner({
-  html: "<p class="nhsuk-notification-banner__heading">You have 9 days to send a response.</p>"
+  html: '<p class="nhsuk-notification-banner__heading">You have 9 days to send a response.</p>'
 }) }}
 ```
 
@@ -7887,12 +7811,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 
 ```njk
 {{ notificationBanner({
-  html: "<h3 class="nhsuk-notification-banner__heading">
-  The patient record was updated
-</h3>
-<p class="nhsuk-body">
-  Contact <a class="nhsuk-notification-banner__link" href="#">example@nhs.uk</a> if you think there's a problem.
-</p>"
+  html: '<h3 class="nhsuk-notification-banner__heading">\n  The patient record was updated\n</h3>\n<p class="nhsuk-body">\n  Contact <a class="nhsuk-notification-banner__link" href="#">example@nhs.uk</a> if you think there\'s a problem.\n</p>'
 }) }}
 ```
 
@@ -7910,13 +7829,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 ```njk
 {{ notificationBanner({
   variant: "success",
-  html: "<h3 class="nhsuk-notification-banner__heading">
-  4 files uploaded
-</h3>
-<ul class="nhsuk-u-margin-0 nhsuk-list">
-  <li><a href="link-1" class="nhsuk-notification-banner__link">government-strategy.pdf</a></li>
-  <li><a href="link-2" class="nhsuk-notification-banner__link">government-strategy-v1.pdf</a></li>
-</ul>"
+  html: '<h3 class="nhsuk-notification-banner__heading">\n  4 files uploaded\n</h3>\n<ul class="nhsuk-u-margin-0 nhsuk-list">\n  <li><a href="link-1" class="nhsuk-notification-banner__link">government-strategy.pdf</a></li>\n  <li><a href="link-2" class="nhsuk-notification-banner__link">government-strategy-v1.pdf</a></li>\n</ul>'
 }) }}
 ```
 
@@ -7924,13 +7837,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 
 ```njk
 {{ notificationBanner({
-  html: "<h3 class="nhsuk-notification-banner__heading">4 files uploaded</h3>
-<ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-margin-bottom-0">
-  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy.pdf</a></li>
-  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy-v2.pdf</a></li>
-  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy-v3-FINAL.pdf</a></li>
-  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy-v4-FINAL-v2.pdf</a></li>
-</ul>"
+  html: '<h3 class="nhsuk-notification-banner__heading">4 files uploaded</h3>\n<ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-margin-bottom-0">\n  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy.pdf</a></li>\n  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy-v2.pdf</a></li>\n  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy-v3-FINAL.pdf</a></li>\n  <li><a href="#" class="nhsuk-notification-banner__link">government-strategy-v4-FINAL-v2.pdf</a></li>\n</ul>'
 }) }}
 ```
 
@@ -7946,16 +7853,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 
 ```njk
 {{ notificationBanner({
-  html: "<h3 class="nhsuk-notification-banner__heading">
-  Check if you need to apply the reverse charge to this application
-</h3>
-<p class="nhsuk-body">
-  You will have to apply the <a href="#" class="nhsuk-notification-banner__link">reverse charge</a> if the applicant supplies any of these services:
-</p>
-<ul class="nhsuk-list nhsuk-list--bullet">
-  <li>constructing, altering, repairing, extending, demolishing or dismantling buildings or structures (whether permanent or not), including offshore installation services</li>
-  <li>constructing, altering, repairing, extending, demolishing of any works forming, or planned to form, part of the land, including (in particular) walls, roadworks, power lines, electronic communications equipment, aircraft runways, railways, inland waterways, docks and harbours</li>
-</ul>"
+  html: '<h3 class="nhsuk-notification-banner__heading">\n  Check if you need to apply the reverse charge to this application\n</h3>\n<p class="nhsuk-body">\n  You will have to apply the <a href="#" class="nhsuk-notification-banner__link">reverse charge</a> if the applicant supplies any of these services:\n</p>\n<ul class="nhsuk-list nhsuk-list--bullet">\n  <li>constructing, altering, repairing, extending, demolishing or dismantling buildings or structures (whether permanent or not), including offshore installation services</li>\n  <li>constructing, altering, repairing, extending, demolishing of any works forming, or planned to form, part of the land, including (in particular) walls, roadworks, power lines, electronic communications equipment, aircraft runways, railways, inland waterways, docks and harbours</li>\n</ul>'
 }) }}
 ```
 
@@ -8331,8 +8229,8 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
 | `text` | string | ✓ | If `html` is set, this is not required. Text to use within the panel content. If `html` is provided, the `text` option will be ignored. |
 | `html` | string | ✓ | If `text` is set, this is not required. Text to use within the panel content. If `text` is provided, the `html` option will be ignored. |
 | `caller` | nunjucks-block |  | Not strictly a parameter but a Nunjucks code convention. Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire panel component in a `call` block. |
-| `classes` | string |  | Optional additional classes to add to the hint `div` tag. Separate each class with a space. |
-| `attributes` | object |  | Any extra HTML attributes (for example data attributes) to add to the input component. |
+| `classes` | string |  | Classes to add to the panel. |
+| `attributes` | object |  | HTML attributes (for example data attributes) to add to the panel. |
 | `variant` | string |  | Optional variant of panel. You can use only `"interruption"` or empty values with this option. |
 
 ### Examples
@@ -8353,15 +8251,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   titleText: "Jodie Brown had a COVID-19 vaccine less than 3 months ago",
   titleSize: "l",
   variant: "interruption",
-  html: "<p>They had a COVID-19 vaccine on 25 September 2025.</p>
-<p>For most people, the minimum recommended gap between COVID-19 vaccine doses is 3 months.</p>
-<div class="nhsuk-button-group">
-  <a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">
-  Continue anyway
-</a>
-
-  <a href="#">Cancel</a>
-</div>"
+  html: '<p>They had a COVID-19 vaccine on 25 September 2025.</p>\n<p>For most people, the minimum recommended gap between COVID-19 vaccine doses is 3 months.</p>\n<div class="nhsuk-button-group">\n  <a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">\n  Continue anyway\n</a>\n\n  <a href="#">Cancel</a>\n</div>'
 }) }}
 ```
 
@@ -8372,15 +8262,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   titleText: "Confirm you want to cancel your hospital appointment",
   titleSize: "l",
   variant: "interruption",
-  html: "<p>You will be able to reschedule your appointment for another time, but this may delay your treatment.</p>
-<p>Cancelling your appointment cannot be undone.</p>
-<div class="nhsuk-button-group">
-  <a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">
-  Cancel appointment
-</a>
-
-  <a href="#">Change my weight</a>
-</div>"
+  html: '<p>You will be able to reschedule your appointment for another time, but this may delay your treatment.</p>\n<p>Cancelling your appointment cannot be undone.</p>\n<div class="nhsuk-button-group">\n  <a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">\n  Cancel appointment\n</a>\n\n  <a href="#">Change my weight</a>\n</div>'
 }) }}
 ```
 
@@ -8391,14 +8273,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   titleText: "Is your weight correct?",
   titleSize: "l",
   variant: "interruption",
-  html: "<p>You entered your weight as <b>21.4 kilograms</b>. This is lower than expected.</p>
-<div class="nhsuk-button-group">
-  <a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">
-  Yes, this is correct
-</a>
-
-  <a href="#">Change my weight</a>
-</div>"
+  html: '<p>You entered your weight as <b>21.4 kilograms</b>. This is lower than expected.</p>\n<div class="nhsuk-button-group">\n  <a class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" href="#" role="button" draggable="false">\n  Yes, this is correct\n</a>\n\n  <a href="#">Change my weight</a>\n</div>'
 }) }}
 ```
 
@@ -9042,39 +8917,21 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -9093,7 +8950,7 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
     }
   },
   hint: {
-    html: "This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App"
+    html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
   },
   idPrefix: "with-divider",
   name: "example",
@@ -9258,29 +9115,15 @@ Foundation Trust, Oxford Road, Manchester, M13 9WL</p>"
   items: [
     {
       value: "nullam",
-      text: "Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
-quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
-Maecenas faucibus mollis interdum. Donec id elit non mi porta gravida
-at eget metus."
+      text: "Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo\nquam. Pellentesque ornare sem lacinia quam venenatis vestibulum.\nMaecenas faucibus mollis interdum. Donec id elit non mi porta gravida\nat eget metus."
     },
     {
       value: "aenean",
-      text: "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
-vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
-nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis
-natoque penatibus et magnis dis parturient montes, nascetur ridiculus
-mus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
-venenatis vestibulum. Cras mattis consectetur purus sit amet
-fermentum."
+      text: "Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis\nvestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,\nnisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis\nnatoque penatibus et magnis dis parturient montes, nascetur ridiculus\nmus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam\nvenenatis vestibulum. Cras mattis consectetur purus sit amet\nfermentum."
     },
     {
       value: "fusce",
-      text: "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
-nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
-malesuada magna mollis euismod. Praesent commodo cursus magna, vel
-scelerisque nisl consectetur et. Etiam porta sem malesuada magna
-mollis euismod. Etiam porta sem malesuada magna mollis euismod.
-Donec sed odio dui. Sed posuere consectetur est at lobortis."
+      text: "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum\nnibh, ut fermentum massa justo sit amet risus. Etiam porta sem\nmalesuada magna mollis euismod. Praesent commodo cursus magna, vel\nscelerisque nisl consectetur et. Etiam porta sem malesuada magna\nmollis euismod. Etiam porta sem malesuada magna mollis euismod.\nDonec sed odio dui. Sed posuere consectetur est at lobortis."
     }
   ]
 }) }}
@@ -9307,39 +9150,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -9367,39 +9192,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -9430,39 +9237,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -9491,42 +9280,21 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "email",
       text: "Email",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n'
       }
     },
     {
       value: "phone",
       text: "Phone",
       conditional: {
-        html: "<div class="nhsuk-form-group nhsuk-form-group--error">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <span class="nhsuk-error-message" id="contact-by-phone-error">
-    <span class="nhsuk-u-visually-hidden">Error:</span> Enter your phone number
-  </span>
-  <input class="nhsuk-input nhsuk-input--error nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel" aria-describedby="contact-by-phone-error">
-</div>
-"
+        html: '<div class="nhsuk-form-group nhsuk-form-group--error">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <p class="nhsuk-error-message" id="contact-by-phone-error">\n    <span class="nhsuk-u-visually-hidden">Error:</span> Enter your phone number\n  </p>\n  <input class="nhsuk-input nhsuk-input--error nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel" aria-describedby="contact-by-phone-error">\n</div>\n'
       }
     },
     {
       value: "text",
       text: "Text message",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n'
       }
     }
   ]
@@ -9558,61 +9326,7 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
       value: "nested",
       text: "Nested conditional",
       conditional: {
-        html: "<div class="nhsuk-form-group">
-  <fieldset class="nhsuk-fieldset" aria-describedby="example-inner-hint">
-  <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">
-    How do you want to be contacted about this?
-  </legend>
-  <div class="nhsuk-hint" id="example-inner-hint">
-    Select 1 option
-  </div>
-  <div class="nhsuk-radios" data-module="nhsuk-radios">
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-inner" name="example-inner" type="radio" value="email" data-aria-controls="conditional-example-inner">
-      <label class="nhsuk-label nhsuk-radios__label" for="example-inner">
-        Email
-      </label>
-    </div>
-    <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-example-inner">
-      <div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-email">
-    Email address
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">
-</div>
-    </div>
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-inner-2" name="example-inner" type="radio" value="phone" data-aria-controls="conditional-example-inner-2">
-      <label class="nhsuk-label nhsuk-radios__label" for="example-inner-2">
-        Phone
-      </label>
-    </div>
-    <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-example-inner-2">
-      <div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-phone">
-    Phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">
-</div>
-    </div>
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-inner-3" name="example-inner" type="radio" value="text" data-aria-controls="conditional-example-inner-3">
-      <label class="nhsuk-label nhsuk-radios__label" for="example-inner-3">
-        Text message
-      </label>
-    </div>
-    <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-example-inner-3">
-      <div class="nhsuk-form-group">
-  <label class="nhsuk-label" for="contact-by-text">
-    Mobile phone number
-  </label>
-  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">
-</div>
-    </div>
-  </div>
-</fieldset>
-</div>
-"
+        html: '<div class="nhsuk-form-group">\n  <fieldset class="nhsuk-fieldset" aria-describedby="example-inner-hint">\n  <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">\n    How do you want to be contacted about this?\n  </legend>\n  <div class="nhsuk-hint" id="example-inner-hint">\n    Select 1 option\n  </div>\n  <div class="nhsuk-radios" data-module="nhsuk-radios">\n    <div class="nhsuk-radios__item">\n      <input class="nhsuk-radios__input" id="example-inner" name="example-inner" type="radio" value="email" data-aria-controls="conditional-example-inner">\n      <label class="nhsuk-label nhsuk-radios__label" for="example-inner">\n        Email\n      </label>\n    </div>\n    <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-example-inner">\n      <div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-email">\n    Email address\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-email" name="contact-by-email" type="text" spellcheck="false">\n</div>\n    </div>\n    <div class="nhsuk-radios__item">\n      <input class="nhsuk-radios__input" id="example-inner-2" name="example-inner" type="radio" value="phone" data-aria-controls="conditional-example-inner-2">\n      <label class="nhsuk-label nhsuk-radios__label" for="example-inner-2">\n        Phone\n      </label>\n    </div>\n    <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-example-inner-2">\n      <div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-phone">\n    Phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-phone" name="contact-by-phone" type="tel">\n</div>\n    </div>\n    <div class="nhsuk-radios__item">\n      <input class="nhsuk-radios__input" id="example-inner-3" name="example-inner" type="radio" value="text" data-aria-controls="conditional-example-inner-3">\n      <label class="nhsuk-label nhsuk-radios__label" for="example-inner-3">\n        Text message\n      </label>\n    </div>\n    <div class="nhsuk-radios__conditional nhsuk-radios__conditional--hidden" id="conditional-example-inner-3">\n      <div class="nhsuk-form-group">\n  <label class="nhsuk-label" for="contact-by-text">\n    Mobile phone number\n  </label>\n  <input class="nhsuk-input nhsuk-u-width-two-thirds" id="contact-by-text" name="contact-by-text" type="tel">\n</div>\n    </div>\n  </div>\n</fieldset>\n</div>\n'
       }
     }
   ]
@@ -10354,10 +10068,7 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
   ],
   formGroup: {
     afterInput: {
-      html: "<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">
-  Save
-</button>
-"
+      html: '<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">\n  Save\n</button>\n'
     }
   }
 }) }}
@@ -10423,10 +10134,7 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
   ],
   formGroup: {
     afterInput: {
-      html: "<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">
-  Save
-</button>
-"
+      html: '<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small" data-module="nhsuk-button" type="submit">\n  Save\n</button>\n'
     }
   }
 }) }}
@@ -10778,9 +10486,7 @@ Donec sed odio dui. Sed posuere consectetur est at lobortis."
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       },
       actions: {
         items: [
@@ -10797,8 +10503,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       },
       actions: {
         items: [
@@ -10849,9 +10554,7 @@ LS2 5ZN"
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       },
       actions: {
         items: [
@@ -10868,8 +10571,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       },
       actions: {
         items: [
@@ -10891,9 +10593,7 @@ LS2 5ZN"
         text: "Medicines"
       },
       value: {
-        html: "<p>Isotretinoin capsules (Roaccutane)</p>
-<p>Isotretinoin gel (Isotrex)</p>
-<p>Pepto-Bismol (bismuth subsalicylate)</p>"
+        html: "<p>Isotretinoin capsules (Roaccutane)</p>\n<p>Isotretinoin gel (Isotrex)</p>\n<p>Pepto-Bismol (bismuth subsalicylate)</p>"
       },
       actions: {
         items: [
@@ -10950,9 +10650,7 @@ LS2 5ZN"
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       },
       actions: {
         items: [
@@ -10970,8 +10668,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       },
       actions: {
         items: [
@@ -10993,9 +10690,7 @@ LS2 5ZN"
         text: "Medicines"
       },
       value: {
-        html: "<p>Isotretinoin capsules (Roaccutane)</p>
-<p>Isotretinoin gel (Isotrex)</p>
-<p>Pepto-Bismol (bismuth subsalicylate)</p>"
+        html: "<p>Isotretinoin capsules (Roaccutane)</p>\n<p>Isotretinoin gel (Isotrex)</p>\n<p>Pepto-Bismol (bismuth subsalicylate)</p>"
       },
       actions: {
         items: [
@@ -11042,9 +10737,7 @@ LS2 5ZN"
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       }
     },
     {
@@ -11052,8 +10745,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       }
     }
   ]
@@ -11087,9 +10779,7 @@ LS2 5ZN"
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       }
     },
     {
@@ -11097,8 +10787,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       }
     }
   ]
@@ -11132,9 +10821,7 @@ LS2 5ZN"
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       }
     },
     {
@@ -11142,8 +10829,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       }
     }
   ]
@@ -11231,9 +10917,7 @@ LS2 5ZN"
         text: "Contact information"
       },
       value: {
-        html: "73 Roman Rd<br>
-Leeds<br>
-LS2 5ZN"
+        html: "73 Roman Rd<br>\nLeeds<br>\nLS2 5ZN"
       },
       actions: {
         items: [
@@ -11250,8 +10934,7 @@ LS2 5ZN"
         text: "Contact details"
       },
       value: {
-        html: "<p>07700 900362</p>
-<p>karen.francis@example.com</p>"
+        html: "<p>07700 900362</p>\n<p>karen.francis@example.com</p>"
       },
       actions: {
         items: [
@@ -11274,9 +10957,7 @@ LS2 5ZN"
         text: "Medicines"
       },
       value: {
-        html: "<p>Isotretinoin capsules (Roaccutane)</p>
-<p>Isotretinoin gel (Isotrex)</p>
-<p>Pepto-Bismol (bismuth subsalicylate)</p>"
+        html: "<p>Isotretinoin capsules (Roaccutane)</p>\n<p>Isotretinoin gel (Isotrex)</p>\n<p>Pepto-Bismol (bismuth subsalicylate)</p>"
       },
       actions: {
         items: [
@@ -11440,12 +11121,7 @@ LS2 5ZN"
         text: "Opinion"
       },
       value: {
-        html: "<p class="nhsuk-u-margin-bottom-3">
-  <strong class="nhsuk-tag nhsuk-tag--red">
-  Recall for assessment
-</strong>
-
-</p>"
+        html: '<p class="nhsuk-u-margin-bottom-3">\n  <strong class="nhsuk-tag nhsuk-tag--red">\n  Recall for assessment\n</strong>\n\n</p>'
       },
       actions: {
         items: [
@@ -11462,28 +11138,7 @@ LS2 5ZN"
         text: "Detailed opinion"
       },
       value: {
-        html: "<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-one-half">
-    <p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">
-      Right breast
-    </p>
-    <p class="nhsuk-u-margin-bottom-3">
-      <strong class="nhsuk-tag nhsuk-tag--red">
-  Abnormal
-</strong>
-
-    </p>
-  </div>
-
-  <div class="nhsuk-grid-column-one-half">
-    <p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">
-      Left breast
-    </p>
-    <p class="nhsuk-u-margin-bottom-3 nhsuk-u-secondary-text-colour">
-      Not recorded
-    </p>
-  </div>
-</div>"
+        html: '<div class="nhsuk-grid-row">\n  <div class="nhsuk-grid-column-one-half">\n    <p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">\n      Right breast\n    </p>\n    <p class="nhsuk-u-margin-bottom-3">\n      <strong class="nhsuk-tag nhsuk-tag--red">\n  Abnormal\n</strong>\n\n    </p>\n  </div>\n\n  <div class="nhsuk-grid-column-one-half">\n    <p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">\n      Left breast\n    </p>\n    <p class="nhsuk-u-margin-bottom-3 nhsuk-u-secondary-text-colour">\n      Not recorded\n    </p>\n  </div>\n</div>'
       },
       actions: {
         items: [
@@ -11501,12 +11156,7 @@ LS2 5ZN"
         text: "Annotations"
       },
       value: {
-        html: "<p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">
-  Right breast
-</p>
-<p class="nhsuk-u-margin-bottom-0">
-  Microcalcification outside a mass, Clinical abnormality – Level 2 (benign)
-</p>"
+        html: '<p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">\n  Right breast\n</p>\n<p class="nhsuk-u-margin-bottom-0">\n  Microcalcification outside a mass, Clinical abnormality – Level 2 (benign)\n</p>'
       },
       actions: {
         items: [
@@ -12397,8 +12047,7 @@ LS2 5ZN"
       },
       {
         header: "Description",
-        html: "<strong>Required.</strong> The rows within the table component.
-<a href="#/macro-options">See macro options for rows</a>."
+        html: '<strong>Required.</strong> The rows within the table component.\n<a href="#/macro-options">See macro options for rows</a>.'
       }
     ],
     [
@@ -12412,8 +12061,7 @@ LS2 5ZN"
       },
       {
         header: "Description",
-        html: "Can be used to add a row of table header cells (<code>&lt;th&gt;</code>) at the top of the table component.
-<a href="#/macro-options">See macro options for head</a>."
+        html: 'Can be used to add a row of table header cells (<code>&lt;th&gt;</code>) at the top of the table component.\n<a href="#/macro-options">See macro options for head</a>.'
       }
     ],
     [
@@ -12483,7 +12131,7 @@ LS2 5ZN"
       },
       {
         header: "Description",
-        text: "	HTML attributes (for example data attributes) to add to the table container."
+        text: "\tHTML attributes (for example data attributes) to add to the table container."
       }
     ]
   ]
@@ -12507,7 +12155,7 @@ LS2 5ZN"
       text: "Status"
     },
     {
-      html: "<span class="nhsuk-u-visually-hidden">Actions</span>"
+      html: '<span class="nhsuk-u-visually-hidden">Actions</span>'
     }
   ],
   rows: [
@@ -12521,10 +12169,7 @@ LS2 5ZN"
         classes: "nhsuk-u-text-break-word"
       },
       {
-        html: "<strong class="nhsuk-tag nhsuk-tag--green">
-  Active
-</strong>
-"
+        html: '<strong class="nhsuk-tag nhsuk-tag--green">\n  Active\n</strong>\n'
       }
     ],
     [
@@ -12537,10 +12182,7 @@ LS2 5ZN"
         classes: "nhsuk-u-text-break-word"
       },
       {
-        html: "<strong class="nhsuk-tag nhsuk-tag--grey">
-  Inactive
-</strong>
-"
+        html: '<strong class="nhsuk-tag nhsuk-tag--grey">\n  Inactive\n</strong>\n'
       }
     ]
   ]
@@ -12803,240 +12445,28 @@ LS2 5ZN"
       label: "Past day",
       id: "past-day",
       panel: {
-        html: "<table class="nhsuk-table">
-  <caption class="nhsuk-table__caption">
-    Past day
-  </caption>
-  <thead class="nhsuk-table__head">
-    <tr class="nhsuk-table__row">
-      <th scope="col" class="nhsuk-table__header">
-        Case manager
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases opened
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases closed
-      </th>
-    </tr>
-  </thead>
-  <tbody class="nhsuk-table__body">
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        David Francis
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        3
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        0
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Paul Farmer
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        0
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Rita Patel
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        2
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        0
-      </td>
-    </tr>
-  </tbody>
-</table>
-"
+        html: '<table class="nhsuk-table">\n  <caption class="nhsuk-table__caption">\n    Past day\n  </caption>\n  <thead class="nhsuk-table__head">\n    <tr class="nhsuk-table__row">\n      <th scope="col" class="nhsuk-table__header">\n        Case manager\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases opened\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases closed\n      </th>\n    </tr>\n  </thead>\n  <tbody class="nhsuk-table__body">\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        David Francis\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        3\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        0\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Paul Farmer\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        0\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Rita Patel\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        2\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        0\n      </td>\n    </tr>\n  </tbody>\n</table>\n'
       }
     },
     {
       label: "Past week",
       id: "past-week",
       panel: {
-        html: "<table class="nhsuk-table">
-  <caption class="nhsuk-table__caption">
-    Past week
-  </caption>
-  <thead class="nhsuk-table__head">
-    <tr class="nhsuk-table__row">
-      <th scope="col" class="nhsuk-table__header">
-        Case manager
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases opened
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases closed
-      </th>
-    </tr>
-  </thead>
-  <tbody class="nhsuk-table__body">
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        David Francis
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        24
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        18
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Paul Farmer
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        16
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        20
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Rita Patel
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        24
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        27
-      </td>
-    </tr>
-  </tbody>
-</table>
-"
+        html: '<table class="nhsuk-table">\n  <caption class="nhsuk-table__caption">\n    Past week\n  </caption>\n  <thead class="nhsuk-table__head">\n    <tr class="nhsuk-table__row">\n      <th scope="col" class="nhsuk-table__header">\n        Case manager\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases opened\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases closed\n      </th>\n    </tr>\n  </thead>\n  <tbody class="nhsuk-table__body">\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        David Francis\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        24\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        18\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Paul Farmer\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        16\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        20\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Rita Patel\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        24\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        27\n      </td>\n    </tr>\n  </tbody>\n</table>\n'
       }
     },
     {
       label: "Past month",
       id: "past-month",
       panel: {
-        html: "<table class="nhsuk-table">
-  <caption class="nhsuk-table__caption">
-    Past month
-  </caption>
-  <thead class="nhsuk-table__head">
-    <tr class="nhsuk-table__row">
-      <th scope="col" class="nhsuk-table__header">
-        Case manager
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases opened
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases closed
-      </th>
-    </tr>
-  </thead>
-  <tbody class="nhsuk-table__body">
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        David Francis
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        98
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        95
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Paul Farmer
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        122
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        131
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Rita Patel
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        126
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        142
-      </td>
-    </tr>
-  </tbody>
-</table>
-"
+        html: '<table class="nhsuk-table">\n  <caption class="nhsuk-table__caption">\n    Past month\n  </caption>\n  <thead class="nhsuk-table__head">\n    <tr class="nhsuk-table__row">\n      <th scope="col" class="nhsuk-table__header">\n        Case manager\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases opened\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases closed\n      </th>\n    </tr>\n  </thead>\n  <tbody class="nhsuk-table__body">\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        David Francis\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        98\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        95\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Paul Farmer\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        122\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        131\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Rita Patel\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        126\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        142\n      </td>\n    </tr>\n  </tbody>\n</table>\n'
       }
     },
     {
       label: "Past year",
       id: "past-year",
       panel: {
-        html: "<table class="nhsuk-table">
-  <caption class="nhsuk-table__caption">
-    Past year
-  </caption>
-  <thead class="nhsuk-table__head">
-    <tr class="nhsuk-table__row">
-      <th scope="col" class="nhsuk-table__header">
-        Case manager
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases opened
-      </th>
-      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">
-        Cases closed
-      </th>
-    </tr>
-  </thead>
-  <tbody class="nhsuk-table__body">
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        David Francis
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1380
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1472
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Paul Farmer
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1129
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1083
-      </td>
-    </tr>
-    <tr class="nhsuk-table__row">
-      <td class="nhsuk-table__cell">
-        Rita Patel
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1539
-      </td>
-      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">
-        1265
-      </td>
-    </tr>
-  </tbody>
-</table>
-"
+        html: '<table class="nhsuk-table">\n  <caption class="nhsuk-table__caption">\n    Past year\n  </caption>\n  <thead class="nhsuk-table__head">\n    <tr class="nhsuk-table__row">\n      <th scope="col" class="nhsuk-table__header">\n        Case manager\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases opened\n      </th>\n      <th scope="col" class="nhsuk-table__header nhsuk-table__header--numeric">\n        Cases closed\n      </th>\n    </tr>\n  </thead>\n  <tbody class="nhsuk-table__body">\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        David Francis\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1380\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1472\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Paul Farmer\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1129\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1083\n      </td>\n    </tr>\n    <tr class="nhsuk-table__row">\n      <td class="nhsuk-table__cell">\n        Rita Patel\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1539\n      </td>\n      <td class="nhsuk-table__cell nhsuk-table__cell--numeric">\n        1265\n      </td>\n    </tr>\n  </tbody>\n</table>\n'
       }
     }
   ]
@@ -13052,29 +12482,21 @@ LS2 5ZN"
       label: "Tab 1",
       id: "tab-1",
       panel: {
-        html: "<h2>Tab 1 content</h2>
-<p>Testing that when you <a href="#anchor">click the link</a> it moves focus.</p>
-<ul>
-  <li><a href="#tab-1" id="anchor">Tab panel 1</a></li>
-  <li><a href="#tab-2">Tab panel 2</a></li>
-  <li><a href="#tab-3">Tab panel 3</a></li>
-</ul>"
+        html: '<h2>Tab 1 content</h2>\n<p>Testing that when you <a href="#anchor">click the link</a> it moves focus.</p>\n<ul>\n  <li><a href="#tab-1" id="anchor">Tab panel 1</a></li>\n  <li><a href="#tab-2">Tab panel 2</a></li>\n  <li><a href="#tab-3">Tab panel 3</a></li>\n</ul>'
       }
     },
     {
       label: "Tab 2",
       id: "tab-2",
       panel: {
-        html: "<h2>Tab 2 content</h2>
-<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p>"
+        html: "<h2>Tab 2 content</h2>\n<p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p>"
       }
     },
     {
       label: "Tab 3",
       id: "tab-3",
       panel: {
-        html: "<h2>Tab 3 content</h2>
-<p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>"
+        html: "<h2>Tab 3 content</h2>\n<p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>"
       }
     }
   ]

--- a/docs/nhs-frontend-sass-reference.md
+++ b/docs/nhs-frontend-sass-reference.md
@@ -4,260 +4,195 @@
 
 ## Metadata
 
-- NHS Frontend Version: 10.5.1
+- NHS Frontend Version: 10.5.2
 - Git Branch: detached
-- Git Commit: ddd8147
-- Generated: 2026-06-04 14:46:26 UTC
+- Git Commit: 67bf2f6
+- Generated: 2026-07-06 12:26:28 UTC
 - Source: https://github.com/nhsuk/nhsuk-frontend
 
 ## Table of Contents
 
 | Name | Type | Group | Line |
 |------|------|-------|------|
-| _map-sort-by-value | function | none | 205 |
-| _nhsuk-equilateral-height | function | tools | 262 |
-| _quick-sort | function | none | 302 |
-| _reverse-colour | function | none | 354 |
-| _should-warn | function | settings/warnings | 381 |
-| _warning-text | function | settings/warnings | 416 |
-| get-breakpoint-width | function | none | 452 |
-| nhsuk-chevron-size | function | tools | 501 |
-| nhsuk-colour | function | helpers/colour | 544 |
-| nhsuk-colour-compatible | function | helpers/colour | 593 |
-| nhsuk-em | function | tools | 663 |
-| nhsuk-font-url | function | tools | 724 |
-| nhsuk-grid-width | function | tools | 756 |
-| nhsuk-image-url | function | tools | 804 |
-| nhsuk-line-height | function | tools | 836 |
-| nhsuk-px-to-rem | function | tools | 895 |
-| nhsuk-shade | function | helpers/colour | 951 |
-| nhsuk-spacing | function | tools | 997 |
-| nhsuk-tint | function | helpers/colour | 1101 |
-| px2em | function | none | 1142 |
-| _header-link-style | mixin | components/header | 1191 |
-| _nhsuk-generate-responsive-spacing-overrides | mixin | utilities | 1244 |
-| _nhsuk-generate-static-spacing-overrides | mixin | utilities | 1303 |
-| _nhsuk-visually-hide-content | mixin | tools | 1353 |
-| add-breakpoint | mixin | none | 1423 |
-| care-card | mixin | tools | 1463 |
-| clearfix | mixin | tools | 1487 |
-| flex | mixin | tools | 1510 |
-| flex-item | mixin | tools | 1531 |
-| govuk-media-query | mixin | tools | 1552 |
-| heading-label | mixin | tools | 1577 |
-| mq | mixin | none | 1601 |
-| nhsuk-button-style | mixin | tools | 1721 |
-| nhsuk-care-card | mixin | tools | 1851 |
-| nhsuk-clearfix | mixin | tools | 1900 |
-| nhsuk-exports | mixin | tools | 1931 |
-| nhsuk-flex | mixin | tools | 1974 |
-| nhsuk-flex-item | mixin | tools | 2002 |
-| nhsuk-focused-box | mixin | tools | 2037 |
-| nhsuk-focused-button | mixin | tools | 2076 |
-| nhsuk-focused-checkbox | mixin | tools | 2122 |
-| nhsuk-focused-input | mixin | tools | 2166 |
-| nhsuk-focused-radio | mixin | tools | 2205 |
-| nhsuk-focused-text | mixin | tools | 2255 |
-| nhsuk-font | mixin | tools | 2305 |
-| nhsuk-font-dynamic-type | mixin | generic | 2359 |
-| nhsuk-font-size | mixin | tools | 2392 |
-| nhsuk-grid-column | mixin | tools | 2548 |
-| nhsuk-heading-label | mixin | tools | 2628 |
-| nhsuk-link-image | mixin | tools | 2703 |
-| nhsuk-link-style | mixin | tools | 2738 |
-| nhsuk-link-style-active | mixin | tools | 2787 |
-| nhsuk-link-style-default | mixin | tools | 2823 |
-| nhsuk-link-style-error | mixin | tools | 2858 |
-| nhsuk-link-style-focus | mixin | tools | 2901 |
-| nhsuk-link-style-hover | mixin | tools | 2939 |
-| nhsuk-link-style-no-underline | mixin | tools | 2976 |
-| nhsuk-link-style-no-visited-state | mixin | tools | 3014 |
-| nhsuk-link-style-reverse | mixin | tools | 3066 |
-| nhsuk-link-style-success | mixin | tools | 3119 |
-| nhsuk-link-style-text | mixin | tools | 3162 |
-| nhsuk-link-style-visited | mixin | tools | 3218 |
-| nhsuk-link-style-white | mixin | tools | 3254 |
-| nhsuk-logo-size | mixin | tools | 3280 |
-| nhsuk-media-query | mixin | tools | 3301 |
-| nhsuk-panel | mixin | tools | 3385 |
-| nhsuk-panel-with-label | mixin | tools | 3443 |
-| nhsuk-print-color | mixin | tools | 3490 |
-| nhsuk-print-colour | mixin | tools | 3514 |
-| nhsuk-print-hide | mixin | tools | 3557 |
-| nhsuk-reading-width | mixin | tools | 3600 |
-| nhsuk-remove-margin-mobile | mixin | tools | 3628 |
-| nhsuk-responsive-margin | mixin | tools | 3659 |
-| nhsuk-responsive-padding | mixin | tools | 3712 |
-| nhsuk-responsive-spacing | mixin | tools | 3764 |
-| nhsuk-shape-arrow | mixin | tools | 3883 |
-| nhsuk-shape-chevron | mixin | tools | 3962 |
-| nhsuk-text-break-word | mixin | tools | 4037 |
-| nhsuk-text-color | mixin | tools | 4079 |
-| nhsuk-text-colour | mixin | tools | 4102 |
-| nhsuk-top-and-bottom | mixin | tools | 4139 |
-| nhsuk-typography-responsive | mixin | tools | 4174 |
-| nhsuk-typography-weight-bold | mixin | tools | 4216 |
-| nhsuk-typography-weight-normal | mixin | tools | 4252 |
-| nhsuk-visually-hidden | mixin | tools | 4288 |
-| nhsuk-visually-hidden-focusable | mixin | tools | 4337 |
-| nhsuk-warning | mixin | settings/warnings | 4380 |
-| nhsuk-width-container | mixin | objects/layout | 4458 |
-| panel | mixin | tools | 4550 |
-| panel-with-label | mixin | tools | 4573 |
-| print-color | mixin | tools | 4597 |
-| print-hide | mixin | tools | 4621 |
-| reading-width | mixin | tools | 4644 |
-| remove-margin-mobile | mixin | tools | 4668 |
-| show-breakpoints | mixin | none | 4697 |
-| top-and-bottom | mixin | tools | 4763 |
-| visually-hidden | mixin | tools | 4787 |
-| visually-hidden-focusable | mixin | tools | 4809 |
-| visually-shown | mixin | tools | 4837 |
-| _icon-sizes | variable | styles | 4904 |
-| _spacing-directions | variable | utilities | 4921 |
-| imported-modules | variable | tools | 4947 |
-| mq-breakpoints | variable | none | 4970 |
-| mq-media-type | variable | none | 5007 |
-| mq-show-breakpoints | variable | none | 5041 |
-| nhsuk-assets-path | variable | settings/globals | 5072 |
-| nhsuk-body-background-colour | variable | settings/colours | 5089 |
-| nhsuk-border-colour | variable | settings/colours | 5106 |
-| nhsuk-border-hover-colour | variable | settings/colours | 5125 |
-| nhsuk-border-width | variable | settings/globals | 5142 |
-| nhsuk-border-width-form-element | variable | settings/globals | 5159 |
-| nhsuk-border-width-form-group-error | variable | settings/globals | 5182 |
-| nhsuk-brand-colour | variable | settings/colours | 5199 |
-| nhsuk-breakpoints | variable | settings/layout | 5216 |
-| nhsuk-button-active-colour | variable | settings/colours | 5238 |
-| nhsuk-button-border-radius | variable | settings/globals | 5255 |
-| nhsuk-button-colour | variable | settings/colours | 5276 |
-| nhsuk-button-hover-colour | variable | settings/colours | 5293 |
-| nhsuk-button-shadow-colour | variable | settings/colours | 5310 |
-| nhsuk-button-shadow-size | variable | settings/globals | 5327 |
-| nhsuk-button-text-colour | variable | settings/colours | 5349 |
-| nhsuk-card-background-colour | variable | settings/colours | 5366 |
-| nhsuk-code-colour | variable | settings/colours | 5383 |
-| nhsuk-code-font | variable | settings/typography | 5400 |
-| nhsuk-colours | variable | settings/colours | 5425 |
-| nhsuk-error-colour | variable | settings/colours | 5472 |
-| nhsuk-focus-colour | variable | settings/colours | 5498 |
-| nhsuk-focus-text-colour | variable | settings/colours | 5528 |
-| nhsuk-focus-width | variable | settings/globals | 5563 |
-| nhsuk-font-family | variable | settings/globals | 5596 |
-| nhsuk-font-family-print | variable | settings/globals | 5613 |
-| nhsuk-font-weight-bold | variable | settings/globals | 5633 |
-| nhsuk-font-weight-normal | variable | settings/globals | 5655 |
-| nhsuk-fonts-path | variable | settings/globals | 5677 |
-| nhsuk-grid-widths | variable | settings/globals | 5698 |
-| nhsuk-gutter | variable | settings/globals | 5727 |
-| nhsuk-gutter-half | variable | settings/globals | 5752 |
-| nhsuk-hover-colour | variable | settings/colours | 5783 |
-| nhsuk-hover-width | variable | settings/globals | 5802 |
-| nhsuk-images-path | variable | settings/globals | 5819 |
-| nhsuk-include-default-font-face | variable | settings/globals | 5840 |
-| nhsuk-include-dynamic-type | variable | settings/globals | 5860 |
-| nhsuk-input-background-colour | variable | settings/colours | 5888 |
-| nhsuk-input-border-colour | variable | settings/colours | 5905 |
-| nhsuk-link-active-colour | variable | settings/colours | 5924 |
-| nhsuk-link-colour | variable | settings/colours | 5945 |
-| nhsuk-link-hover-colour | variable | settings/colours | 5967 |
-| nhsuk-link-visited-colour | variable | settings/colours | 5988 |
-| nhsuk-login-button-active-colour | variable | settings/colours | 6005 |
-| nhsuk-login-button-colour | variable | settings/colours | 6022 |
-| nhsuk-login-button-hover-colour | variable | settings/colours | 6039 |
-| nhsuk-login-button-shadow-colour | variable | settings/colours | 6056 |
-| nhsuk-page-width | variable | settings/globals | 6073 |
-| nhsuk-panel-border-width | variable | components/panel | 6090 |
-| nhsuk-print-text-colour | variable | settings/colours | 6114 |
-| nhsuk-reverse-border-colour | variable | settings/colours | 6139 |
-| nhsuk-reverse-button-active-colour | variable | settings/colours | 6156 |
-| nhsuk-reverse-button-colour | variable | settings/colours | 6173 |
-| nhsuk-reverse-button-hover-colour | variable | settings/colours | 6190 |
-| nhsuk-reverse-button-shadow-colour | variable | settings/colours | 6207 |
-| nhsuk-reverse-button-text-colour | variable | settings/colours | 6224 |
-| nhsuk-reverse-text-colour | variable | settings/colours | 6241 |
-| nhsuk-root-font-size | variable | settings/globals | 6263 |
-| nhsuk-secondary-border-colour | variable | settings/colours | 6295 |
-| nhsuk-secondary-button-active-colour | variable | settings/colours | 6312 |
-| nhsuk-secondary-button-border-colour | variable | settings/colours | 6329 |
-| nhsuk-secondary-button-colour | variable | settings/colours | 6346 |
-| nhsuk-secondary-button-hover-colour | variable | settings/colours | 6363 |
-| nhsuk-secondary-button-shadow-colour | variable | settings/colours | 6380 |
-| nhsuk-secondary-button-solid-background-colour | variable | settings/colours | 6397 |
-| nhsuk-secondary-button-text-colour | variable | settings/colours | 6414 |
-| nhsuk-secondary-text-colour | variable | settings/colours | 6431 |
-| nhsuk-show-breakpoints | variable | settings/layout | 6450 |
-| nhsuk-spacing-points | variable | settings/spacing | 6469 |
-| nhsuk-spacing-responsive-scale | variable | settings/spacing | 6507 |
-| nhsuk-success-colour | variable | settings/colours | 6585 |
-| nhsuk-suppressed-warnings | variable | settings/warnings | 6611 |
-| nhsuk-template-background-colour | variable | settings/colours | 6659 |
-| nhsuk-text-colour | variable | settings/colours | 6679 |
-| nhsuk-typography-scale | variable | settings/typography | 6700 |
-| nhsuk-warning-button-active-colour | variable | settings/colours | 6853 |
-| nhsuk-warning-button-colour | variable | settings/colours | 6870 |
-| nhsuk-warning-button-hover-colour | variable | settings/colours | 6887 |
-| nhsuk-warning-button-shadow-colour | variable | settings/colours | 6904 |
+| _nhsuk-equilateral-height | function | tools | 197 |
+| _reverse-colour | function | none | 229 |
+| _should-warn | function | settings/warnings | 250 |
+| _warning-text | function | settings/warnings | 279 |
+| nhsuk-chevron-size | function | tools | 309 |
+| nhsuk-colour | function | helpers/colour | 335 |
+| nhsuk-colour-compatible | function | helpers/colour | 370 |
+| nhsuk-em | function | tools | 405 |
+| nhsuk-font-url | function | tools | 446 |
+| nhsuk-grid-width | function | tools | 472 |
+| nhsuk-image-url | function | tools | 510 |
+| nhsuk-line-height | function | tools | 536 |
+| nhsuk-px-to-rem | function | tools | 571 |
+| nhsuk-shade | function | helpers/colour | 612 |
+| nhsuk-spacing | function | tools | 649 |
+| nhsuk-tint | function | helpers/colour | 716 |
+| _header-link-style | mixin | components/header | 751 |
+| _nhsuk-generate-responsive-spacing-overrides | mixin | utilities | 780 |
+| _nhsuk-generate-static-spacing-overrides | mixin | utilities | 820 |
+| _nhsuk-visually-hide-content | mixin | tools | 854 |
+| care-card (deprecated) | mixin | tools | 882 |
+| clearfix (deprecated) | mixin | tools | 901 |
+| flex (deprecated) | mixin | tools | 919 |
+| flex-item (deprecated) | mixin | tools | 935 |
+| heading-label (deprecated) | mixin | tools | 951 |
+| nhsuk-button-style | mixin | tools | 970 |
+| nhsuk-care-card | mixin | tools | 1000 |
+| nhsuk-clearfix | mixin | tools | 1034 |
+| nhsuk-exports | mixin | tools | 1055 |
+| nhsuk-flex | mixin | tools | 1084 |
+| nhsuk-flex-item | mixin | tools | 1105 |
+| nhsuk-focused-box | mixin | tools | 1130 |
+| nhsuk-focused-button | mixin | tools | 1160 |
+| nhsuk-focused-checkbox | mixin | tools | 1184 |
+| nhsuk-focused-input | mixin | tools | 1208 |
+| nhsuk-focused-radio | mixin | tools | 1234 |
+| nhsuk-focused-text | mixin | tools | 1264 |
+| nhsuk-font | mixin | tools | 1292 |
+| nhsuk-font-code | mixin | tools | 1330 |
+| nhsuk-font-dynamic-type | mixin | generic | 1354 |
+| nhsuk-font-monospace | mixin | tools | 1372 |
+| nhsuk-font-size | mixin | tools | 1398 |
+| nhsuk-font-weight-bold | mixin | tools | 1465 |
+| nhsuk-font-weight-normal | mixin | tools | 1492 |
+| nhsuk-grid-column | mixin | tools | 1519 |
+| nhsuk-heading-label | mixin | tools | 1582 |
+| nhsuk-link-image | mixin | tools | 1624 |
+| nhsuk-link-style | mixin | tools | 1642 |
+| nhsuk-link-style-active | mixin | tools | 1677 |
+| nhsuk-link-style-default | mixin | tools | 1705 |
+| nhsuk-link-style-error | mixin | tools | 1730 |
+| nhsuk-link-style-focus | mixin | tools | 1762 |
+| nhsuk-link-style-hover | mixin | tools | 1788 |
+| nhsuk-link-style-no-underline | mixin | tools | 1816 |
+| nhsuk-link-style-no-visited-state | mixin | tools | 1839 |
+| nhsuk-link-style-reverse | mixin | tools | 1876 |
+| nhsuk-link-style-success | mixin | tools | 1911 |
+| nhsuk-link-style-text | mixin | tools | 1943 |
+| nhsuk-link-style-visited | mixin | tools | 1979 |
+| nhsuk-link-style-white (deprecated) | mixin | tools | 2007 |
+| nhsuk-logo-size | mixin | tools | 2025 |
+| nhsuk-panel | mixin | tools | 2039 |
+| nhsuk-panel-with-label | mixin | tools | 2078 |
+| nhsuk-print-color (deprecated) | mixin | tools | 2114 |
+| nhsuk-print-colour | mixin | tools | 2133 |
+| nhsuk-print-hide | mixin | tools | 2167 |
+| nhsuk-reading-width | mixin | tools | 2198 |
+| nhsuk-remove-margin-mobile | mixin | tools | 2220 |
+| nhsuk-responsive-margin | mixin | tools | 2242 |
+| nhsuk-responsive-padding | mixin | tools | 2289 |
+| nhsuk-responsive-spacing | mixin | tools | 2335 |
+| nhsuk-shape-arrow | mixin | tools | 2398 |
+| nhsuk-shape-chevron | mixin | tools | 2440 |
+| nhsuk-text-break-word | mixin | tools | 2471 |
+| nhsuk-text-color (deprecated) | mixin | tools | 2492 |
+| nhsuk-text-colour | mixin | tools | 2510 |
+| nhsuk-top-and-bottom | mixin | tools | 2537 |
+| nhsuk-typography-responsive (deprecated) | mixin | tools | 2560 |
+| nhsuk-typography-weight-bold (deprecated) | mixin | tools | 2594 |
+| nhsuk-typography-weight-normal (deprecated) | mixin | tools | 2612 |
+| nhsuk-visually-hidden | mixin | tools | 2630 |
+| nhsuk-visually-hidden-focusable | mixin | tools | 2661 |
+| nhsuk-warning | mixin | settings/warnings | 2692 |
+| nhsuk-width-container | mixin | objects/layout | 2760 |
+| panel (deprecated) | mixin | tools | 2799 |
+| panel-with-label (deprecated) | mixin | tools | 2817 |
+| print-color (deprecated) | mixin | tools | 2836 |
+| print-hide (deprecated) | mixin | tools | 2855 |
+| reading-width (deprecated) | mixin | tools | 2873 |
+| remove-margin-mobile (deprecated) | mixin | tools | 2892 |
+| top-and-bottom (deprecated) | mixin | tools | 2912 |
+| visually-hidden (deprecated) | mixin | tools | 2931 |
+| visually-hidden-focusable (deprecated) | mixin | tools | 2949 |
+| visually-shown (deprecated) | mixin | tools | 2969 |
+| _icon-sizes | variable | styles | 2996 |
+| _spacing-directions | variable | utilities | 3013 |
+| imported-modules | variable | tools | 3039 |
+| nhsuk-assets-path | variable | settings/globals | 3060 |
+| nhsuk-body-background-colour | variable | settings/colours | 3077 |
+| nhsuk-border-colour | variable | settings/colours | 3094 |
+| nhsuk-border-hover-colour (deprecated) | variable | settings/colours | 3113 |
+| nhsuk-border-width | variable | settings/globals | 3131 |
+| nhsuk-border-width-form-element | variable | settings/globals | 3148 |
+| nhsuk-border-width-form-group-error | variable | settings/globals | 3170 |
+| nhsuk-brand-colour | variable | settings/colours | 3187 |
+| nhsuk-breakpoints | variable | settings/layout | 3204 |
+| nhsuk-button-active-colour | variable | settings/colours | 3226 |
+| nhsuk-button-border-radius | variable | settings/globals | 3243 |
+| nhsuk-button-colour | variable | settings/colours | 3264 |
+| nhsuk-button-hover-colour | variable | settings/colours | 3281 |
+| nhsuk-button-shadow-colour | variable | settings/colours | 3298 |
+| nhsuk-button-shadow-size | variable | settings/globals | 3315 |
+| nhsuk-button-text-colour | variable | settings/colours | 3336 |
+| nhsuk-card-background-colour | variable | settings/colours | 3353 |
+| nhsuk-code-colour | variable | settings/colours | 3370 |
+| nhsuk-code-font | variable | settings/typography | 3387 |
+| nhsuk-colours | variable | settings/colours | 3416 |
+| nhsuk-error-colour | variable | settings/colours | 3462 |
+| nhsuk-focus-colour | variable | settings/colours | 3485 |
+| nhsuk-focus-text-colour | variable | settings/colours | 3514 |
+| nhsuk-focus-width | variable | settings/globals | 3544 |
+| nhsuk-font-family | variable | settings/globals | 3571 |
+| nhsuk-font-family-print | variable | settings/globals | 3588 |
+| nhsuk-font-weight-bold | variable | settings/globals | 3608 |
+| nhsuk-font-weight-normal | variable | settings/globals | 3629 |
+| nhsuk-fonts-path | variable | settings/globals | 3650 |
+| nhsuk-grid-widths | variable | settings/globals | 3671 |
+| nhsuk-gutter | variable | settings/globals | 3699 |
+| nhsuk-gutter-half | variable | settings/globals | 3720 |
+| nhsuk-hover-colour | variable | settings/colours | 3743 |
+| nhsuk-hover-width | variable | settings/globals | 3762 |
+| nhsuk-images-path | variable | settings/globals | 3779 |
+| nhsuk-include-default-font-face | variable | settings/globals | 3800 |
+| nhsuk-include-dynamic-type | variable | settings/globals | 3820 |
+| nhsuk-input-background-colour | variable | settings/colours | 3848 |
+| nhsuk-input-border-colour | variable | settings/colours | 3865 |
+| nhsuk-link-active-colour | variable | settings/colours | 3884 |
+| nhsuk-link-colour | variable | settings/colours | 3905 |
+| nhsuk-link-hover-colour | variable | settings/colours | 3926 |
+| nhsuk-link-visited-colour | variable | settings/colours | 3947 |
+| nhsuk-login-button-active-colour | variable | settings/colours | 3964 |
+| nhsuk-login-button-colour | variable | settings/colours | 3981 |
+| nhsuk-login-button-hover-colour | variable | settings/colours | 3998 |
+| nhsuk-login-button-shadow-colour | variable | settings/colours | 4015 |
+| nhsuk-page-width | variable | settings/globals | 4032 |
+| nhsuk-panel-border-width | variable | components/panel | 4049 |
+| nhsuk-print-text-colour | variable | settings/colours | 4073 |
+| nhsuk-reverse-border-colour | variable | settings/colours | 4098 |
+| nhsuk-reverse-button-active-colour | variable | settings/colours | 4115 |
+| nhsuk-reverse-button-colour | variable | settings/colours | 4132 |
+| nhsuk-reverse-button-hover-colour | variable | settings/colours | 4149 |
+| nhsuk-reverse-button-shadow-colour | variable | settings/colours | 4166 |
+| nhsuk-reverse-button-text-colour | variable | settings/colours | 4183 |
+| nhsuk-reverse-text-colour | variable | settings/colours | 4200 |
+| nhsuk-root-font-size | variable | settings/globals | 4221 |
+| nhsuk-secondary-border-colour (deprecated) | variable | settings/colours | 4252 |
+| nhsuk-secondary-button-active-colour | variable | settings/colours | 4270 |
+| nhsuk-secondary-button-border-colour | variable | settings/colours | 4287 |
+| nhsuk-secondary-button-colour | variable | settings/colours | 4304 |
+| nhsuk-secondary-button-hover-colour | variable | settings/colours | 4321 |
+| nhsuk-secondary-button-shadow-colour | variable | settings/colours | 4338 |
+| nhsuk-secondary-button-solid-background-colour | variable | settings/colours | 4355 |
+| nhsuk-secondary-button-text-colour | variable | settings/colours | 4372 |
+| nhsuk-secondary-text-colour | variable | settings/colours | 4389 |
+| nhsuk-show-breakpoints | variable | settings/layout | 4408 |
+| nhsuk-spacing-points | variable | settings/spacing | 4427 |
+| nhsuk-spacing-responsive-scale | variable | settings/spacing | 4464 |
+| nhsuk-success-colour | variable | settings/colours | 4541 |
+| nhsuk-suppressed-warnings | variable | settings/warnings | 4564 |
+| nhsuk-template-background-colour | variable | settings/colours | 4611 |
+| nhsuk-text-colour | variable | settings/colours | 4631 |
+| nhsuk-typography-scale | variable | settings/typography | 4652 |
+| nhsuk-warning-button-active-colour | variable | settings/colours | 4803 |
+| nhsuk-warning-button-colour | variable | settings/colours | 4820 |
+| nhsuk-warning-button-hover-colour | variable | settings/colours | 4837 |
+| nhsuk-warning-button-shadow-colour | variable | settings/colours | 4854 |
 
 
 ## Functions
-
-### _map-sort-by-value
-
-- Type: function
-- Access: private
-- Group: none
-- File: core/vendor/sass-mq.scss (L232-L255)
-
-Sort a map by values (works with numbers only)
-
-#### Implementation
-
-```scss
-$map-sorted: ();
-  $map-keys: map.keys($map);
-  $map-values: map.values($map);
-  $map-values-sorted: _quick-sort($map-values);
-
-  // Reorder key/value pairs based on key values
-  @each $value in $map-values-sorted {
-    $index: index($map-values, $value);
-    $key: list.nth($map-keys, $index);
-    $map-sorted: map.merge(
-      $map-sorted,
-      (
-        $key: $value
-      )
-    );
-
-    // Unset the value in $map-values to prevent the loop
-    // from finding the same index twice
-    $map-values: list.set-nth($map-values, $index, 0);
-  }
-
-  @return $map-sorted;
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| map | Map | No | - | Map to sort |
-
-#### Returns
-
-- Type: Map
-- Description: Map sorted by value
-
-#### Requires
-
-- function: _quick-sort
-
-#### Used By
-
-- mixin: add-breakpoint
-
----
 
 ### _nhsuk-equilateral-height
 
@@ -269,14 +204,6 @@ $map-sorted: ();
 Calculate the height of an equilateral triangle
 Multiplying half the length of the base of an equilateral triangle by the
 square root of three gives us its height. We use 1.732 as an approximation.
-
-#### Implementation
-
-```scss
-$square-root-of-three: 1.732;
-
-  @return math.div($base, 2) * $square-root-of-three;
-```
 
 #### Parameters
 
@@ -299,72 +226,14 @@ $square-root-of-three: 1.732;
 
 ---
 
-### _quick-sort
-
-- Type: function
-- Access: private
-- Group: none
-- File: core/vendor/sass-mq.scss (L203-L225)
-
-Quick sort
-
-#### Implementation
-
-```scss
-$less: ();
-  $equal: ();
-  $large: ();
-
-  @if length($list) > 1 {
-    $seed: list.nth($list, math.ceil(math.div(length($list), 2)));
-
-    @each $item in $list {
-      @if ($item == $seed) {
-        $equal: list.append($equal, $item);
-      } @else if ($item < $seed) {
-        $less: list.append($less, $item);
-      } @else if ($item > $seed) {
-        $large: list.append($large, $item);
-      }
-    }
-
-    @return join(join(_quick-sort($less), $equal), _quick-sort($large));
-  }
-
-  @return $list;
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| list | List | No | - | List to sort |
-
-#### Returns
-
-- Type: List
-- Description: Sorted List
-
-#### Used By
-
-- function: _map-sort-by-value
-
----
-
 ### _reverse-colour
 
 - Type: function
 - Access: private
 - Group: none
-- File: lib/highlighter/styles/index.scss (L24-L26)
+- File: lib/highlighter/styles/index.scss (L25-L27)
 
 Lighten colour for reverse backgrounds
-
-#### Implementation
-
-```scss
-@return nhsuk-colour-compatible(color.scale($code-colour, $lightness: 80%));
-```
 
 #### Parameters
 
@@ -386,12 +255,6 @@ Lighten colour for reverse backgrounds
 - File: core/settings/_warnings.scss (L71-L73)
 
 Check whether a key is present in the suppressed warnings list.
-
-#### Implementation
-
-```scss
-@return list.index($nhsuk-suppressed-warnings, $key) == null;
-```
 
 #### Parameters
 
@@ -422,12 +285,6 @@ Check whether a key is present in the suppressed warnings list.
 
 Format a warning by appending information on how to suppress it.
 
-#### Implementation
-
-```scss
-@return $message + " To silence this warning, update $nhsuk-suppressed-warnings " + 'with key: "#{$key}"';
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -449,55 +306,6 @@ Format a warning by appending information on how to suppress it.
 
 ---
 
-### get-breakpoint-width
-
-- Type: function
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L84-L91)
-
-Get a breakpoint's width
-
-#### Implementation
-
-```scss
-@if map.has-key($breakpoints, $name) {
-    @return map.get($breakpoints, $name);
-  } @else {
-    @warn "Breakpoint #{$name} wasn't found in $breakpoints.";
-    @return null;
-  }
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| name | String | No | - | Name of the breakpoint. One of $mq-breakpoints |
-
-#### Returns
-
-- Type: Number
-- Description: Value in pixels
-
-#### Requires
-
-- variable: mq-breakpoints
-
-#### Used By
-
-- mixin: mq
-- mixin: show-breakpoints
-
-#### Examples
-
-```scss
-$tablet-width: get-breakpoint-width(tablet);
-@media (min-width: get-breakpoint-width(tablet)) {}
-```
-
----
-
 ### nhsuk-chevron-size
 
 - Type: function
@@ -506,23 +314,6 @@ $tablet-width: get-breakpoint-width(tablet);
 - File: core/tools/_functions.scss (L66-L79)
 
 Get the size (△↕) of chevron, from base to tip, given a certain font size
-
-#### Implementation
-
-```scss
-@if math.is-unitless($font-size) {
-    $font-size: $font-size * 1px;
-  }
-
-  // Get unitless chevron border width
-  $border: math.div($nhsuk-chevron-border, 1px);
-
-  // Get unitless length of one side of the chevron, minus the border
-  $box-size: math.div($font-size, 2px) - $border;
-
-  // Calculate width (△↕) of the chevron, from base to tip
-  @return math.sqrt(math.pow($box-size, 2) + math.pow($box-size, 2)) * 0.5;
-```
 
 #### Parameters
 
@@ -549,20 +340,6 @@ Get the size (△↕) of chevron, from base to tip, given a certain font size
 - File: core/helpers/_colour.scss (L21-L31)
 
 Get colour
-
-#### Implementation
-
-```scss
-@if meta.type-of($colour) == "color" {
-    $colour: string.quote("#{$colour}");
-  }
-
-  @if not map.has-key($nhsuk-colours, $colour) {
-    @error "Unknown colour `#{$colour}`";
-  }
-
-  @return map.get($nhsuk-colours, $colour);
-```
 
 #### Parameters
 
@@ -602,41 +379,6 @@ into hexadecimal notation where possible (e.g. no alpha transparency)
 
 This ensures the colour is rendered properly by Safari < 12
 
-#### Implementation
-
-```scss
-@if meta.type-of($colour) == "string" {
-    $colour: nhsuk-colour($colour);
-  }
-
-  $alpha: color.alpha($colour);
-  $parts: ();
-
-  // Maintain compatibility with Sass < v1.79.0 where colour space functions
-  // are unavailable and RGB channels are automatically rounded to integers
-  // https://github.com/sass/dart-sass/blob/1.79.0/CHANGELOG.md
-  @if not meta.function-exists("channel", "color") {
-    $parts: (
-      "red": color.red($colour),
-      "green": color.green($colour),
-      "blue": color.blue($colour),
-      "alpha": $alpha
-    );
-  } @else {
-    $colour: color.to-space($colour, rgb);
-    $alpha: color.channel($colour, "alpha");
-
-    $parts: (
-      "red": math.round(color.channel($colour, "red")),
-      "green": math.round(color.channel($colour, "green")),
-      "blue": math.round(color.channel($colour, "blue")),
-      "alpha": $alpha
-    );
-  }
-
-  @return color.change($colour, $parts...);
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -669,24 +411,6 @@ This ensures the colour is rendered properly by Safari < 12
 
 Convert pixels to em
 
-#### Implementation
-
-```scss
-@if math.is-unitless($value) {
-    $value: $value * 1px;
-  }
-
-  @if math.is-unitless($context-font-size) {
-    $context-font-size: $context-font-size * 1px;
-  }
-
-  @if math.compatible($value, 1rem) {
-    $value: math.div($value, 1rem) * $nhsuk-root-font-size;
-  }
-
-  @return math.div($value, $context-font-size) * 1em;
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -710,8 +434,6 @@ Convert pixels to em
 #### Used By
 
 - mixin: nhsuk-shape-chevron
-- mixin: nhsuk-shape-chevron
-- mixin: nhsuk-shape-chevron
 
 #### Examples
 
@@ -729,12 +451,6 @@ nhsuk-em(20px, $nhsuk-root-font-size);
 - File: core/tools/_font-url.scss (L12-L14)
 
 Font URL
-
-#### Implementation
-
-```scss
-@return url($nhsuk-fonts-path + $filename);
-```
 
 #### Parameters
 
@@ -761,16 +477,6 @@ Font URL
 - File: core/tools/_grid.scss (L20-L26)
 
 Grid width percentage
-
-#### Implementation
-
-```scss
-@if map.has-key($nhsuk-grid-widths, $key) {
-    @return map.get($nhsuk-grid-widths, $key);
-  }
-
-  @error "Unknown grid width `#{$key}`";
-```
 
 #### Parameters
 
@@ -810,12 +516,6 @@ Grid width percentage
 
 Font URL
 
-#### Implementation
-
-```scss
-@return url($nhsuk-images-path + $filename);
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -838,37 +538,13 @@ Font URL
 - Type: function
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L107-L127)
+- File: core/tools/_typography.scss (L162-L182)
 
 Line height
 
 Convert line-heights specified in pixels into a relative value, unless
 they are already unit-less (and thus already treated as relative values),
 in rems, or the units do not match the units used for the font size.
-
-#### Implementation
-
-```scss
-@if not math.is-unitless($line-height) {
-    @if math.compatible($line-height, 1rem) and math.compatible($font-size, 1px) {
-      $line-height: math.div($line-height, 1rem) * $nhsuk-root-font-size;
-
-      @if math.is-unitless($font-size) {
-        $font-size: $font-size * 1px;
-      }
-    }
-
-    @if math.compatible($line-height, 1px) and math.compatible($font-size, 1rem) {
-      $font-size: math.div($font-size, 1rem) * $nhsuk-root-font-size;
-    }
-
-    @if math.unit($line-height) == math.unit($font-size) {
-      $line-height: math.div($line-height, $font-size);
-    }
-  }
-
-  @return $line-height;
-```
 
 #### Parameters
 
@@ -904,20 +580,6 @@ Convert pixels to rem
 The $nhsuk-root-font-size (defined in settings/_globals.scss)
 must be configured to match the font-size of your root (html) element
 
-#### Implementation
-
-```scss
-@if math.is-unitless($value) {
-    $value: $value * 1px;
-  }
-
-  @if math.compatible($value, 1rem) {
-    @return $value;
-  }
-
-  @return math.div($value, $nhsuk-root-font-size) * 1rem;
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -935,7 +597,6 @@ must be configured to match the font-size of your root (html) element
 
 #### Used By
 
-- mixin: nhsuk-button-style
 - mixin: nhsuk-button-style
 - mixin: nhsuk-shape-arrow
 - mixin: nhsuk-font-size
@@ -957,14 +618,6 @@ nhsuk-px-to-rem(20px);
 
 Make a colour darker by mixing it with black
 
-#### Implementation
-
-```scss
-// Ensure the output is a hex string so that Safari <12 can render the colour
-  // without issues from float values in `rgb()`
-  @return nhsuk-colour-compatible(color.mix(black, $colour, $percentage));
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -982,7 +635,6 @@ Make a colour darker by mixing it with black
 
 #### Used By
 
-- mixin: nhsuk-link-style-success
 - mixin: nhsuk-link-style-success
 
 #### Examples
@@ -1004,34 +656,6 @@ nhsuk-shade(nhsuk-colour("blue"), 50%);
 Single point spacing
 
 Returns measurement corresponding to the spacing point requested.
-
-#### Implementation
-
-```scss
-$actual-input-type: meta.type-of($spacing-point);
-  @if $actual-input-type != "number" {
-    @error "Expected a number (integer), but got a "
-      + "#{$actual-input-type}.";
-  }
-
-  $is-negative: false;
-  @if $spacing-point < 0 {
-    $is-negative: true;
-    $spacing-point: math.abs($spacing-point);
-  }
-
-  @if not map.has-key($nhsuk-spacing-points, $spacing-point) {
-    @error "Unknown spacing variable `#{$spacing-point}`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.";
-  }
-
-  $value: map.get($nhsuk-spacing-points, $spacing-point);
-
-  @if $is-negative {
-    @return $value * -1;
-  }
-
-  @return $value;
-```
 
 #### Parameters
 
@@ -1061,15 +685,6 @@ $actual-input-type: meta.type-of($spacing-point);
 #### Used By
 
 - mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-heading-label
-- mixin: _nhsuk-generate-static-spacing-overrides
 - mixin: _nhsuk-generate-static-spacing-overrides
 
 #### Examples
@@ -1107,14 +722,6 @@ Marking spacing declarations as important
 
 Make a colour lighter by mixing it with white
 
-#### Implementation
-
-```scss
-// Ensure the output is a hex string so that Safari <12 can render the colour
-  // without issues from float values in `rgb()`
-  @return nhsuk-colour-compatible(color.mix(white, $colour, $percentage));
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -1139,53 +746,6 @@ nhsuk-tint(nhsuk-colour("blue"), 10%);
 
 ---
 
-### px2em
-
-- Type: function
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L61-L71)
-
-Convert pixels to ems
-
-#### Implementation
-
-```scss
-@if math.is-unitless($px) {
-    @warn "Assuming #{$px} to be in pixels, attempting to convert it into pixels.";
-    @return px2em($px * 1px);
-  }
-  // if $px is compatible with em units, then return value unchanged
-  @if math.compatible($px, 1em) {
-    @return $px;
-  }
-  @return math.div($px, 16px) * 1em;
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| px | Number | No | - | value to convert |
-
-#### Returns
-
-- Number
-
-#### Used By
-
-- mixin: mq
-- mixin: show-breakpoints
-
-#### Examples
-
-```scss
-$font-size-in-ems: px2em(16px);
-p { font-size: px2em(16px); }
-```
-
----
-
 ## Mixins
 
 ### _header-link-style
@@ -1196,30 +756,6 @@ p { font-size: px2em(16px); }
 - File: components/header/_index.scss (L45-L69)
 
 Header link styling
-
-#### Implementation
-
-```scss
-& {
-    color: $link-colour;
-  }
-
-  @include nhsuk-link-style-visited($link-colour);
-  @include nhsuk-link-style-hover($link-hover-colour);
-  @include nhsuk-link-style-active($link-active-colour);
-  @include nhsuk-link-style-focus;
-
-  &:focus {
-    color: $nhsuk-focus-text-colour;
-    box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-focus-text-colour;
-  }
-
-  @include nhsuk-print-colour($print-colour: inherit) {
-    &::after {
-      content: "";
-    }
-  }
-```
 
 #### Parameters
 
@@ -1252,25 +788,6 @@ Generate responsive spacing override classes
 
 Generate spacing override classes for the given property (e.g. margin)
 for each point in the responsive spacing scale.
-
-#### Implementation
-
-```scss
-// For each point in the spacing scale (defined in settings), create an
-  // override that affects all directions...
-  @each $scale-point, $scale-map in $nhsuk-spacing-responsive-scale {
-    .nhsuk-u-#{$property}-#{$scale-point} {
-      @include nhsuk-responsive-spacing($scale-point, $property, "all", true);
-    }
-
-    // ... and then an override for each individual direction
-    @each $direction in $_spacing-directions {
-      .nhsuk-u-#{$property}-#{$direction}-#{$scale-point} {
-        @include nhsuk-responsive-spacing($scale-point, $property, $direction, true);
-      }
-    }
-  }
-```
 
 #### Parameters
 
@@ -1312,22 +829,6 @@ Generate static spacing override classes
 Generate spacing override classes for the given property (e.g. margin)
 for each point in the non-responsive spacing scale.
 
-#### Implementation
-
-```scss
-@each $spacing-point in map.keys($nhsuk-spacing-points) {
-    .nhsuk-u-static-#{$property}-#{$spacing-point} {
-      #{$property}: nhsuk-spacing($spacing-point) !important;
-    }
-
-    @each $direction in $_spacing-directions {
-      .nhsuk-u-static-#{$property}-#{$direction}-#{$spacing-point} {
-        #{$property}-#{$direction}: nhsuk-spacing($spacing-point) !important;
-      }
-    }
-  }
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -1359,48 +860,6 @@ for each point in the non-responsive spacing scale.
 
 Helper function containing the common code for the following two mixins
 
-#### Implementation
-
-```scss
-$properties: (
-    "position": absolute,
-
-    "width": 1px,
-    "height": 1px,
-
-    // If margin is set to a negative value it can cause text to be announced in
-    // the wrong order in VoiceOver for OSX
-    "margin": 0,
-    "padding": 0,
-
-    "overflow": hidden,
-
-    // `clip` is needed for IE11 support
-    "clip": rect(0 0 0 0),
-    "clip-path": inset(50%),
-    "border": 0,
-
-    // For long content, line feeds are not interpreted as spaces and small width
-    // causes content to wrap 1 word per line:
-    // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-    "white-space": nowrap
-  );
-
-  // Workaround to avoid deprecated `if()` function
-  @each $property, $value in $properties {
-    @if $important == true {
-      #{$property}: $value !important;
-    } @else {
-      #{$property}: $value;
-    }
-  }
-
-  // Prevent users from selecting or copying visually-hidden text. This prevents
-  // a user unintentionally copying more text than they intended and needing to
-  // manually trim it down again.
-  user-select: none;
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -1420,62 +879,17 @@ $properties: (
 
 ---
 
-### add-breakpoint
-
-- Type: mixin
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L267-L273)
-
-Add a breakpoint
-
-#### Implementation
-
-```scss
-$new-breakpoint: (
-    $name: $width
-  );
-  $mq-breakpoints: map.merge($mq-breakpoints, $new-breakpoint) !global;
-  $mq-breakpoints: _map-sort-by-value($mq-breakpoints) !global;
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| name | String | No | - | Name of the breakpoint |
-| width | Number | No | - | Width of the breakpoint |
-
-#### Requires
-
-- function: _map-sort-by-value
-- variable: mq-breakpoints
-
-#### Examples
-
-```scss
-@include add-breakpoint(tvscreen, 1920px);
-@include mq(tvscreen) {}
-```
-
----
-
 ### care-card
 
 - Type: mixin
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L416-L419)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-care-card
+- Alias of: nhsuk-care-card (prefer the original)
 
 Care card mixin, used for creating
 different coloured care cards (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("care-card", "care-card is deprecated. Use nhsuk-care-card instead.");
-  @include nhsuk-care-card($args...);
-```
 
 #### Requires
 
@@ -1490,15 +904,10 @@ different coloured care cards (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L34-L37)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-clearfix
+- Alias of: nhsuk-clearfix (prefer the original)
 
 Clearfix mixin (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("clearfix", "clearfix is deprecated. Use nhsuk-clearfix instead.");
-  @include nhsuk-clearfix;
-```
 
 #### Requires
 
@@ -1513,13 +922,8 @@ Clearfix mixin (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L503-L506)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("flex", "flex is deprecated. Use nhsuk-flex instead.");
-  @include nhsuk-flex;
-```
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-flex
+- Alias of: nhsuk-flex (prefer the original)
 
 #### Requires
 
@@ -1534,43 +938,13 @@ Clearfix mixin (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L527-L530)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("flex-item", "flex-item is deprecated. Use nhsuk-flex-item instead.");
-  @include nhsuk-flex-item;
-```
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-flex-item
+- Alias of: nhsuk-flex-item (prefer the original)
 
 #### Requires
 
 - mixin: nhsuk-warning
 - mixin: nhsuk-flex-item
-
----
-
-### govuk-media-query
-
-- Type: mixin
-- Access: public
-- Group: tools
-- File: core/tools/_sass-mq.scss (L70-L75)
-
-Media query (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("govuk-media-query", "govuk-media-query is deprecated. Use nhsuk-media-query instead.");
-  @include nhsuk-media-query($args...) {
-    @content;
-  }
-```
-
-#### Requires
-
-- mixin: nhsuk-warning
-- mixin: nhsuk-media-query
 
 ---
 
@@ -1580,16 +954,11 @@ Media query (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L381-L384)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-heading-label
+- Alias of: nhsuk-heading-label (prefer the original)
 
 Heading label mixin, adds a tab heading to
 warning callout, do and don't lists and panel (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("heading-label", "heading-label is deprecated. Use nhsuk-heading-label instead.");
-  @include nhsuk-heading-label($args...);
-```
 
 #### Requires
 
@@ -1598,234 +967,14 @@ warning callout, do and don't lists and panel (deprecated)
 
 ---
 
-### mq
-
-- Type: mixin
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L142-L195)
-
-Media Query mixin
-
-#### Implementation
-
-```scss
-$min-width: 0;
-  $max-width: 0;
-  $media-query: "";
-
-  @if not $silence-warning {
-    @include nhsuk-warning("mq", "mq is deprecated. Use nhsuk-media-query instead.");
-  }
-
-  // From: this breakpoint (inclusive)
-  @if $from {
-    @if meta.type-of($from) == number {
-      $min-width: px2em($from);
-    } @else {
-      $min-width: px2em(get-breakpoint-width($from, $breakpoints));
-    }
-  }
-
-  // Until: that breakpoint (exclusive)
-  @if $until {
-    @if meta.type-of($until) == number {
-      $max-width: px2em($until);
-    } @else {
-      $max-width: px2em(get-breakpoint-width($until, $breakpoints)) - 0.01em;
-    }
-  }
-
-  @if $min-width != 0 {
-    $media-query: "#{$media-query} and (min-width: #{$min-width})";
-  }
-  @if $max-width != 0 {
-    $media-query: "#{$media-query} and (max-width: #{$max-width})";
-  }
-  @if $and {
-    $media-query: "#{$media-query} and #{$and}";
-  }
-
-  // Remove unnecessary media query prefix 'all and '
-  @if ($media-type == "all" and $media-query != "") {
-    $media-type: "";
-    $media-query: string.slice(string.unquote($media-query), 6);
-  }
-
-  @media #{$media-type + $media-query} {
-    @content;
-  }
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| from | String \| Boolean | No | false | One of $mq-breakpoints |
-| until | String \| Boolean | No | false | One of $mq-breakpoints |
-| and | String \| Boolean | No | false | Additional media query parameters |
-| media-type | String | No | $mq-media-type | Media type: screen, print… |
-| silence-warning | Boolean | No | false | Whether to silence deprecation
-warning to use nhsuk-media-query instead |
-
-#### Requires
-
-- mixin: nhsuk-warning
-- variable: mq-media-type
-- variable: mq-breakpoints
-- function: px2em
-- function: get-breakpoint-width
-
-#### Links
-
-- [Full documentation and examples](https://github.com/sass-mq/sass-mq#responsive-mode-on-default)
-
-#### Used By
-
-- mixin: nhsuk-media-query
-- mixin: show-breakpoints
-
-#### Examples
-
-```scss
-@use 'path/to/mq' as *;
-.element {
-  @include mq($from: mobile) {
-    color: red;
-  }
-  @include mq($until: tablet) {
-    color: blue;
-  }
-  @include mq(mobile, tablet) {
-    color: green;
-  }
-  @include mq($from: tablet, $and: '(orientation: landscape)') {
-    color: teal;
-  }
-  @include mq(950px) {
-    color: hotpink;
-  }
-  @include mq(tablet, $media-type: screen) {
-    color: hotpink;
-  }
-  // Advanced use:
-  $my-breakpoints: (L: 900px, XL: 1200px);
-  @include mq(L, $breakpoints: $my-breakpoints) {
-    color: hotpink;
-  }
-}
-```
-
----
-
 ### nhsuk-button-style
 
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_buttons.scss (L22-L126)
+- File: core/tools/_buttons.scss (L22-L127)
 
 Button styling with colour overrides
-
-#### Implementation
-
-```scss
-background-color: $button-colour;
-  box-shadow: 0 $nhsuk-button-shadow-size 0 $button-shadow-colour;
-
-  &,
-  &:visited,
-  &:hover,
-  &:active {
-    color: $button-text-colour;
-  }
-
-  &[href] .nhsuk-icon {
-    fill: $button-text-colour;
-
-    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-      fill: currentcolor;
-    }
-  }
-
-  &:hover {
-    @if $button-hover-colour {
-      background-color: $button-hover-colour;
-    } @else {
-      background-color: $button-colour;
-    }
-  }
-
-  &:active,
-  &:active:focus {
-    @if $button-active-colour {
-      background-color: $button-active-colour;
-    } @else {
-      background-color: $button-colour;
-    }
-  }
-
-  // Override default border radius
-  @if $button-border-radius != $nhsuk-button-border-radius {
-    &,
-    &::before,
-    &::after {
-      border-radius: nhsuk-px-to-rem($button-border-radius);
-    }
-  }
-
-  // Handle shadow on both the button and the pseudo element. The button shadow
-  // remains in place to prevent any pixel gaps due to browser rounding
-  @if $button-border-colour {
-    &,
-    &::after {
-      box-shadow: 0 $nhsuk-button-shadow-size 0 $button-shadow-colour;
-    }
-
-    &:active,
-    &:active:focus,
-    // Set border on click area for default and hover states which allows the
-    // border to render underneath the shadow and hide pixel artifacts, but
-    // ensuring the active "pressed" and focus states have priority
-    &:not(:focus):not(:active)::before {
-      border-color: $button-border-colour;
-
-      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        border-color: buttonborder;
-      }
-    }
-
-    // Inset the pseudo element shadow away from the edges, to restore lost
-    // border radius (and its shadow) previously hidden by the 2px border
-    &:not(:focus)::after {
-      right: 0;
-      left: 0;
-      border-radius: nhsuk-px-to-rem($button-border-radius - $nhsuk-border-width-form-element);
-    }
-
-    // Remove the pseudo element shadow when focused or pressed
-    &:focus::after,
-    &:active::after {
-      box-shadow: none;
-    }
-  }
-
-  // Override high-contrast link colours to match buttons
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    &,
-    &:visited,
-    &:active {
-      color: buttontext;
-    }
-
-    &:not(:focus):not(:active):hover,
-    &:not(:focus):not(:active):hover::before,
-    &:not(:focus):not(:active):hover::after {
-      border-color: Highlight;
-      color: Highlight;
-    }
-  }
-```
 
 #### Parameters
 
@@ -1857,21 +1006,6 @@ background-color: $button-colour;
 
 Care card mixin, used for creating
 different coloured care cards
-
-#### Implementation
-
-```scss
-.nhsuk-card__heading-container,
-  .nhsuk-card--care__heading-container {
-    color: $heading-text-colour;
-    background-color: $heading-background-colour;
-  }
-
-  @include nhsuk-print-colour {
-    border: $print-border-size solid $nhsuk-print-text-colour;
-    page-break-inside: avoid;
-  }
-```
 
 #### Parameters
 
@@ -1906,16 +1040,6 @@ different coloured care cards
 
 Clearfix mixin
 
-#### Implementation
-
-```scss
-&::after {
-    content: "";
-    display: block;
-    clear: both;
-  }
-```
-
 #### Used By
 
 - mixin: clearfix
@@ -1940,20 +1064,6 @@ Export module
 Ensure that the modules of CSS that we define throughout frontend are only
 included in the generated CSS once, no matter how many times they are
 imported across the individual components.
-
-#### Implementation
-
-```scss
-// If the mixin is not in the list of modules already exported...
-  @if not list.index($imported-modules, $name) {
-    // ... then add it to the list
-    $imported-modules: list.append($imported-modules, $name) !global;
-    // ... and output the CSS for that module
-    @content;
-  }
-  // The next time exports is called for the module of the same name, it will be
-  // found in the list and so nothing will be outputted.
-```
 
 #### Parameters
 
@@ -1980,13 +1090,6 @@ imported across the individual components.
 
 Flex mixin
 
-#### Implementation
-
-```scss
-display: flex;
-  flex-wrap: wrap;
-```
-
 #### Used By
 
 - mixin: flex
@@ -2007,16 +1110,6 @@ display: flex;
 - File: core/tools/_mixins.scss (L514-L520)
 
 Flex item mixin
-
-#### Implementation
-
-```scss
-display: flex;
-
-  @include nhsuk-media-query($until: desktop) {
-    flex: 0 0 100%;
-  }
-```
 
 #### Requires
 
@@ -2039,7 +1132,7 @@ display: flex;
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_focused.scss (L132-L137)
+- File: core/tools/_focused.scss (L128-L139)
 
 Focused box
 
@@ -2047,15 +1140,6 @@ Provides an outline to clearly indicate when the target element is focused.
 Unlike nhsuk-focused-text, which only draws an underline below the element,
 nhsuk-focused-box draws an outline around all sides of the element.
 Best used for non-text content contained within links.
-
-#### Implementation
-
-```scss
-outline: $nhsuk-focus-width solid transparent;
-  box-shadow:
-    0 0 0 4px $nhsuk-focus-colour,
-    0 0 0 8px $nhsuk-focus-text-colour;
-```
 
 #### Requires
 
@@ -2078,34 +1162,12 @@ outline: $nhsuk-focus-width solid transparent;
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_focused.scss (L105-L123)
+- File: core/tools/_focused.scss (L105-L119)
 
 Focused button
 
 Provides an additional outline and background to clearly indicate when
 the target element has focus. Used for buttons.
-
-#### Implementation
-
-```scss
-outline: $nhsuk-focus-width solid transparent;
-  outline-offset: $nhsuk-focus-width;
-  color: $nhsuk-focus-text-colour;
-  background-color: $nhsuk-focus-colour;
-  box-shadow: 0 $nhsuk-focus-width 0 0 $nhsuk-focus-text-colour;
-
-  .nhsuk-icon {
-    fill: $nhsuk-focus-text-colour;
-  }
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: buttontext;
-
-    .nhsuk-icon {
-      fill: buttontext;
-    }
-  }
-```
 
 #### Requires
 
@@ -2130,26 +1192,6 @@ Focused checkbox input (form element)
 
 Provides an additional outline and border to clearly indicate when
 the target element has focus. Used by checkbox.
-
-#### Implementation
-
-```scss
-border: $nhsuk-focus-width solid $nhsuk-focus-text-colour;
-
-  // When colours are overridden, the yellow box-shadow becomes invisible
-  // which means the focus state is less obvious. By adding a transparent
-  // outline, which becomes solid (text-coloured) in that context, we ensure
-  // the focus remains clearly visible.
-  outline: $nhsuk-focus-width solid transparent;
-  outline-offset: 1px;
-  box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-colour;
-
-  // When in an explicit forced-color mode, we can use the Highlight system
-  // color for the outline to better match focus states of native controls
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    outline-color: Highlight;
-  }
-```
 
 #### Requires
 
@@ -2176,19 +1218,6 @@ Provides an additional outline and border to clearly indicate when
 the target element has focus. Used for interactive input-based elements such
 as text inputs.
 
-#### Implementation
-
-```scss
-border: $nhsuk-border-width-form-element solid $nhsuk-focus-text-colour;
-  outline: $nhsuk-focus-width solid $nhsuk-focus-colour;
-  // Ensure outline appears outside of the element
-  outline-offset: 0;
-  // Double the border by adding its width again. Use `box-shadow` to do
-  // this instead of changing `border-width` (which changes element size)
-  // and since `outline` is already used for the yellow focus state.
-  box-shadow: inset 0 0 0 $nhsuk-border-width-form-element $nhsuk-focus-text-colour;
-```
-
 #### Requires
 
 - variable: nhsuk-border-width-form-element
@@ -2213,26 +1242,6 @@ Focused radio input (form element)
 
 Provides an additional outline and border to clearly indicate when
 the target element has focus. Used by radios.
-
-#### Implementation
-
-```scss
-border: $nhsuk-focus-width solid $nhsuk-focus-text-colour;
-
-  // When colours are overridden, the yellow box-shadow becomes invisible
-  // which means the focus state is less obvious. By adding a transparent
-  // outline, which becomes solid (text-coloured) in that context, we ensure
-  // the focus remains clearly visible.
-  outline: $nhsuk-focus-width solid transparent;
-  outline-offset: 1px;
-  box-shadow: 0 0 0 $focus-width $nhsuk-focus-colour;
-
-  // When in an explicit forced-color mode, we can use the Highlight system
-  // color for the outline to better match focus states of native controls
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    outline-color: Highlight;
-  }
-```
 
 #### Parameters
 
@@ -2264,28 +1273,6 @@ Focused text
 Provides an outline to clearly indicate when the target element is focused.
 Used for interactive text-based elements.
 
-#### Implementation
-
-```scss
-// When colours are overridden, for example when users have a dark mode,
-  // backgrounds and box-shadows disappear, so we need to ensure there's a
-  // transparent outline which will be set to a visible colour.
-  outline: $nhsuk-focus-width solid transparent;
-  color: $nhsuk-focus-text-colour;
-  background-color: $nhsuk-focus-colour;
-  box-shadow:
-    0 -2px $nhsuk-focus-colour,
-    0 $nhsuk-focus-width $nhsuk-focus-text-colour;
-
-  // When link is focussed, hide the default underline since the
-  // box shadow adds the "underline"
-  text-decoration: none;
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: linktext;
-  }
-```
-
 #### Requires
 
 - variable: nhsuk-focus-width
@@ -2307,25 +1294,9 @@ Used for interactive text-based elements.
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L291-L303)
+- File: core/tools/_typography.scss (L346-L358)
 
 Font helper
-
-#### Implementation
-
-```scss
-& {
-    @if $weight == normal {
-      @include nhsuk-typography-weight-normal;
-    } @else if $weight == bold {
-      @include nhsuk-typography-weight-bold;
-    }
-  }
-
-  @if $size {
-    @include nhsuk-font-size($size, $line-height);
-  }
-```
 
 #### Parameters
 
@@ -2338,8 +1309,8 @@ Font helper
 
 #### Requires
 
-- mixin: nhsuk-typography-weight-normal
-- mixin: nhsuk-typography-weight-bold
+- mixin: nhsuk-font-weight-normal
+- mixin: nhsuk-font-weight-bold
 - mixin: nhsuk-font-size
 
 #### Examples
@@ -2356,6 +1327,30 @@ Font helper
 
 ---
 
+### nhsuk-font-code
+
+- Type: mixin
+- Access: public
+- Group: tools
+- File: core/tools/_typography.scss (L102-L106)
+
+Code font helper
+
+Used for codes and sequences
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| important | Boolean | No | false | Whether to mark declarations as
+  \`!important\`. Generally used to create override classes. |
+
+#### Requires
+
+- mixin: nhsuk-font-monospace
+
+---
+
 ### nhsuk-font-dynamic-type
 
 - Type: mixin
@@ -2368,24 +1363,35 @@ Font 'Dynamic Type' support
 On Apple devices, uses the -apple-system-body font to enable system-level
 Dynamic Type for accessibility but prevents the system body font-family.
 
-#### Implementation
-
-```scss
-@at-root {
-    html {
-      font-size: math.percentage(math.div($nhsuk-root-font-size, 16px));
-
-      @supports (font: -apple-system-body) and (-webkit-touch-callout: default) {
-        // stylelint-disable-next-line font-family-no-missing-generic-family-keyword
-        font: -apple-system-body;
-      }
-    }
-  }
-```
-
 #### Requires
 
 - variable: nhsuk-root-font-size
+
+---
+
+### nhsuk-font-monospace
+
+- Type: mixin
+- Access: public
+- Group: tools
+- File: core/tools/_typography.scss (L113-L122)
+
+Monospace font helper
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| important | Boolean | No | false | Whether to mark declarations as
+  \`!important\`. Generally used to create override classes. |
+
+#### Requires
+
+- variable: nhsuk-code-font
+
+#### Used By
+
+- mixin: nhsuk-font-code
 
 ---
 
@@ -2394,7 +1400,7 @@ Dynamic Type for accessibility but prevents the system body font-family.
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L165-L250)
+- File: core/tools/_typography.scss (L220-L305)
 
 Font size and line height helper
 
@@ -2419,95 +1425,6 @@ Example font map:
     line-height: 1.15
   )
 );
-```
-
-#### Implementation
-
-```scss
-// Flag font sizes that start with underscores so we can suppress warnings on
-  // deprecated sizes used internally, for example `nhsuk-font($size: "_24")`
-  $size-internal-use-only: string.slice(#{$size}, 1, 1) == "_";
-
-  // Remove underscore from font sizes flagged for internal use
-  @if $size-internal-use-only {
-    $size: string.slice(#{$size}, 2);
-  }
-
-  // Check for a font map exactly matching the given size
-  $font-map: map.get($nhsuk-typography-scale, $size);
-
-  // No match? Try with string type (e.g. $size: "16" not 16)
-  @if not $font-map {
-    @each $font-size in map.keys($nhsuk-typography-scale) {
-      @if not $font-map and "#{$font-size}" == "#{$size}" {
-        $font-map: map.get($nhsuk-typography-scale, $font-size);
-      }
-    }
-  }
-
-  // Still no match? Throw error
-  @if not $font-map {
-    @error "Unknown font size `#{$size}` - expected a point from the typography scale.";
-  }
-
-  // Check for a deprecation within the typography scale
-  $deprecation: map.get($font-map, "deprecation");
-
-  @if $deprecation {
-    // Warn on deprecated font sizes unless flagged for internal use
-    @if not $size-internal-use-only {
-      @include nhsuk-warning(map.get($deprecation, "key"), map.get($deprecation, "message"));
-    }
-
-    // remove the deprecation map keys so they do not break the breakpoint loop
-    $font-map: map.remove($font-map, "deprecation");
-  }
-
-  @each $breakpoint, $breakpoint-map in $font-map {
-    $font-size: map.get($breakpoint-map, "font-size");
-    $font-size-rem: nhsuk-px-to-rem($font-size);
-
-    // $calculated-line-height is a separate variable from $line-height,
-    // as otherwise the value would get redefined with each loop and
-    // eventually break nhsuk-line-height.
-    $calculated-line-height: $line-height;
-    @if $line-height == false {
-      $calculated-line-height: map.get($breakpoint-map, "line-height");
-    }
-
-    // We continue to call the param $line-height to stay consistent with the
-    // naming with nhsuk-font.
-    $calculated-line-height: nhsuk-line-height(
-      $line-height: $calculated-line-height,
-      $font-size: $font-size
-    );
-
-    // Mark rules as !important if $important is true - this will result in
-    // these variables becoming strings, so this needs to happen *after* they
-    // are used in calculations
-    @if $important == true {
-      $font-size: $font-size !important;
-      $font-size-rem: $font-size-rem !important;
-      $calculated-line-height: $calculated-line-height !important;
-    }
-
-    & {
-      @if not $breakpoint {
-        font-size: $font-size-rem;
-        line-height: $calculated-line-height;
-      } @else if $breakpoint == "print" {
-        @include nhsuk-media-query($media-type: print) {
-          font-size: $font-size;
-          line-height: $calculated-line-height;
-        }
-      } @else {
-        @include nhsuk-media-query($from: $breakpoint) {
-          font-size: $font-size-rem;
-          line-height: $calculated-line-height;
-        }
-      }
-    }
-  }
 ```
 
 #### Parameters
@@ -2545,6 +1462,60 @@ Example font map:
 
 ---
 
+### nhsuk-font-weight-bold
+
+- Type: mixin
+- Access: public
+- Group: tools
+- File: core/tools/_typography.scss (L74-L80)
+
+Bold font weight
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| important | Boolean | No | false | Whether to mark declarations as
+  \`!important\`. Generally Used to create override classes. |
+
+#### Requires
+
+- variable: nhsuk-font-weight-bold
+
+#### Used By
+
+- mixin: nhsuk-typography-weight-bold
+- mixin: nhsuk-font
+
+---
+
+### nhsuk-font-weight-normal
+
+- Type: mixin
+- Access: public
+- Group: tools
+- File: core/tools/_typography.scss (L48-L54)
+
+Normal font weight
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| important | Boolean | No | false | Whether to mark declarations as
+  \`!important\`. Generally Used to create override classes. |
+
+#### Requires
+
+- variable: nhsuk-font-weight-normal
+
+#### Used By
+
+- mixin: nhsuk-typography-weight-normal
+- mixin: nhsuk-font
+
+---
+
 ### nhsuk-grid-column
 
 - Type: mixin
@@ -2561,23 +1532,6 @@ Grid widths are defined in the `$nhsuk-grid-widths` map.
 By default the column width changes from 100% to specified width at the
 'desktop' breakpoint, but other breakpoints can be specified using the `$at`
 parameter.
-
-#### Implementation
-
-```scss
-box-sizing: border-box;
-
-  @if $at != tablet {
-    width: 100%;
-  }
-
-  padding: 0 $nhsuk-gutter-half;
-
-  @include nhsuk-media-query($from: $at) {
-    width: nhsuk-grid-width($width);
-    float: $float;
-  }
-```
 
 #### Parameters
 
@@ -2642,39 +1596,6 @@ warning callout, do and don't lists and panel
 5. Negative left margin aligns the heading to the box.
 6. Top positioning set to minus to make heading sit just outside the box.
 
-#### Implementation
-
-```scss
-display: inline-block; // [4]
-
-  position: relative;
-  top: nhsuk-spacing(-3); // [6]
-
-  margin: 0;
-  margin-bottom: nhsuk-spacing(2);
-  margin-left: nhsuk-spacing(-5) - 1px; // [5]
-  padding: nhsuk-spacing(2) nhsuk-spacing(5);
-
-  outline: 1px solid transparent; // [2]
-  outline-offset: -1px;
-
-  color: $heading-text-colour; // [3]
-  background-color: $heading-background-colour; // [1]
-
-  @include nhsuk-font-size(26);
-
-  @include nhsuk-media-query($until: tablet) {
-    top: nhsuk-spacing(-2); // [6]
-    margin-left: nhsuk-spacing(-4) - 1px; // [5]
-    padding: nhsuk-spacing(2) nhsuk-spacing(4);
-  }
-
-  @include nhsuk-print-colour {
-    top: 0;
-    background: none;
-  }
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -2705,29 +1626,12 @@ display: inline-block; // [4]
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L299-L312)
+- File: core/tools/_links.scss (L303-L316)
 
 Image link styles
 
 Prepares and provides the focus state for links that only contain images
 with no accompanying text.
-
-#### Implementation
-
-```scss
-// Needed to draw the focus around the entire image
-  display: inline-block;
-
-  // Remove extra space at the bottom of the image that's added by line-height
-  line-height: 0;
-
-  // Don't render an underline
-  text-decoration: none;
-
-  &:focus {
-    @include nhsuk-focused-box;
-  }
-```
 
 #### Requires
 
@@ -2740,23 +1644,9 @@ with no accompanying text.
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L20-L35)
+- File: core/tools/_links.scss (L20-L39)
 
 Link styling with colour overrides
-
-#### Implementation
-
-```scss
-& {
-    color: $link-colour;
-    text-decoration: underline;
-  }
-
-  @include nhsuk-link-style-visited($link-visited-colour);
-  @include nhsuk-link-style-hover($link-hover-colour);
-  @include nhsuk-link-style-active($link-active-colour);
-  @include nhsuk-link-style-focus;
-```
 
 #### Parameters
 
@@ -2789,17 +1679,9 @@ Link styling with colour overrides
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L152-L156)
+- File: core/tools/_links.scss (L152-L160)
 
 Default link active only styling
-
-#### Implementation
-
-```scss
-&:active {
-    color: $link-active-colour;
-  }
-```
 
 #### Parameters
 
@@ -2825,21 +1707,11 @@ Default link active only styling
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L47-L53)
+- File: core/tools/_links.scss (L51-L53)
 
 Default link styles
 
 Makes links use the default unvisited, visited, hover and active colours.
-
-#### Implementation
-
-```scss
-@include nhsuk-link-style;
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: linktext;
-  }
-```
 
 #### Requires
 
@@ -2860,7 +1732,7 @@ Makes links use the default unvisited, visited, hover and active colours.
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L173-L180)
+- File: core/tools/_links.scss (L177-L184)
 
 Error link styles
 
@@ -2869,17 +1741,6 @@ user hovers their cursor over it.
 
 If you use this mixin in a component, you must also include the
 `nhsuk-link-style-default` mixin to get the correct focus and hover states.
-
-#### Implementation
-
-```scss
-@include nhsuk-link-style(
-    $link-colour: $nhsuk-error-colour,
-    $link-visited-colour: $nhsuk-error-colour,
-    $link-hover-colour: nhsuk-colour-compatible(color.scale($nhsuk-error-colour, $lightness: -30%)),
-    $link-active-colour: $nhsuk-error-colour
-  );
-```
 
 #### Requires
 
@@ -2907,18 +1768,6 @@ If you use this mixin in a component, you must also include the
 
 Default link focus only styling
 
-#### Implementation
-
-```scss
-&:focus {
-    @include nhsuk-focused-text;
-  }
-
-  &:focus:hover {
-    text-decoration: none;
-  }
-```
-
 #### Requires
 
 - mixin: nhsuk-focused-text
@@ -2941,18 +1790,9 @@ Default link focus only styling
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L121-L126)
+- File: core/tools/_links.scss (L117-L126)
 
 Default link hover only styling
-
-#### Implementation
-
-```scss
-&:hover {
-    color: $link-hover-colour;
-    text-decoration: none;
-  }
-```
 
 #### Parameters
 
@@ -2985,21 +1825,6 @@ Remove underline from links
 Remove underlines from links unless the link is active or a user hovers
 their cursor over it.
 
-#### Implementation
-
-```scss
-// Allow ':hover' and ':active' companion classes from postcss-pseudo-classes
-  // which the plugin unfortunately doesn't handle automatically.
-  // stylelint-disable-next-line selector-class-pattern
-  &:not(:hover):not(.\:hover):not(:active):not(.\:active) {
-    text-decoration: none;
-  }
-
-  &:hover {
-    text-decoration: underline;
-  }
-```
-
 #### Examples
 
 ```scss
@@ -3016,7 +1841,7 @@ their cursor over it.
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L225-L236)
+- File: core/tools/_links.scss (L229-L236)
 
 No visited state link mixin
 
@@ -3029,21 +1854,6 @@ that you’ve visited it before is not important.
 
 If you use this mixin in a component, you must also include the
 `nhsuk-link-style-default` mixin to get the correct focus and hover states.
-
-#### Implementation
-
-```scss
-@include nhsuk-link-style(
-    $link-colour: $nhsuk-link-colour,
-    $link-visited-colour: $nhsuk-link-colour,
-    $link-hover-colour: $nhsuk-link-hover-colour,
-    $link-active-colour: $nhsuk-link-active-colour
-  );
-
-  &:visited .nhsuk-icon {
-    fill: currentcolor;
-  }
-```
 
 #### Requires
 
@@ -3068,7 +1878,7 @@ If you use this mixin in a component, you must also include the
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L70-L84)
+- File: core/tools/_links.scss (L70-L76)
 
 Reverse link styles
 
@@ -3077,24 +1887,6 @@ against a dark background.
 
 If you use this mixin in a component, you must also include the
 `nhsuk-link-style-default` mixin to get the correct focus and hover states.
-
-#### Implementation
-
-```scss
-@include nhsuk-link-style-text($override-colour: $nhsuk-reverse-text-colour);
-
-  &:not(:focus) .nhsuk-icon {
-    fill: $nhsuk-reverse-text-colour;
-  }
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: linktext;
-
-    &:not(:focus) .nhsuk-icon {
-      fill: currentcolor;
-    }
-  }
-```
 
 #### Requires
 
@@ -3121,7 +1913,7 @@ If you use this mixin in a component, you must also include the
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L197-L204)
+- File: core/tools/_links.scss (L201-L208)
 
 Success link styles
 
@@ -3130,17 +1922,6 @@ user hovers their cursor over it.
 
 If you use this mixin in a component you must also include the
 `nhsuk-link-style-default` mixin to get the correct focus and hover states.
-
-#### Implementation
-
-```scss
-@include nhsuk-link-style(
-    $link-colour: $nhsuk-success-colour,
-    $link-visited-colour: $nhsuk-success-colour,
-    $link-hover-colour: nhsuk-shade($nhsuk-success-colour, 20%),
-    $link-active-colour: nhsuk-shade($nhsuk-success-colour, 50%)
-  );
-```
 
 #### Requires
 
@@ -3164,32 +1945,12 @@ If you use this mixin in a component you must also include the
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L276-L292)
+- File: core/tools/_links.scss (L276-L296)
 
 Text link styles
 
 Makes links use the primary text colour, in all states. Use this mixin for
 navigation components, such as breadcrumbs or the back link.
-
-#### Implementation
-
-```scss
-@include nhsuk-link-style(
-    $link-colour: $override-colour,
-    $link-visited-colour: $override-colour,
-    $link-hover-colour: $override-colour,
-    $link-active-colour: $override-colour
-  );
-
-  // Force a colour change on hover to work around a bug in Safari
-  // Also allows for ':focus' companion classes from postcss-pseudo-classes
-  // which the plugin unfortunately doesn't handle automatically.
-  // https://bugs.webkit.org/show_bug.cgi?id=224483
-  // stylelint-disable-next-line selector-class-pattern
-  &:not(:focus):not(.\:focus):hover {
-    color: rgba($override-colour, 0.99);
-  }
-```
 
 #### Parameters
 
@@ -3220,17 +1981,9 @@ navigation components, such as breadcrumbs or the back link.
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L107-L111)
+- File: core/tools/_links.scss (L99-L107)
 
 Default link visited only styling
-
-#### Implementation
-
-```scss
-&:visited {
-    color: $link-visited-colour;
-  }
-```
 
 #### Parameters
 
@@ -3256,19 +2009,11 @@ Default link visited only styling
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_links.scss (L91-L97)
+- File: core/tools/_links.scss (L83-L89)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-link-style-reverse
+- Alias of: nhsuk-link-style-reverse (prefer the original)
 
 White link styles (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning(
-    "nhsuk-link-style-white",
-    "nhsuk-link-style-white is deprecated. Use nhsuk-link-style-reverse instead."
-  );
-  @include nhsuk-link-style-reverse;
-```
 
 #### Requires
 
@@ -3289,97 +2034,6 @@ NHS logo size helper
 Saves duplicating the code for when using the logo as a link.
 Used in the header and footer.
 
-#### Implementation
-
-```scss
-width: 100px;
-  height: 40px;
-```
-
----
-
-### nhsuk-media-query
-
-- Type: mixin
-- Access: public
-- Group: tools
-- File: core/tools/_sass-mq.scss (L59-L63)
-
-Media query
-
-This is a currently a wrapper for sass-mq - abstracted so that we can
-replace it in the future if we so choose.
-
-Due to Sass deprecated 'misplaced-rest' named argument warnings, all
-arguments must be passed to maintain `nhsuk-media-query(950px)` support.
-
-#### Implementation
-
-```scss
-@include mq($from, $until, $and, $media-type, $silence-warning: true) {
-    @content;
-  }
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| from | String \| Boolean | No | false | One of $nhsuk-breakpoints |
-| until | String \| Boolean | No | false | One of $nhsuk-breakpoints |
-| and | String \| Boolean | No | false | Additional media query parameters |
-| media-type | String | No | all | Media type: screen, print… |
-
-#### Requires
-
-- mixin: mq
-
-#### Links
-
-- [Original code taken from GDS (Government Digital Service)](https://github.com/alphagov/govuk-frontend)
-
-#### Used By
-
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-grid-column
-- mixin: nhsuk-panel
-- mixin: nhsuk-heading-label
-- mixin: nhsuk-print-colour
-- mixin: nhsuk-print-hide
-- mixin: nhsuk-flex-item
-- mixin: nhsuk-remove-margin-mobile
-- mixin: govuk-media-query
-- mixin: nhsuk-responsive-spacing
-- mixin: nhsuk-text-colour
-- mixin: nhsuk-font-size
-- mixin: nhsuk-font-size
-
-#### Examples
-
-```scss
-.element {
-  @include nhsuk-media-query($from: mobile) {
-    color: red;
-  }
-  @include nhsuk-media-query($until: tablet) {
-    color: blue;
-  }
-  @include nhsuk-media-query(mobile, tablet) {
-    color: green;
-  }
-  @include nhsuk-media-query($from: tablet, $and: '(orientation: landscape)') {
-    color: teal;
-  }
-  @include nhsuk-media-query(950px) {
-    color: hotpink;
-  }
-  @include nhsuk-media-query(tablet, $media-type: screen) {
-    color: hotpink;
-  }
-}
-```
-
 ---
 
 ### nhsuk-panel
@@ -3392,25 +2046,6 @@ arguments must be passed to maintain `nhsuk-media-query(950px)` support.
 Panel mixin
 
 See components/_panel
-
-#### Implementation
-
-```scss
-box-sizing: border-box;
-  @if $panel-border-colour {
-    border: 1px solid $panel-border-colour;
-  }
-  color: $panel-text-colour;
-  background-color: $panel-background-colour;
-
-  @include nhsuk-top-and-bottom;
-  @include nhsuk-responsive-margin(7, "bottom");
-
-  @include nhsuk-media-query($media-type: print) {
-    border: 1px solid $nhsuk-print-text-colour;
-    page-break-inside: avoid;
-  }
-```
 
 #### Parameters
 
@@ -3450,17 +2085,6 @@ box-sizing: border-box;
 Panel with label mixin, inherits panel styling
 and removes padding top for the label positioning
 
-#### Implementation
-
-```scss
-padding-top: 0 !important;
-  border: 1px solid $panel-border-colour;
-
-  @include nhsuk-panel($panel-background-colour, $panel-text-colour, $panel-border-colour);
-  @include nhsuk-responsive-margin(7, "top");
-  @include nhsuk-responsive-padding(5);
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -3493,16 +2117,11 @@ padding-top: 0 !important;
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L443-L446)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-print-colour
+- Alias of: nhsuk-print-colour (prefer the original)
 
 Print colour mixin, sets the text print colour
 warning callout, do and don't lists and panels (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("color-to-colour", "nhsuk-print-color is deprecated. Use nhsuk-print-colour instead.");
-  @include nhsuk-print-colour($args...);
-```
 
 #### Requires
 
@@ -3520,15 +2139,6 @@ warning callout, do and don't lists and panels (deprecated)
 
 Print colour mixin, sets the text print colour
 warning callout, do and don't lists and panels
-
-#### Implementation
-
-```scss
-@include nhsuk-media-query($media-type: print) {
-    color: $print-colour;
-    @content;
-  }
-```
 
 #### Parameters
 
@@ -3563,18 +2173,6 @@ warning callout, do and don't lists and panels
 
 Print hide mixin, hides the element from print
 
-#### Implementation
-
-```scss
-@include nhsuk-media-query($media-type: print) {
-    @if $important == true {
-      display: none !important;
-    } @else {
-      display: none;
-    }
-  }
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -3607,12 +2205,6 @@ Print hide mixin, hides the element from print
 Reading width mixin, add a maximum width
 to large pieces of content
 
-#### Implementation
-
-```scss
-max-width: 44em;
-```
-
 #### Used By
 
 - mixin: reading-width
@@ -3635,15 +2227,6 @@ max-width: 44em;
 Remove margin mobile mixin
 
 Removes left and right margin at tablet breakpoint
-
-#### Implementation
-
-```scss
-@include nhsuk-media-query($until: tablet) {
-    margin-right: -$nhsuk-gutter-half;
-    margin-left: -$nhsuk-gutter-half;
-  }
-```
 
 #### Requires
 
@@ -3668,12 +2251,6 @@ Responsive margin
 Adds responsive margin by fetching a 'spacing map' from the responsive
 spacing scale, which defines different spacing values at different
 breakpoints. Wrapper for the `nhsuk-responsive-spacing` mixin.
-
-#### Implementation
-
-```scss
-@include nhsuk-responsive-spacing($responsive-spacing-point, "margin", $direction, $important, $adjustment);
-```
 
 #### Parameters
 
@@ -3721,12 +2298,6 @@ Responsive padding
 Adds responsive padding by fetching a 'spacing map' from the responsive
 spacing scale, which defines different spacing values at different
 breakpoints. Wrapper for the `nhsuk-responsive-spacing` mixin.
-
-#### Implementation
-
-```scss
-@include nhsuk-responsive-spacing($responsive-spacing-point, "padding", $direction, $important, $adjustment);
-```
 
 #### Parameters
 
@@ -3777,61 +2348,6 @@ different spacing values at different breakpoints.
 To generate responsive spacing, use 'nhsuk-responsive-margin' or
 'nhsuk-responsive-padding' mixins
 
-#### Implementation
-
-```scss
-$actual-input-type: meta.type-of($responsive-spacing-point);
-  @if $actual-input-type != "number" {
-    @error "Expected a number (integer), but got a " + "#{$actual-input-type}.";
-  }
-
-  @if not map.has-key($nhsuk-spacing-responsive-scale, $responsive-spacing-point) {
-    @error "Unknown spacing point `#{$responsive-spacing-point}`. Make sure you are using a point from the "
-      + "responsive spacing scale in `_settings/spacing.scss`.";
-  }
-
-  $scale-map: map.get($nhsuk-spacing-responsive-scale, $responsive-spacing-point); // [1]
-  $actual-map-type: meta.type-of($scale-map);
-  @if $actual-map-type != "map" {
-    @error "Expected a number (integer), but got a "
-      + "#{$actual-map-type}. Make sure you are using a map to set the responsive spacing in `_settings/spacing.scss`)";
-  }
-
-  // [2]
-  @each $breakpoint, $breakpoint-value in $scale-map {
-    @if $adjustment {
-      @if not math.compatible($breakpoint-value, $adjustment) {
-        $breakpoint-value: calc($breakpoint-value + $adjustment);
-      } @else {
-        $breakpoint-value: $breakpoint-value + $adjustment;
-      }
-    }
-
-    @if $important == true {
-      $breakpoint-value: $breakpoint-value !important;
-    }
-
-    & {
-      // [3]
-      @if not $breakpoint {
-        @if $direction == all {
-          #{$property}: $breakpoint-value;
-        } @else {
-          #{$property}-#{$direction}: $breakpoint-value;
-        }
-      } @else {
-        @include nhsuk-media-query($from: $breakpoint) {
-          @if $direction == all {
-            #{$property}: $breakpoint-value;
-          } @else {
-            #{$property}-#{$direction}: $breakpoint-value;
-          }
-        }
-      }
-    }
-  }
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -3862,7 +2378,6 @@ $actual-input-type: meta.type-of($responsive-spacing-point);
 
 - mixin: nhsuk-responsive-margin
 - mixin: nhsuk-responsive-padding
-- mixin: _nhsuk-generate-responsive-spacing-overrides
 - mixin: _nhsuk-generate-responsive-spacing-overrides
 
 #### Examples
@@ -3897,43 +2412,6 @@ providing a clip path (3). Without this the transparent borders are
 overridden to become visible which results in a square.
 
 We need both because older browsers do not support clip-path.
-
-#### Implementation
-
-```scss
-display: $display;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-color: transparent; // 1
-
-  $base: nhsuk-px-to-rem($base);
-  $perpendicular: math.div($base, 2);
-
-  @if not $height {
-    $height: _nhsuk-equilateral-height($base);
-  }
-
-  @if $direction == "up" {
-    clip-path: polygon(50% 0%, 0% 100%, 100% 100%); // 3
-    border-width: 0 $perpendicular $height;
-    border-bottom-color: inherit; // 2
-  } @else if $direction == "right" {
-    clip-path: polygon(0% 0%, 100% 50%, 0% 100%); // 3
-    border-width: $perpendicular 0 $perpendicular $height;
-    border-left-color: inherit; // 2
-  } @else if $direction == "down" {
-    clip-path: polygon(0% 0%, 50% 100%, 100% 0%); // 3
-    border-width: $height $perpendicular 0 $perpendicular;
-    border-top-color: inherit; // 2
-  } @else if $direction == "left" {
-    clip-path: polygon(0% 50%, 100% 100%, 100% 0%); // 3
-    border-width: $perpendicular $height $perpendicular 0;
-    border-right-color: inherit; // 2
-  } @else {
-    @error "Invalid arrow direction: expected `up`, `right`, `down` or `left`, got `#{$direction}`";
-  }
-```
 
 #### Parameters
 
@@ -3970,50 +2448,6 @@ Chevron mixin
 
 Generate chevron by using a box with borders on two sides, then rotating it.
 
-#### Implementation
-
-```scss
-$outline-width: nhsuk-em($nhsuk-chevron-border, $font-size);
-  $box-size: nhsuk-em(math.div($font-size, 2), $font-size);
-  $size: nhsuk-em(nhsuk-chevron-size($font-size));
-  display: $display;
-
-  width: $box-size;
-  height: $box-size;
-
-  clip-path: polygon(100% 100%, 100% 0, 0 0);
-
-  border-radius: $outline-width;
-
-  // Safari renders a hairline gap if we use borders, so use an inset outline
-  // instead. Because outlines are added to all sides of a box, we hide the
-  // outline on the two other two sides using clip-path.
-  outline: $outline-width solid currentcolor;
-  outline-offset: -$outline-width;
-
-  color: $colour;
-
-  @if $direction == "up" {
-    transform: translateY($outline-width) rotate(-45deg);
-  } @else if $direction == "right" {
-    transform: translateX(-$size + $outline-width) rotate(45deg);
-  } @else if $direction == "down" {
-    transform: translateY(-$size + $outline-width) rotate(135deg);
-  } @else if $direction == "left" {
-    transform: translateX($outline-width) rotate(225deg);
-  } @else {
-    @error "Invalid arrow direction: expected `up`, `right`, `down` or `left`, got `#{$direction}`";
-  }
-
-  @supports (outline-width: string.unquote("max(0px)")) {
-    // Ensure that the chevron outline never gets smaller than 2px
-    outline-width: string.unquote("max(#{$nhsuk-chevron-border}, #{$outline-width})");
-
-    // Ensure that the chevron never gets smaller than 16px
-    font-size: string.unquote("max(#{$font-size * 1px}, 1em)");
-  }
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -4039,33 +2473,12 @@ $outline-width: nhsuk-em($nhsuk-chevron-border, $font-size);
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L77-L94)
+- File: core/tools/_typography.scss (L132-L149)
 
 Word break helper
 
 Forcibly breaks long words that lack spaces, such as email addresses,
 across multiple lines when they wouldn't otherwise fit.
-
-#### Implementation
-
-```scss
-$properties: (
-    // IE 11 and Edge 16–17 only support the non-standard `word-wrap` property
-    "word-wrap": break-word,
-
-    // All other browsers support `overflow-wrap`
-    "overflow-wrap": break-word
-  );
-
-  // Workaround to avoid deprecated `if()` function
-  @each $property, $value in $properties {
-    @if $important == true {
-      #{$property}: $value !important;
-    } @else {
-      #{$property}: $value;
-    }
-  }
-```
 
 #### Parameters
 
@@ -4082,15 +2495,10 @@ $properties: (
 - Access: public
 - Group: tools
 - File: core/tools/_typography.scss (L38-L41)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-text-colour
+- Alias of: nhsuk-text-colour (prefer the original)
 
 Text colour (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("color-to-colour", "nhsuk-text-color is deprecated. Use nhsuk-text-colour instead.");
-  @include nhsuk-text-colour;
-```
 
 #### Requires
 
@@ -4109,16 +2517,6 @@ Text colour (deprecated)
 Text colour
 
 Sets the text colour, including a suitable override for print.
-
-#### Implementation
-
-```scss
-color: $nhsuk-text-colour;
-
-  @include nhsuk-media-query($media-type: print) {
-    color: $nhsuk-print-text-colour;
-  }
-```
 
 #### Requires
 
@@ -4146,18 +2544,6 @@ color: $nhsuk-text-colour;
 Top and bottom margin mixin, remove
 the top and bottom margin spacing
 
-#### Implementation
-
-```scss
-& > *:first-child {
-    margin-top: 0;
-  }
-
-  & > *:last-child {
-    margin-bottom: 0;
-  }
-```
-
 #### Used By
 
 - mixin: top-and-bottom
@@ -4176,19 +2562,11 @@ the top and bottom margin spacing
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L267-L273)
+- File: core/tools/_typography.scss (L322-L328)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-font-size
+- Alias of: nhsuk-font-size (prefer the original)
 
 Font size and line height helper (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning(
-    "nhsuk-typography-responsive",
-    "nhsuk-typography-responsive is deprecated. Use nhsuk-font-size instead."
-  );
-  @include nhsuk-font-size($size, $override-line-height, $important);
-```
 
 #### Parameters
 
@@ -4218,34 +2596,16 @@ Font size and line height helper (deprecated)
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L61-L67)
+- File: core/tools/_typography.scss (L87-L93)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-font-weight-bold
+- Alias of: nhsuk-font-weight-bold (prefer the original)
 
-Bold font weight
-
-#### Implementation
-
-```scss
-@if $important == true {
-    font-weight: $nhsuk-font-weight-bold !important;
-  } @else {
-    font-weight: $nhsuk-font-weight-bold;
-  }
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| important | Boolean | No | false | Whether to mark declarations as
-  \`!important\`. Generally Used to create override classes. |
+Bold typography weight (deprecated)
 
 #### Requires
 
-- variable: nhsuk-font-weight-bold
-
-#### Used By
-
-- mixin: nhsuk-font
+- mixin: nhsuk-warning
+- mixin: nhsuk-font-weight-bold
 
 ---
 
@@ -4254,34 +2614,16 @@ Bold font weight
 - Type: mixin
 - Access: public
 - Group: tools
-- File: core/tools/_typography.scss (L48-L54)
+- File: core/tools/_typography.scss (L61-L67)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-font-weight-normal
+- Alias of: nhsuk-font-weight-normal (prefer the original)
 
-Normal font weight
-
-#### Implementation
-
-```scss
-@if $important == true {
-    font-weight: $nhsuk-font-weight-normal !important;
-  } @else {
-    font-weight: $nhsuk-font-weight-normal;
-  }
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| important | Boolean | No | false | Whether to mark declarations as
-  \`!important\`. Generally Used to create override classes. |
+Normal typography weight (deprecated)
 
 #### Requires
 
-- variable: nhsuk-font-weight-normal
-
-#### Used By
-
-- mixin: nhsuk-font
+- mixin: nhsuk-warning
+- mixin: nhsuk-font-weight-normal
 
 ---
 
@@ -4293,24 +2635,6 @@ Normal font weight
 - File: core/tools/_mixins.scss (L122-L136)
 
 Hide an element visually, but have it available for screen readers
-
-#### Implementation
-
-```scss
-@include _nhsuk-visually-hide-content($important: $important);
-
-  // Absolute positioning has the unintended consequence of removing any
-  // whitespace surrounding visually hidden text from the accessibility tree.
-  // Insert a space character before and after visually hidden text to separate
-  // it from any visible text surrounding it.
-  &::before {
-    content: "\00a0";
-  }
-
-  &::after {
-    content: "\00a0";
-  }
-```
 
 #### Parameters
 
@@ -4344,18 +2668,6 @@ Hide an element visually, but have it available for screen readers
 Hide an element visually, but have it available for screen readers whilst
 allowing the element to be focused when navigated to via the keyboard (e.g.
 for the skip link)
-
-#### Implementation
-
-```scss
-// IE 11 doesn't support the combined `:not(:active, :focus)` syntax.
-  // Also allows for ':focus' companion classes from postcss-pseudo-classes
-  // which the plugin unfortunately doesn't handle automatically.
-  // stylelint-disable-next-line selector-class-pattern
-  &:not(:active):not(:focus):not(.\:focus) {
-    @include _nhsuk-visually-hide-content($important: $important);
-  }
-```
 
 #### Parameters
 
@@ -4397,18 +2709,6 @@ in which case we don't call `@warn` and printing the warning to the user
 `$nhsuk-suppressed-warnings` after `@warn` is called to ensure it only runs
 once per sass compilation
 
-#### Implementation
-
-```scss
-@if _should-warn($key) {
-    @warn _warning-text($key, $message);
-
-    @if $silence-further-warnings {
-      $nhsuk-suppressed-warnings: list.append($nhsuk-suppressed-warnings, $key) !global;
-    }
-  }
-```
-
 #### Parameters
 
 | Name | Type | Required | Default | Description |
@@ -4449,6 +2749,8 @@ warnings that use the same $key |
 - mixin: remove-margin-mobile
 - mixin: govuk-media-query
 - mixin: nhsuk-text-color
+- mixin: nhsuk-typography-weight-normal
+- mixin: nhsuk-typography-weight-bold
 - mixin: nhsuk-font-size
 - mixin: nhsuk-typography-responsive
 - mixin: mq
@@ -4465,59 +2767,6 @@ warnings that use the same $key |
 Width container mixin
 
 Used to create page width and custom width container classes.
-
-#### Implementation
-
-```scss
-// By default, limit the width of the container to the page width
-  max-width: $width;
-
-  // On mobile, add half width gutters
-  margin-right: $nhsuk-gutter-half;
-  margin-left: $nhsuk-gutter-half;
-
-  // Respect 'display cutout' safe area (avoids notches and rounded corners)
-  @supports (margin: string.unquote("max(calc(0px))")) {
-    $gutter-safe-area-right: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-right));
-    $gutter-safe-area-left: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-left));
-
-    // Use max() to pick largest margin, default or with safe area
-    // Escaped due to Sass max() vs. CSS native max()
-    margin-right: string.unquote("max(#{$nhsuk-gutter-half}, #{$gutter-safe-area-right})");
-    margin-left: string.unquote("max(#{$nhsuk-gutter-half}, #{$gutter-safe-area-left})");
-  }
-
-  // On desktop, add full width gutters
-  @include nhsuk-media-query($from: desktop) {
-    margin-right: $nhsuk-gutter;
-    margin-left: $nhsuk-gutter;
-
-    // Respect 'display cutout' safe area (avoids notches and rounded corners)
-    @supports (margin: string.unquote("max(calc(0px))")) {
-      $gutter-safe-area-right: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-right));
-      $gutter-safe-area-left: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-left));
-
-      // Use max() to pick largest margin, default or with safe area
-      // Escaped due to Sass max() vs. CSS native max()
-      margin-right: string.unquote("max(#{$nhsuk-gutter}, #{$gutter-safe-area-right})");
-      margin-left: string.unquote("max(#{$nhsuk-gutter}, #{$gutter-safe-area-left})");
-    }
-  }
-
-  // As soon as the viewport is greater than the width of the page plus the
-  // gutters, just centre the content instead of adding gutters.
-  @include nhsuk-media-query($and: "(min-width: #{($width + $nhsuk-gutter * 2)})") {
-    margin-right: auto;
-    margin-left: auto;
-
-    // Since a safe area may have previously been set above,
-    // we need to duplicate this margin that centers the page.
-    @supports (margin: string.unquote("max(calc(0px))")) {
-      margin-right: auto;
-      margin-left: auto;
-    }
-  }
-```
 
 #### Parameters
 
@@ -4553,15 +2802,10 @@ Creating a 1200px wide container class
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L291-L294)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-panel
+- Alias of: nhsuk-panel (prefer the original)
 
 Panel mixin (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("panel", "panel is deprecated. Use nhsuk-panel instead.");
-  @include nhsuk-panel($args...);
-```
 
 #### Requires
 
@@ -4576,16 +2820,11 @@ Panel mixin (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L322-L325)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-panel-with-label
+- Alias of: nhsuk-panel-with-label (prefer the original)
 
 Panel with label mixin, inherits panel styling
 and removes padding top for the label positioning (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("panel-with-label", "panel-with-label is deprecated. Use nhsuk-panel-with-label instead.");
-  @include nhsuk-panel-with-label($args...);
-```
 
 #### Requires
 
@@ -4600,16 +2839,11 @@ and removes padding top for the label positioning (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L454-L457)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-print-colour
+- Alias of: nhsuk-print-colour (prefer the original)
 
 Print colour mixin, sets the text print colour
 warning callout, do and don't lists and panels (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("print-color", "print-color is deprecated. Use nhsuk-print-colour instead.");
-  @include nhsuk-print-colour($args...);
-```
 
 #### Requires
 
@@ -4624,15 +2858,10 @@ warning callout, do and don't lists and panels (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L482-L485)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-print-hide
+- Alias of: nhsuk-print-hide (prefer the original)
 
 Print hide mixin, hides the element from print (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("print-hide", "print-hide is deprecated. Use nhsuk-print-hide instead.");
-  @include nhsuk-print-hide;
-```
 
 #### Requires
 
@@ -4647,16 +2876,11 @@ Print hide mixin, hides the element from print (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L56-L59)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-reading-width
+- Alias of: nhsuk-reading-width (prefer the original)
 
 Reading width mixin, add a maximum width
 to large pieces of content (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("reading-width", "reading-width is deprecated. Use nhsuk-reading-width instead.");
-  @include nhsuk-reading-width;
-```
 
 #### Requires
 
@@ -4671,92 +2895,17 @@ to large pieces of content (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L550-L557)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-remove-margin-mobile
+- Alias of: nhsuk-remove-margin-mobile (prefer the original)
 
 Remove margin mobile mixin (deprecated)
 
 Removes left and right margin at tablet breakpoint
 
-#### Implementation
-
-```scss
-@include nhsuk-warning(
-    "remove-margin-mobile",
-    "remove-margin-mobile is deprecated. Use nhsuk-remove-margin-mobile instead."
-  );
-
-  @include nhsuk-remove-margin-mobile;
-```
-
 #### Requires
 
 - mixin: nhsuk-warning
 - mixin: nhsuk-remove-margin-mobile
-
----
-
-### show-breakpoints
-
-- Type: mixin
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L290-L312)
-
-Show the active breakpoint in the top right corner of the viewport
-
-#### Implementation
-
-```scss
-body:before {
-    background-color: #fcf8e3;
-    border-bottom: 1px solid #fbeed5;
-    border-left: 1px solid #fbeed5;
-    color: #c09853;
-    font: small-caption;
-    padding: 3px 6px;
-    pointer-events: none;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: 100;
-
-    // Loop through the breakpoints that should be shown
-    @each $show-breakpoint in $show-breakpoints {
-      $width: get-breakpoint-width($show-breakpoint, $breakpoints);
-      @include mq($show-breakpoint, $breakpoints: $breakpoints, $silence-warning: true) {
-        content: "#{$show-breakpoint} ≥ #{$width} (#{px2em($width)})";
-      }
-    }
-  }
-```
-
-#### Parameters
-
-| Name | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| show-breakpoints | List | No | $mq-show-breakpoints | List of breakpoints to show in the top right corner |
-| breakpoints | Map | No | $mq-breakpoints | Breakpoint names and sizes |
-
-#### Requires
-
-- mixin: mq
-- function: get-breakpoint-width
-- function: px2em
-- variable: mq-breakpoints
-- variable: mq-show-breakpoints
-
-#### Links
-
-- [https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint](https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint)
-
-#### Examples
-
-```scss
-// Show breakpoints using global settings
-@include show-breakpoints;
-
-// Show breakpoints using custom settings
-@include show-breakpoints((L, XL), (S: 300px, L: 800px, XL: 1200px));
-```
 
 ---
 
@@ -4766,16 +2915,11 @@ body:before {
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L252-L255)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-top-and-bottom
+- Alias of: nhsuk-top-and-bottom (prefer the original)
 
 Top and bottom margin mixin, remove
 the top and bottom margin spacing (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning("top-and-bottom", "top-and-bottom is deprecated and will be removed in a future release.");
-  @include nhsuk-top-and-bottom;
-```
 
 #### Requires
 
@@ -4790,15 +2934,11 @@ the top and bottom margin spacing (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L144-L146)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-visually-hidden
+- Alias of: nhsuk-visually-hidden (prefer the original)
 
 Hide an element visually, but have it available for screen readers
 (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-visually-hidden;
-```
 
 #### Requires
 
@@ -4812,20 +2952,12 @@ Hide an element visually, but have it available for screen readers
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L173-L179)
+- **Deprecated:** To be removed in v11.0, replaced by nhsuk-visually-hidden-focusable
+- Alias of: nhsuk-visually-hidden-focusable (prefer the original)
 
 Hide an element visually, but have it available for screen readers whilst
 allowing the element to be focused when navigated to via the keyboard (e.g.
 for the skip link) (deprecated)
-
-#### Implementation
-
-```scss
-@include nhsuk-warning(
-    "visually-hidden-focusable",
-    "visually-hidden-focusable is deprecated. Use nhsuk-visually-hidden-focusable instead."
-  );
-  @include nhsuk-visually-hidden-focusable($args...);
-```
 
 #### Requires
 
@@ -4840,51 +2972,11 @@ for the skip link) (deprecated)
 - Access: public
 - Group: tools
 - File: core/tools/_mixins.scss (L190-L227)
+- **Deprecated:** To be removed in v11.0, use @media queries to apply \`visually-hidden\` instead
 
 Show an element visually that has previously been hidden by visually-hidden
 
 For differences between mobile and desktop views, use $display to set the CSS display property
-
-#### Implementation
-
-```scss
-@include nhsuk-warning(
-    "visually-shown",
-    "visually-shown is deprecated. Use @media queries to apply `visually-hidden` instead."
-  );
-
-  $properties: (
-    "position": static,
-
-    "width": auto,
-    "height": auto,
-    "margin": 0,
-    "padding": 0,
-
-    "overflow": visible,
-
-    "clip": auto,
-    "clip-path": none,
-
-    "border": none,
-
-    "white-space": normal,
-    "user-select": auto
-  );
-
-  // Workaround to avoid deprecated `if()` function
-  @each $property, $value in $properties {
-    @if $important == true {
-      #{$property}: $value !important;
-    } @else {
-      #{$property}: $value;
-    }
-  }
-
-  @if $display {
-    display: $display;
-  }
-```
 
 #### Parameters
 
@@ -4906,7 +2998,7 @@ For differences between mobile and desktop views, use $display to set the CSS di
 - Type: variable
 - Access: private
 - Group: styles
-- File: core/styles/_icons.scss (L30)
+- File: core/styles/_icons.scss (L37)
 
 Icon size adjustments
 
@@ -4962,110 +3054,6 @@ List of modules which have already been exported
 #### Used By
 
 - mixin: nhsuk-exports
-- mixin: nhsuk-exports
-- mixin: nhsuk-exports
-
----
-
-### mq-breakpoints
-
-- Type: variable
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L20-L25)
-
-Breakpoint list
-
-Name your breakpoints in a way that creates a ubiquitous language
-across team members. It will improve communication between
-stakeholders, designers, developers, and testers.
-
-#### Value
-
-```scss
-(
-  mobile: 320px,
-  tablet: 740px,
-  desktop: 980px,
-  wide: 1300px
-)
-```
-
-#### Links
-
-- [Full documentation and examples](https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint)
-
-#### Used By
-
-- function: get-breakpoint-width
-- mixin: mq
-- mixin: add-breakpoint
-- mixin: show-breakpoints
-
----
-
-### mq-media-type
-
-- Type: variable
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L49)
-
-Customize the media type (for example: `@media screen` or `@media print`)
-By default sass-mq uses an "all" media type (`@media all and …`)
-
-If you want to overried the media type, you can use this option.
-
-#### Value
-
-```scss
-all
-```
-
-#### Links
-
-- [Full documentation and example](https://github.com/sass-mq/sass-mq#changing-media-type)
-
-#### Used By
-
-- mixin: mq
-
-#### Examples
-
-```scss
-@use 'path/to/mq' with ($media-type: 'screen');
-```
-
----
-
-### mq-show-breakpoints
-
-- Type: variable
-- Access: public
-- Group: none
-- File: core/vendor/sass-mq.scss (L38)
-
-Show breakpoints in the top right corner
-
-If you want to display the currently active breakpoint in the top
-right corner of your site during development, add the breakpoints
-to this list, ordered by width. For example: (mobile, tablet, desktop).
-
-#### Value
-
-```scss
-()
-```
-
-#### Used By
-
-- mixin: show-breakpoints
-
-#### Examples
-
-```scss
-@use 'path/to/mq' with ($mq-show-breakpoints: ('mobile', 'tablet', 'desktop'));
-```
 
 ---
 
@@ -5128,6 +3116,7 @@ nhsuk-colour("grey-4")
 - Access: public
 - Group: settings/colours
 - File: core/settings/_colours-applied.scss (L115)
+- **Deprecated:** To be removed in v11.0
 
 Border hover colour
 
@@ -5174,7 +3163,6 @@ Form control border width
 #### Used By
 
 - mixin: nhsuk-button-style
-- mixin: nhsuk-focused-input
 - mixin: nhsuk-focused-input
 
 ---
@@ -5342,7 +3330,6 @@ Button shadow size
 #### Used By
 
 - mixin: nhsuk-button-style
-- mixin: nhsuk-button-style
 
 ---
 
@@ -5420,6 +3407,10 @@ default but we need to specify fallbacks for others:
 menlo, "Cascadia Mono", "Segoe UI Mono", consolas, "Liberation Mono", monospace
 ```
 
+#### Used By
+
+- mixin: nhsuk-font-monospace
+
 ---
 
 ### nhsuk-colours
@@ -5465,7 +3456,6 @@ NHS colour palette
 #### Used By
 
 - function: nhsuk-colour
-- function: nhsuk-colour
 
 ---
 
@@ -5488,9 +3478,6 @@ nhsuk-colour("red")
 
 #### Used By
 
-- mixin: nhsuk-link-style-error
-- mixin: nhsuk-link-style-error
-- mixin: nhsuk-link-style-error
 - mixin: nhsuk-link-style-error
 
 ---
@@ -5515,7 +3502,6 @@ nhsuk-colour("yellow")
 
 #### Used By
 
-- mixin: nhsuk-focused-text
 - mixin: nhsuk-focused-text
 - mixin: nhsuk-focused-input
 - mixin: nhsuk-focused-radio
@@ -5546,15 +3532,10 @@ nhsuk-colour("black")
 #### Used By
 
 - mixin: _header-link-style
-- mixin: _header-link-style
 - mixin: nhsuk-focused-text
-- mixin: nhsuk-focused-text
-- mixin: nhsuk-focused-input
 - mixin: nhsuk-focused-input
 - mixin: nhsuk-focused-radio
 - mixin: nhsuk-focused-checkbox
-- mixin: nhsuk-focused-button
-- mixin: nhsuk-focused-button
 - mixin: nhsuk-focused-button
 - mixin: nhsuk-focused-box
 
@@ -5579,15 +3560,9 @@ Border width of focus outline
 
 - mixin: _header-link-style
 - mixin: nhsuk-focused-text
-- mixin: nhsuk-focused-text
 - mixin: nhsuk-focused-input
 - mixin: nhsuk-focused-radio
-- mixin: nhsuk-focused-radio
 - mixin: nhsuk-focused-checkbox
-- mixin: nhsuk-focused-checkbox
-- mixin: nhsuk-focused-checkbox
-- mixin: nhsuk-focused-button
-- mixin: nhsuk-focused-button
 - mixin: nhsuk-focused-button
 - mixin: nhsuk-focused-box
 
@@ -5647,8 +3622,7 @@ $nhsuk-font-bold
 
 #### Used By
 
-- mixin: nhsuk-typography-weight-bold
-- mixin: nhsuk-typography-weight-bold
+- mixin: nhsuk-font-weight-bold
 
 ---
 
@@ -5669,8 +3643,7 @@ $nhsuk-font-normal
 
 #### Used By
 
-- mixin: nhsuk-typography-weight-normal
-- mixin: nhsuk-typography-weight-normal
+- mixin: nhsuk-font-weight-normal
 
 ---
 
@@ -5720,7 +3693,6 @@ Map of grid column widths
 #### Used By
 
 - function: nhsuk-grid-width
-- function: nhsuk-grid-width
 
 ---
 
@@ -5741,10 +3713,6 @@ Width of gutter between grid columns
 
 #### Used By
 
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
 - mixin: nhsuk-width-container
 
 ---
@@ -5767,15 +3735,7 @@ math.div($nhsuk-gutter, 2)
 #### Used By
 
 - mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
-- mixin: nhsuk-width-container
 - mixin: nhsuk-grid-column
-- mixin: nhsuk-remove-margin-mobile
 - mixin: nhsuk-remove-margin-mobile
 
 ---
@@ -5959,7 +3919,6 @@ nhsuk-colour("blue")
 
 #### Used By
 
-- mixin: nhsuk-link-style-no-visited-state
 - mixin: nhsuk-link-style-no-visited-state
 
 ---
@@ -6256,7 +4215,6 @@ nhsuk-colour("white")
 #### Used By
 
 - mixin: nhsuk-link-style-reverse
-- mixin: nhsuk-link-style-reverse
 
 ---
 
@@ -6288,7 +4246,6 @@ should be set to 16px.
 - function: nhsuk-em
 - function: nhsuk-px-to-rem
 - function: nhsuk-line-height
-- function: nhsuk-line-height
 
 ---
 
@@ -6298,6 +4255,7 @@ should be set to 16px.
 - Access: public
 - Group: settings/colours
 - File: core/settings/_colours-applied.scss (L122)
+- **Deprecated:** To be changed to "grey-3" in v11.0
 
 Secondary border colour
 
@@ -6499,7 +4457,6 @@ Single point spacing variables
 #### Used By
 
 - function: nhsuk-spacing
-- function: nhsuk-spacing
 - mixin: _nhsuk-generate-static-spacing-overrides
 
 ---
@@ -6577,7 +4534,6 @@ Access responsive spacing with `nhsuk-responsive-margin` or
 #### Used By
 
 - mixin: nhsuk-responsive-spacing
-- mixin: nhsuk-responsive-spacing
 - mixin: _nhsuk-generate-responsive-spacing-overrides
 
 ---
@@ -6601,9 +4557,6 @@ nhsuk-colour("green")
 
 #### Used By
 
-- mixin: nhsuk-link-style-success
-- mixin: nhsuk-link-style-success
-- mixin: nhsuk-link-style-success
 - mixin: nhsuk-link-style-success
 
 ---
@@ -6638,7 +4591,6 @@ it using the warning key, found in the warning message. For example:
 
 #### Used By
 
-- mixin: nhsuk-warning
 - mixin: nhsuk-warning
 - function: _should-warn
 - function: _warning-text
@@ -6844,8 +4796,6 @@ You can also specify a separate font size and line height for print media.
 
 #### Used By
 
-- mixin: nhsuk-font-size
-- mixin: nhsuk-font-size
 - mixin: nhsuk-font-size
 
 ---


### PR DESCRIPTION
## Description

Primarily updates the image reading opinion page to be more space compact.

<img width="1314" height="1155" alt="Screenshot 2026-07-09 at 16 47 31" src="https://github.com/user-attachments/assets/eb1dbf43-d29b-40e4-99bb-ea163c0ce745" />

Changes to opinion page:
* Move images to right column so number of images doesn't push other content down
* Change image info to summary list
* Combine prior mammograms, image info, medical info on one card
* Swap buttons to horizontal on tablet up

Other changes:
* Fix bug where breast features display wouldn't work in a modal
* Add new grey feature card
* Refactor mammogram display so we can do one per row in a summary list.
* Fix sass depreciations
* Helpers to keep buttons all the same height, things not get misaligned when 'normal, but add details' link is visible.
* Compact mode fixes, esp setting gutter size.
* New prior mammograms seed profile
* New summariser for prior mammograms
* Misc bugs fixed