### PR TITLE
Undo "did not attend" status bug fix

### DIFF
--- a/app/routes/appointments/cancel-reschedule.js
+++ b/app/routes/appointments/cancel-reschedule.js
@@ -217,8 +217,8 @@ module.exports = (router) => {
 
       if (appointment && appointment.status === 'did_not_attend') {
         const participantName = getFullName(data.participant)
-        // Revert to checked_in status
-        updateAppointmentStatus(data, appointmentId, 'checked_in')
+        // Revert to scheduled status
+        updateAppointmentStatus(data, appointmentId, 'scheduled')
         req.flash('success', `${participantName} did not attend status undone`)
       }
 


### PR DESCRIPTION
When undoing did not attend, there is a bug: it shows the participant as checked in instead of scheduled. This fix keeps the appointment as scheduled when undo did not attend is pressed. 