### PR TITLE
Add support for mammographer noted signs

### DIFF
--- a/app/filters/nunjucks.js
+++ b/app/filters/nunjucks.js
@@ -97,6 +97,7 @@ const join = (input, delimiter = '', attribute = null, options = {}) => {
  * @param {string} userId - ID of the user
  * @param {object} [options] - Display options
  * @param {boolean} [options.identifyCurrentUser] - Whether to add "(you)" for current user
+ * @param {boolean} [options.useYou] - Return just "you" for the current user
  * @param {string} [options.format] - Name format: 'full', 'short', or 'initial'
  * @returns {string} User's name in requested format
  */
@@ -126,8 +127,13 @@ const getUsername = function (userId, options = {}) {
   }
 
   const currentUser = this.ctx.data.currentUser
-  if (options.identifyCurrentUser && user.id === currentUser.id) {
-    return `${formattedName} (you)`
+  if (currentUser && user.id === currentUser.id) {
+    if (options.useYou) {
+      return 'you'
+    }
+    if (options.identifyCurrentUser) {
+      return `${formattedName} (you)`
+    }
   }
 
   return formattedName

--- a/app/lib/generators/medical-information/symptoms-generator.js
+++ b/app/lib/generators/medical-information/symptoms-generator.js
@@ -220,6 +220,12 @@ const generateSymptom = (options = {}) => {
     symptom.isSignificant = Math.random() < 0.1
   }
 
+  // Some symptoms are signs noted by the mammographer rather than reported
+  // by the participant. Breast pain is excluded as it cannot be observed.
+  if (type !== 'Breast pain' && Math.random() < 0.2) {
+    symptom.isMammographerObserved = true
+  }
+
   // Add user who added the symptom
   if (options.addedByUserId) {
     symptom.addedByUserId = options.addedByUserId
@@ -335,8 +341,9 @@ const generateSymptom = (options = {}) => {
     }
   }
 
-  // 20% chance of symptom notes
-  if (Math.random() < 0.2) {
+  // 20% chance of symptom notes - skipped for mammographer-noted signs as
+  // the note options are all participant-reported
+  if (!symptom.isMammographerObserved && Math.random() < 0.2) {
     const symptomNotesOptions = [
       'Noticed during self-examination',
       'Partner noticed the change',

--- a/app/lib/utils/medical-information.js
+++ b/app/lib/utils/medical-information.js
@@ -312,7 +312,7 @@ const summariseSymptom = (symptom) => {
       symptom.skinChangeType === 'other' && symptom.skinChangeDescription
         ? symptom.skinChangeDescription
         : symptom.skinChangeType
-    summary += `: ${changeType}`
+    summary += `, ${changeType}`
   } else if (symptom.type === 'Other' && symptom.otherDescription) {
     summary = startLowerCase(symptom.otherDescription)
   }

--- a/app/lib/utils/medical-information.js
+++ b/app/lib/utils/medical-information.js
@@ -306,7 +306,7 @@ const summariseSymptom = (symptom) => {
       symptom.nippleChangeType === 'other' && symptom.nippleChangeDescription
         ? symptom.nippleChangeDescription
         : symptom.nippleChangeType
-    summary += `: ${changeType}`
+    summary += `, ${changeType}`
   } else if (symptom.type === 'Skin change' && symptom.skinChangeType) {
     const changeType =
       symptom.skinChangeType === 'other' && symptom.skinChangeDescription

--- a/app/lib/utils/medical-information.js
+++ b/app/lib/utils/medical-information.js
@@ -1,6 +1,7 @@
 // app/lib/utils/medical-information.js
 
 const medicalHistoryTypes = require('../../data/medical-history-types')
+const { startLowerCase } = require('./strings')
 
 /**
  * Check whether a string names a medical history type, by type or slug
@@ -287,15 +288,17 @@ const countMedicalHistoryItems = (medicalHistory) => {
 /**
  * Summarise a single symptom into a concise string
  *
+ * Output is lowercase - run through the sentenceCase filter when displaying
+ *
  * @param {Object} symptom - The symptom object
- * @returns {string} A summary string like "Lump (right breast)" or "Nipple change: bloody discharge (both nipples)"
+ * @returns {string} A summary string like "lump (right breast)" or "nipple change: bloody discharge (both nipples)"
  */
 const summariseSymptom = (symptom) => {
   if (!symptom || !symptom.type) {
     return ''
   }
 
-  let summary = symptom.type
+  let summary = startLowerCase(symptom.type)
 
   // Add sub-type details for specific symptom types
   if (symptom.type === 'Nipple change' && symptom.nippleChangeType) {
@@ -311,7 +314,7 @@ const summariseSymptom = (symptom) => {
         : symptom.skinChangeType
     summary += `: ${changeType}`
   } else if (symptom.type === 'Other' && symptom.otherDescription) {
-    summary = symptom.otherDescription
+    summary = startLowerCase(symptom.otherDescription)
   }
 
   // Add location
@@ -355,7 +358,7 @@ const summariseSymptom = (symptom) => {
 
   // Flag signs noted by the mammographer rather than reported by the participant
   if (symptom.isMammographerObserved) {
-    summary = `Sign: ${summary}`
+    summary = `sign: ${summary}`
   }
 
   return summary

--- a/app/lib/utils/medical-information.js
+++ b/app/lib/utils/medical-information.js
@@ -353,6 +353,11 @@ const summariseSymptom = (symptom) => {
     summary += ` (${location})`
   }
 
+  // Flag signs noted by the mammographer rather than reported by the participant
+  if (symptom.isMammographerObserved) {
+    summary = `Sign: ${summary}`
+  }
+
   return summary
 }
 

--- a/app/routes/appointments/symptoms.js
+++ b/app/routes/appointments/symptoms.js
@@ -266,6 +266,12 @@ module.exports = (router) => {
           symptom.isIntermittent = true
         }
 
+        // Sign noted by the mammographer rather than reported by the participant
+        const observedValue = symptomTemp.isMammographerObserved
+        symptom.isMammographerObserved = Array.isArray(observedValue)
+          ? observedValue.includes('yes')
+          : observedValue === 'yes' || observedValue === true
+
         symptom.hasStopped =
           Array.isArray(symptomTemp.hasStopped) &&
           symptomTemp.hasStopped.includes('yes')

--- a/app/routes/appointments/symptoms.js
+++ b/app/routes/appointments/symptoms.js
@@ -220,9 +220,12 @@ module.exports = (router) => {
           symptomNotes: symptomTemp.symptomNotes
         }
 
-        // For new symptoms, add the creation timestamp
+        // For new symptoms, record when and who added them
         if (isNewSymptom) {
           symptom.dateAdded = new Date().toISOString()
+          symptom.addedByUserId = data.currentUser?.id
+        } else {
+          symptom.addedByUserId = symptomTemp.addedByUserId
         }
 
         if (symptomTypeConfig) {

--- a/app/views/_includes/medical-information/index.njk
+++ b/app/views/_includes/medical-information/index.njk
@@ -131,7 +131,7 @@
 {# -------------------------------------------------------------- #}
 {# Symptoms #}
 {% set sectionHeading = "Symptoms" %}
-{% set subHeading = "Any problems or symptoms, including lumps, swelling, rashes or nipple changes" %}
+{% set subHeading = "Any signs or symptoms, including lumps, swelling, rashes or nipple changes" %}
 {% set sectionId = sectionHeading | kebabCase %}
 {% set scrollTo = sectionId %}
 

--- a/app/views/_includes/summary-lists/medical-info-summary.njk
+++ b/app/views/_includes/summary-lists/medical-info-summary.njk
@@ -47,11 +47,11 @@
   {% if symptomsCount == 0 %}
     <p>No symptoms added</p>
   {% elif symptomsCount == 1 %}
-    <p>{{ symptomSummaries[0] }}</p>
+    <p>{{ symptomSummaries[0] | sentenceCase }}</p>
   {% else %}
     <ul class="nhsuk-list">
       {% for summary in symptomSummaries %}
-        <li>{{ summary }}</li>
+        <li>{{ summary | sentenceCase }}</li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
+++ b/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
@@ -22,7 +22,8 @@
 
     {# Sign noted by the mammographer rather than reported by the participant #}
     {% if symptom.isMammographerObserved %}
-      {% set valueLines = valueLines | push("Sign noted by mammographer") %}
+      {% set notedByName = (symptom.addedByUserId | getUsername({ format: "short", useYou: true })) or "mammographer" %}
+      {% set valueLines = valueLines | push("Sign noted by " + notedByName) %}
     {% endif %}
 
     {# Add sub-type as first line with appropriate descriptor #}

--- a/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
+++ b/app/views/_includes/summary-lists/medical-information/symptoms/summary.njk
@@ -20,6 +20,11 @@
     {# Build the value (right column) - all supporting details #}
     {% set valueLines = [] %}
 
+    {# Sign noted by the mammographer rather than reported by the participant #}
+    {% if symptom.isMammographerObserved %}
+      {% set valueLines = valueLines | push("Sign noted by mammographer") %}
+    {% endif %}
+
     {# Add sub-type as first line with appropriate descriptor #}
     {% if symptom.type == "Nipple change" and symptom.nippleChangeType %}
       {% if symptom.nippleChangeType == "other" and symptom.nippleChangeDescription %}

--- a/app/views/_includes/workflow/workflow-side-navigation.njk
+++ b/app/views/_includes/workflow/workflow-side-navigation.njk
@@ -17,7 +17,7 @@
 {% set workflowSteps = [
   { id: 'confirm-identity', label: 'Confirm identity' },
   { id: 'review-medical-information', label: 'Review medical information' },
-  { id: 'take-images', label: 'Take images' },
+  { id: 'take-images', label: 'Take mammogram images' },
   { id: 'check-information', label: 'Check information' }
 ] %}
 

--- a/app/views/appointments/images-before-mammography.html
+++ b/app/views/appointments/images-before-mammography.html
@@ -2,7 +2,7 @@
 {% extends 'layout-appointment.html' %}
 
 
-{% set pageHeading = "Awaiting images" %}
+{% set pageHeading = "Take mammogram images" %}
 {% set showNavigation = true %}
 {% set activeWorkflowStep = 'take-images' %}
 {% set hideBackLink = true %}

--- a/app/views/appointments/images-manual.html
+++ b/app/views/appointments/images-manual.html
@@ -4,7 +4,7 @@
 {% set hideBackLink = true %}
 {% set activeWorkflowStep = 'take-images' %}
 
-{% set pageHeading = "Manually record image information" %}
+{% set pageHeading = "Take mammogram images" %}
 
 {% set gridColumn = "nhsuk-grid-column-two-thirds" %}
 

--- a/app/views/appointments/medical-information/symptoms/details.html
+++ b/app/views/appointments/medical-information/symptoms/details.html
@@ -63,6 +63,25 @@
 
   {% endif %}
 
+  {# Whether this is a sign noted by the mammographer rather than a symptom reported by the participant #}
+  {{ checkboxes({
+    idPrefix: "isMammographerObserved",
+    name: "appointment[symptomTemp][isMammographerObserved]",
+    fieldset: {
+      legend: {
+        text: "Clinical sign",
+        size: "m"
+      }
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Mammographer-noted sign",
+        checked: true if appointment.symptomTemp.isMammographerObserved else false
+      }
+    ]
+  }) }}
+
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-one-half">
 


### PR DESCRIPTION
## Description

Adds support for mammographer noted signs (symptoms). 

Also changes the third workflow step from `Take images` to `Take mammogram images` and updates both the manual and automatic images page h1s to match.