### PR TITLE
Casework IA: nest episode pages under participants, add breadcrumbs and round navigation

### DIFF
--- a/app/lib/utils/episodes.js
+++ b/app/lib/utils/episodes.js
@@ -12,6 +12,7 @@ const { getAppointment } = require('./appointment-data.js')
 const { getReadingStatusForAppointments } = require('./reading.js')
 const { getClinic } = require('./clinics.js')
 const { formatMonthYear } = require('./dates.js')
+const { isActive } = require('./status.js')
 
 // An episode is open until it closes. While open, the stage says where in the
 // process it has got to; `closed` means it has an outcome and is done.
@@ -330,12 +331,19 @@ const getLastMammogram = (data, participantId) => {
  * @returns {object | null} The appointment, or null if nothing is booked
  */
 const getNextAppointment = (data, participantId) => {
-  const now = Date.now()
+  // From the start of today, not from this moment - an appointment earlier
+  // today that hasn't happened yet is still their next one. Only appointments
+  // still in play count; one that concluded this morning is not "next".
+  const startOfToday = new Date().setHours(0, 0, 0, 0)
 
   const upcoming = getEpisodesForParticipant(data, participantId)
     .filter(isEpisodeOpen)
     .flatMap((episode) => getEpisodeAppointments(data, episode))
-    .filter((appointment) => new Date(appointment.timing?.startTime) >= now)
+    .filter(
+      (appointment) =>
+        new Date(appointment.timing?.startTime) >= startOfToday &&
+        isActive(appointment.status)
+    )
     .sort((a, b) => new Date(a.timing.startTime) - new Date(b.timing.startTime))
 
   return upcoming[0] || null

--- a/app/lib/utils/episodes.js
+++ b/app/lib/utils/episodes.js
@@ -11,6 +11,7 @@ const dataStore = require('../data-store')
 const { getAppointment } = require('./appointment-data.js')
 const { getReadingStatusForAppointments } = require('./reading.js')
 const { getClinic } = require('./clinics.js')
+const { formatMonthYear } = require('./dates.js')
 
 // An episode is open until it closes. While open, the stage says where in the
 // process it has got to; `closed` means it has an outcome and is done.
@@ -341,6 +342,22 @@ const getNextAppointment = (data, participantId) => {
 }
 
 /**
+ * Human name for an episode. Episodes are named by date, not number -
+ * people say "the March 2026 episode" or "the current episode", they don't
+ * count rounds. Dated by when its mammograms were taken; a round with no
+ * images yet (or that never got them) dates by when it opened.
+ *
+ * @param {object} episode - Episode object
+ * @returns {string} Label like "March 2026 episode"
+ */
+const getEpisodeLabel = (episode) => {
+  const date = getEpisodeMammogramDate(episode) || episode?.openedDate
+  if (!date) return 'Episode'
+
+  return `${formatMonthYear(date)} episode`
+}
+
+/**
  * Display text for an episode's stage
  *
  * @param {string} stage - Episode stage
@@ -577,6 +594,7 @@ module.exports = {
   getEpisodeMammogramDate,
   getLastMammogram,
   getNextAppointment,
+  getEpisodeLabel,
   getEpisodeStageText,
   getEpisodeStageTagColour,
   getEpisodeOutcomeText,

--- a/app/routes/episodes.js
+++ b/app/routes/episodes.js
@@ -1,18 +1,11 @@
 // app/routes/episodes.js
 //
-// Minimal episode views. Deliberately not in the nav yet - the casework IA
-// work decides how episodes are navigated to. These exist so the episode
-// entity is reachable and provable in the real app, and so the participant
-// page has somewhere to link to.
+// The whole-service episode index - a finder for locating a specific
+// episode. The canonical episode page lives under the participant
+// (see routes/participants.js); the flat show URL here redirects to it.
 
-const {
-  EPISODE_STAGES,
-  getEpisode,
-  getEpisodeAppointments,
-  getEpisodeReadingStatus
-} = require('../lib/utils/episodes')
+const { EPISODE_STAGES, getEpisode } = require('../lib/utils/episodes')
 const { getParticipant } = require('../lib/utils/participants')
-const { getClinic } = require('../lib/utils/clinics')
 
 // Enough rows to browse without rendering thousands
 const INDEX_LIMIT = 100
@@ -57,23 +50,16 @@ module.exports = (router) => {
     })
   })
 
+  // An episode has no meaning without its participant, so the canonical URL
+  // is nested under them. This flat URL stays as a second door - queues and
+  // backlogs can link to an episode knowing only its id.
   router.get('/episodes/:episodeId', (req, res, next) => {
-    const data = req.session.data
-    const episode = getEpisode(data, req.params.episodeId)
+    const episode = getEpisode(req.session.data, req.params.episodeId)
 
     if (!episode) return next()
 
-    // Each appointment with the clinic it sat in, so the page can link back
-    const appointments = getEpisodeAppointments(data, episode).map((appointment) => ({
-      appointment,
-      clinic: getClinic(data, appointment.clinicId)
-    }))
-
-    res.render('episodes/show', {
-      episode,
-      participant: getParticipant(data, episode.participantId),
-      appointments,
-      readingStatus: getEpisodeReadingStatus(data, episode)
-    })
+    res.redirect(
+      `/participants/${episode.participantId}/episodes/${episode.id}`
+    )
   })
 }

--- a/app/routes/participants.js
+++ b/app/routes/participants.js
@@ -6,10 +6,14 @@ const {
   saveTempParticipantToParticipant
 } = require('../lib/utils/participants')
 const {
+  getEpisode,
   getEpisodesForParticipant,
+  getCurrentEpisode,
   getEpisodeAppointments,
-  getEpisodeMammogramDate
+  getEpisodeMammogramDate,
+  getEpisodeReadingStatus
 } = require('../lib/utils/episodes')
+const { getClinic } = require('../lib/utils/clinics')
 const { findById } = require('../lib/utils/arrays')
 const { createDynamicTemplateRoute } = require('../lib/utils/dynamic-routing')
 const {
@@ -120,13 +124,20 @@ module.exports = (router) => {
     // Store original participant data for reference if needed
     res.locals.originalParticipant = originalParticipant
 
+    // Their open episode, if they have one - the participant page promotes
+    // it above the history rather than listing it as history
+    const currentEpisode = getCurrentEpisode(data, participantId)
+    res.locals.currentEpisode = currentEpisode
+
     // A participant's screening history is their episodes, newest first. Past
     // rounds are summary-only episodes, so this covers their whole history
-    // without needing old appointments to exist.
+    // without needing old appointments to exist. The open episode is not
+    // history, so it is left out.
     res.locals.episodeHistory = getEpisodesForParticipant(
       data,
       originalParticipant.id
     )
+      .filter((episode) => episode.id !== currentEpisode?.id)
       .map((episode) => {
         // Screened rounds date by when their images were taken. A round with
         // no images (not yet screened, missed, cancelled) dates by its
@@ -153,6 +164,48 @@ module.exports = (router) => {
   router.get('/participants/:participantId', (req, res) => {
     res.render('participants/show')
   })
+
+  // Episode pages are casework pages, so they live under the participant -
+  // an episode has no meaning without one. Registered here rather than in
+  // routes/episodes.js so they land before the dynamic template catch-all
+  // below, which would otherwise swallow them.
+  router.use(
+    '/participants/:participantId/episodes/:episodeId',
+    (req, res, next) => {
+      const data = req.session.data
+      const episode = getEpisode(data, req.params.episodeId)
+
+      // 404 unless the episode exists and belongs to this participant
+      if (!episode || episode.participantId !== req.params.participantId) {
+        return next()
+      }
+
+      res.locals.episode = episode
+
+      // Each appointment with the clinic it sat in, so pages can link back
+      res.locals.episodeAppointments = getEpisodeAppointments(
+        data,
+        episode
+      ).map((appointment) => ({
+        appointment,
+        clinic: getClinic(data, appointment.clinicId)
+      }))
+
+      res.locals.readingStatus = getEpisodeReadingStatus(data, episode)
+
+      next()
+    }
+  )
+
+  router.get(
+    '/participants/:participantId/episodes/:episodeId',
+    (req, res, next) => {
+      // No episode loaded means the middleware above declined it
+      if (!res.locals.episode) return next()
+
+      res.render('episodes/show')
+    }
+  )
 
   router.get(
     '/participants/:participantId/*subPaths',

--- a/app/routes/participants.js
+++ b/app/routes/participants.js
@@ -182,6 +182,18 @@ module.exports = (router) => {
 
       res.locals.episode = episode
 
+      // Where this episode sits in the participant's sequence, so the page
+      // can link between their rounds
+      const participantEpisodes = getEpisodesForParticipant(
+        data,
+        req.params.participantId
+      )
+      const episodeIndex = participantEpisodes.findIndex(
+        (each) => each.id === episode.id
+      )
+      res.locals.previousEpisode = participantEpisodes[episodeIndex - 1] || null
+      res.locals.nextEpisode = participantEpisodes[episodeIndex + 1] || null
+
       // Each appointment with the clinic it sat in, so pages can link back
       res.locals.episodeAppointments = getEpisodeAppointments(
         data,

--- a/app/views/_includes/summary-lists/screening-episode-history.njk
+++ b/app/views/_includes/summary-lists/screening-episode-history.njk
@@ -2,7 +2,8 @@
 
 {# A participant's screening rounds, newest first. Past rounds are held as
    summary-only episodes, so this covers their whole history without needing
-   the old appointments to exist. #}
+   the old appointments to exist. An open episode is not history - the
+   participant page promotes it separately, so it is excluded here. #}
 
 {% if episodeHistory.length %}
 
@@ -50,7 +51,7 @@
             {% endif %}
           </td>
           <td class="nhsuk-table__cell">
-            <a href="{{ ('/episodes/' + episode.id) | urlWithReferrer(currentUrl) }}">
+            <a href="/participants/{{ episode.participantId }}/episodes/{{ episode.id }}">
               View episode
             </a>
           </td>
@@ -60,5 +61,5 @@
   </table>
 
 {% else %}
-  <p>No screening history found</p>
+  <p>No previous screening episodes</p>
 {% endif %}

--- a/app/views/episodes/index.html
+++ b/app/views/episodes/index.html
@@ -83,7 +83,7 @@
               {% endif %}
             </td>
             <td class="nhsuk-table__cell">
-              <a href="{{ ('/episodes/' + row.episode.id) | urlWithReferrer(currentUrl) }}">
+              <a href="/participants/{{ row.episode.participantId }}/episodes/{{ row.episode.id }}">
                 View episode
               </a>
             </td>

--- a/app/views/episodes/show.html
+++ b/app/views/episodes/show.html
@@ -1,137 +1,163 @@
 {% extends 'layout-app.html' %}
 
-{% set pageHeading = "Screening episode" %}
+{% set pageHeading = episode | getEpisodeLabel %}
 {% set gridColumn = "nhsuk-grid-column-full" %}
+{% set hideBackLink = true %}
 
-{# You can reach an episode from the participant record or from the episode
-   list, so send people back where they came from rather than always to the
-   participant. #}
-{% set backText %}
-  {% if referrerChain | stringIncludes("/episodes") %}
-    Back to episodes
-  {% else %}
-    Back to participant
-  {% endif %}
-{% endset %}
-
-{% set back = {
-  href: ("/participants/" + episode.participantId) | getReturnUrl(referrerChain),
-  text: backText
-} %}
-
-{% block pageContent %}
-
-  <span class="nhsuk-caption-l">{{ participant | getFullName }}</span>
-  <h1>{{ pageHeading }}</h1>
-
-  <p>
-    <a href="/participants/{{ episode.participantId }}">
-      View participant record
-    </a>
-    &nbsp;·&nbsp;
-    <a href="/episodes">All episodes</a>
-  </p>
-
-  {{ summaryList({
-    rows: [
+{% block beforeContent %}
+  {{ breadcrumb({
+    items: [
       {
-        key: { text: "Stage" },
-        value: { html: tag({
-          text: episode.stage | getEpisodeStageText,
-          colour: episode.stage | getEpisodeStageTagColour
-        }) }
+        href: "/participants",
+        text: "Participants"
       },
       {
-        key: { text: "Outcome" },
-        value: { html: tag({
-          text: episode.outcome | getEpisodeOutcomeText,
-          colour: episode.outcome | getEpisodeOutcomeTagColour
-        }) if episode.outcome else "Not yet - the episode is still open" }
-      },
-      {
-        key: { text: "Type" },
-        value: { text: episode.type | sentenceCase }
-      },
-      {
-        key: { text: "Opened" },
-        value: { text: episode.openedDate | formatDate }
-      },
-      {
-        key: { text: "Closed" },
-        value: { text: episode.closedDate | formatDate if episode.closedDate else "Not closed" }
+        href: participantUrl,
+        text: participant | getFullName
       }
     ]
   }) }}
+{% endblock %}
+
+{% block pageContent %}
+
+  <h1 class="nhsuk-heading-l">
+    <span class="nhsuk-caption-l">{{ participant | getFullName }}</span>
+    {{ pageHeading }}
+  </h1>
 
   {% if episode.isHistoric %}
+
+    {# Past rounds are held as summaries - what the round concluded, not how
+       it got there. There are no appointment or reading records to show. #}
+
     <div class="nhsuk-inset-text">
       <span class="nhsuk-u-visually-hidden">Information: </span>
       <p>
-        This is a past round, held as a summary only - it has no appointment
-        or reading detail.
+        This is a past screening episode, held as a summary only.
       </p>
     </div>
-  {% endif %}
 
-  <h2>Appointments</h2>
+    {% set mammogramDate = episode | getEpisodeMammogramDate %}
 
-  {% if appointments.length %}
-    <table class="nhsuk-table">
-      <thead class="nhsuk-table__head">
-        <tr>
-          <th scope="col">Date</th>
-          <th scope="col">Type</th>
-          <th scope="col">Status</th>
-          <th scope="col"><span class="nhsuk-u-visually-hidden">Actions</span></th>
-        </tr>
-      </thead>
-      <tbody class="nhsuk-table__body">
-        {% for row in appointments %}
-          <tr class="nhsuk-table__row">
-            <td class="nhsuk-table__cell">
-              {{ row.appointment.timing.startTime | formatDate }}
-            </td>
-            <td class="nhsuk-table__cell">
-              {{ row.clinic.clinicType | formatWords | sentenceCase }}
-            </td>
-            <td class="nhsuk-table__cell">
-              {{ tag({
-                text: row.appointment.status | getStatusText('appointment'),
-                colour: row.appointment.status | getStatusTagColour('appointment')
-              }) }}
-            </td>
-            <td class="nhsuk-table__cell">
-              <a href="/clinics/{{ row.clinic.id }}/appointments/{{ row.appointment.id }}">
-                View appointment
-              </a>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-
-    <h2>Image reading</h2>
-    <p>
-      Reading state across this episode’s appointments:
-      {{ tag({
-        text: readingStatus.status | formatWords | sentenceCase,
-        colour: readingStatus.statusColor
-      }) }}
-    </p>
+    {{ summaryList({
+      rows: [
+        {
+          key: { text: "Outcome" },
+          value: { html: tag({
+            text: episode.outcome | getEpisodeOutcomeText,
+            colour: episode.outcome | getEpisodeOutcomeTagColour
+          }) }
+        },
+        {
+          key: { text: "Type" },
+          value: { text: episode.type | sentenceCase }
+        },
+        {
+          key: { text: "Mammograms taken" },
+          value: { text: mammogramDate | formatDate if mammogramDate else "Not screened" }
+        },
+        {
+          key: { text: "Closed" },
+          value: { text: episode.closedDate | formatDate }
+        }
+      ]
+    }) }}
 
   {% else %}
-    <p>This episode has no appointments.</p>
+
+    {{ summaryList({
+      rows: [
+        {
+          key: { text: "Stage" },
+          value: { html: tag({
+            text: episode.stage | getEpisodeStageText,
+            colour: episode.stage | getEpisodeStageTagColour
+          }) }
+        },
+        {
+          key: { text: "Outcome" },
+          value: { html: tag({
+            text: episode.outcome | getEpisodeOutcomeText,
+            colour: episode.outcome | getEpisodeOutcomeTagColour
+          }) if episode.outcome else "Not yet - the episode is still open" }
+        },
+        {
+          key: { text: "Type" },
+          value: { text: episode.type | sentenceCase }
+        },
+        {
+          key: { text: "Opened" },
+          value: { text: episode.openedDate | formatDate }
+        },
+        {
+          key: { text: "Closed" },
+          value: { text: episode.closedDate | formatDate if episode.closedDate else "Not closed" }
+        }
+      ]
+    }) }}
+
+    <h2>Appointments</h2>
+
+    {% if episodeAppointments.length %}
+      <table class="nhsuk-table">
+        <thead class="nhsuk-table__head">
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Type</th>
+            <th scope="col">Status</th>
+            <th scope="col"><span class="nhsuk-u-visually-hidden">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+          {% for row in episodeAppointments %}
+            <tr class="nhsuk-table__row">
+              <td class="nhsuk-table__cell">
+                {{ row.appointment.timing.startTime | formatDate }}
+              </td>
+              <td class="nhsuk-table__cell">
+                {{ row.clinic.clinicType | formatWords | sentenceCase }}
+              </td>
+              <td class="nhsuk-table__cell">
+                {{ tag({
+                  text: row.appointment.status | getStatusText('appointment'),
+                  colour: row.appointment.status | getStatusTagColour('appointment')
+                }) }}
+              </td>
+              <td class="nhsuk-table__cell">
+                <a href="/clinics/{{ row.clinic.id }}/appointments/{{ row.appointment.id }}">
+                  View appointment
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <h2>Image reading</h2>
+      <p>
+        Reading state across this episode’s appointments:
+        {{ tag({
+          text: readingStatus.status | formatWords | sentenceCase,
+          colour: readingStatus.statusColor
+        }) }}
+      </p>
+
+    {% else %}
+      <p>This episode has no appointments.</p>
+    {% endif %}
+
+    <h2>History</h2>
+
+    <ol class="nhsuk-list nhsuk-list--number">
+      {% for entry in episode.stageHistory %}
+        <li>
+          {{ entry.stage | getEpisodeStageText }} -
+          {{ entry.timestamp | formatDate }}
+        </li>
+      {% endfor %}
+    </ol>
+
   {% endif %}
-
-  <h2>History</h2>
-
-  <ol class="nhsuk-list nhsuk-list--number">
-    {% for entry in episode.stageHistory %}
-      <li>
-        {{ entry.stage | getEpisodeStageText }} -
-        {{ entry.timestamp | formatDate }}
-      </li>
-    {% endfor %}
-  </ol>
 
 {% endblock %}

--- a/app/views/episodes/show.html
+++ b/app/views/episodes/show.html
@@ -26,6 +26,18 @@
     {{ pageHeading }}
   </h1>
 
+  {# Looking at a past round while another is in progress - flag the live one #}
+  {% if currentEpisode and currentEpisode.id !== episode.id %}
+    <div class="nhsuk-inset-text">
+      <span class="nhsuk-u-visually-hidden">Information: </span>
+      <p>
+        This participant has an episode in progress -
+        <a href="{{ participantUrl }}/episodes/{{ currentEpisode.id }}">
+          {{ currentEpisode | getEpisodeLabel }}</a>.
+      </p>
+    </div>
+  {% endif %}
+
   {% if episode.isHistoric %}
 
     {# Past rounds are held as summaries - what the round concluded, not how
@@ -38,31 +50,54 @@
       </p>
     </div>
 
-    {% set mammogramDate = episode | getEpisodeMammogramDate %}
+    {% set mammogram = episode.mammograms | last %}
+    {% set screeningUnit = data.breastScreeningUnits | findById(mammogram.breastScreeningUnitId) if mammogram else null %}
 
-    {{ summaryList({
-      rows: [
+    {% set rows = [
+      {
+        key: { text: "Outcome" },
+        value: { html: tag({
+          text: episode.outcome | getEpisodeOutcomeText,
+          colour: episode.outcome | getEpisodeOutcomeTagColour
+        }) }
+      },
+      {
+        key: { text: "Type" },
+        value: { text: episode.type | sentenceCase }
+      },
+      {
+        key: { text: "Opened" },
+        value: { text: episode.openedDate | formatDate }
+      },
+      {
+        key: { text: "Mammograms taken" },
+        value: { text: mammogram.takenDate | formatDate if mammogram else "Not screened" }
+      }
+    ] %}
+
+    {# A summary round holds where it was screened and an image count, but
+       no appointment or reading records beneath them #}
+    {% if mammogram %}
+      {% set rows = rows.concat([
         {
-          key: { text: "Outcome" },
-          value: { html: tag({
-            text: episode.outcome | getEpisodeOutcomeText,
-            colour: episode.outcome | getEpisodeOutcomeTagColour
-          }) }
+          key: { text: "Screened at" },
+          value: { text: screeningUnit.name if screeningUnit else "Not known" }
         },
         {
-          key: { text: "Type" },
-          value: { text: episode.type | sentenceCase }
-        },
-        {
-          key: { text: "Mammograms taken" },
-          value: { text: mammogramDate | formatDate if mammogramDate else "Not screened" }
-        },
-        {
-          key: { text: "Closed" },
-          value: { text: episode.closedDate | formatDate }
+          key: { text: "Images" },
+          value: { text: mammogram.viewCount + " views" }
         }
-      ]
-    }) }}
+      ]) %}
+    {% endif %}
+
+    {% set rows = rows.concat([
+      {
+        key: { text: "Closed" },
+        value: { text: episode.closedDate | formatDate }
+      }
+    ]) %}
+
+    {{ summaryList({ rows: rows }) }}
 
   {% else %}
 
@@ -158,6 +193,22 @@
       {% endfor %}
     </ol>
 
+  {% endif %}
+
+  {# Step between this participant's rounds without going back to their record #}
+  {% if previousEpisode or nextEpisode %}
+    {{ pagination({
+      previous: {
+        text: "Previous episode",
+        labelText: previousEpisode | getEpisodeLabel,
+        href: participantUrl + "/episodes/" + previousEpisode.id
+      } if previousEpisode,
+      next: {
+        text: "Next episode",
+        labelText: nextEpisode | getEpisodeLabel,
+        href: participantUrl + "/episodes/" + nextEpisode.id
+      } if nextEpisode
+    }) }}
   {% endif %}
 
 {% endblock %}

--- a/app/views/participants/show.html
+++ b/app/views/participants/show.html
@@ -8,23 +8,18 @@
 
 {% set allowEdits = allowEdits | default(true) %}
 
-{% set backText %}
-  {% if referrerChain %}
-    {% if referrerChain | stringIncludes("/appointments/") %}
-      Back to appointment
-    {% else %}
-      Back to clinic
-    {% endif %}
-  {% else %}
-    Back to participants
-  {% endif %}
+{% set hideBackLink = true %}
 
-{% endset %}
-
-{% set back = {
-  href: "/participants" | getReturnUrl(referrerChain),
-  text: backText
-} %}
+{% block beforeContent %}
+  {{ breadcrumb({
+    items: [
+      {
+        href: "/participants",
+        text: "Participants"
+      }
+    ]
+  }) }}
+{% endblock %}
 
 {% block pageContent %}
 
@@ -57,6 +52,47 @@
    #}
 
   {% include "_includes/tabs/participant-details.njk" %}
+
+  {# An open episode is live casework, so it gets its own card above the
+     history rather than a row in it #}
+  {% if currentEpisode %}
+    {% set nextAppointment = data | getNextAppointment(participant.id) %}
+
+    {% set episodeLinkHtml %}
+      <a href="{{ participantUrl }}/episodes/{{ currentEpisode.id }}">
+        {{ currentEpisode | getEpisodeLabel }}
+      </a>
+    {% endset %}
+
+    {% call card({
+      heading: "Current episode",
+      headingLevel: "2"
+    }) %}
+      {{ summaryList({
+        rows: [
+          {
+            key: { text: "Episode" },
+            value: { html: episodeLinkHtml }
+          },
+          {
+            key: { text: "Stage" },
+            value: { html: tag({
+              text: currentEpisode.stage | getEpisodeStageText,
+              colour: currentEpisode.stage | getEpisodeStageTagColour
+            }) }
+          },
+          {
+            key: { text: "Opened" },
+            value: { text: currentEpisode.openedDate | formatDate }
+          },
+          {
+            key: { text: "Next appointment" },
+            value: { text: nextAppointment.timing.startTime | formatDate if nextAppointment else "None booked" }
+          }
+        ]
+      }) }}
+    {% endcall %}
+  {% endif %}
 
   {% call card({
     heading: "Screening details"

--- a/app/views/participants/show.html
+++ b/app/views/participants/show.html
@@ -53,21 +53,23 @@
 
   {% include "_includes/tabs/participant-details.njk" %}
 
-  {# An open episode is live casework, so it gets its own card above the
-     history rather than a row in it #}
-  {% if currentEpisode %}
-    {% set nextAppointment = data | getNextAppointment(participant.id) %}
+  {# One card for their episodes: the open one picked out as live casework,
+     past rounds as history beneath #}
+  {% call card({
+    heading: "Screening episodes",
+    headingLevel: "2"
+  }) %}
+    {% if currentEpisode %}
+      {% set nextAppointment = data | getNextAppointment(participant.id) %}
 
-    {% set episodeLinkHtml %}
-      <a href="{{ participantUrl }}/episodes/{{ currentEpisode.id }}">
-        {{ currentEpisode | getEpisodeLabel }}
-      </a>
-    {% endset %}
+      {% set episodeLinkHtml %}
+        <a href="{{ participantUrl }}/episodes/{{ currentEpisode.id }}">
+          {{ currentEpisode | getEpisodeLabel }}
+        </a>
+      {% endset %}
 
-    {% call card({
-      heading: "Current episode",
-      headingLevel: "2"
-    }) %}
+      <h3 class="nhsuk-heading-s">Current episode</h3>
+
       {{ summaryList({
         rows: [
           {
@@ -91,20 +93,17 @@
           }
         ]
       }) }}
-    {% endcall %}
-  {% endif %}
+
+      <h3 class="nhsuk-heading-s">Previous episodes</h3>
+    {% endif %}
+
+    {% include "summary-lists/screening-episode-history.njk" %}
+  {% endcall %}
 
   {% call card({
     heading: "Screening details"
   }) %}
     {% include "summary-lists/screening-details.njk" %}
-  {% endcall %}
-
-  {% call card({
-    heading: "Screening history",
-    headingLevel: "2"
-  }) %}
-    {% include "summary-lists/screening-episode-history.njk" %}
   {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
- Canonical episode URL is now `/participants/:id/episodes/:id`; the flat `/episodes/:id` redirects to it
- Breadcrumbs replace back links on episode and participant pages
- Episodes are named by date ("June 2026 episode") rather than numbered
- Participant page gets a combined "Screening episodes" card, with the current episode picked out from history
- Historic summary episodes render a fuller compact summary (opened date, screening unit, image count)
- Previous/next links page between a participant's episodes
- Viewing a past round shows an inset flagging the in-progress episode
- `getNextAppointment` now counts still-active appointments from the start of today, fixing "Next screening: Not known" for appointments earlier today
