### PR TITLE
Add reading case backlog and case view

### DIFF
--- a/app/lib/data-store.js
+++ b/app/lib/data-store.js
@@ -77,6 +77,11 @@ const state = {
   appointmentIdsByClinic: new Map(),
   appointmentIdsByParticipant: new Map(),
   episodeIdsByParticipant: new Map(),
+  // Reading cases live inside episodes, so finding one by its own id means
+  // knowing which episode holds it. The index points at the episode rather than
+  // the case itself so lookups still go through getEpisode, and a case changed
+  // this session is found on the session's copy rather than the frozen one.
+  episodeIdByReadingCase: new Map(),
   generationInfo: {},
   // Identifies which generation of seed data the store holds. Sessions stamp
   // their _changes with this; the attach middleware discards changes made
@@ -138,11 +143,16 @@ const reload = () => {
   // Episodes are generated oldest-first per participant, so these id lists
   // stay in sequence order
   state.episodeIdsByParticipant = new Map()
+  state.episodeIdByReadingCase = new Map()
   for (const episode of episodes) {
     if (!state.episodeIdsByParticipant.has(episode.participantId)) {
       state.episodeIdsByParticipant.set(episode.participantId, [])
     }
     state.episodeIdsByParticipant.get(episode.participantId).push(episode.id)
+
+    for (const readingCase of episode.readingCases || []) {
+      state.episodeIdByReadingCase.set(readingCase.id, episode.id)
+    }
   }
 
   console.log(

--- a/app/lib/utils/clinics.js
+++ b/app/lib/utils/clinics.js
@@ -26,6 +26,35 @@ const getClinic = (data, clinicId) => {
 }
 
 /**
+ * Where a clinic was held, as one line.
+ *
+ * A mobile unit is named by both the unit and the site it was parked at, since
+ * the unit alone doesn't say where anyone went. Templates have long written
+ * this inline as `location.name at clinic.siteName`; this is the same rule in
+ * one place, for callers that only want the string.
+ *
+ * @param {object} data - Session data
+ * @param {object} clinic - Clinic object
+ * @returns {string} Display name, or an empty string if it can't be resolved
+ */
+const getClinicLocationName = (data, clinic) => {
+  if (!clinic) return ''
+
+  const unit = (data.breastScreeningUnits || []).find(
+    (candidate) => candidate.id === clinic.breastScreeningUnitId
+  )
+  const location = (unit?.locations || []).find(
+    (candidate) => candidate.id === clinic.locationId
+  )
+
+  if (!location) return clinic.siteName || ''
+
+  return location.type === 'mobile_unit' && clinic.siteName
+    ? `${location.name} at ${clinic.siteName}`
+    : location.name
+}
+
+/**
  * Get today's clinics
  *
  * @param {Array} clinics - Array of all clinics
@@ -137,6 +166,7 @@ const getFilteredClinics = (clinics, filter = 'all') => {
 
 module.exports = {
   getClinic,
+  getClinicLocationName,
   getTodaysClinics,
   getFilteredClinics,
   getClinicAppointments,

--- a/app/lib/utils/episodes.js
+++ b/app/lib/utils/episodes.js
@@ -253,6 +253,39 @@ const getReadingCase = (data, appointment) => {
 }
 
 /**
+ * Find a reading case by its own id, with the episode that holds it.
+ *
+ * Cases live inside episodes, so a case id on its own is not enough to reach
+ * one - hence the store index. Callers that have an appointment should use
+ * getReadingCase instead; this is for the case views, which are reached by case
+ * id and need the episode anyway (for the participant and the appointment).
+ *
+ * @param {object} data - Session data
+ * @param {string} caseId - Reading case ID
+ * @returns {{ readingCase: object, episode: object } | null} Both, or null
+ */
+const getReadingCaseById = (data, caseId) => {
+  if (!caseId) return null
+
+  const episodeId = dataStore.state.episodeIdByReadingCase.get(caseId)
+
+  // A case opened this session exists only in _changes, so isn't in the index
+  const episode = episodeId
+    ? getEpisode(data, episodeId)
+    : Object.values(data._changes?.episodes || {}).find((candidate) =>
+        getReadingCases(candidate).some((readingCase) => readingCase.id === caseId)
+      )
+
+  if (!episode) return null
+
+  const readingCase = getReadingCases(episode).find(
+    (candidate) => candidate.id === caseId
+  )
+
+  return readingCase ? { readingCase, episode } : null
+}
+
+/**
  * Get an episode's reading cases, oldest first
  *
  * @param {object} episode - Episode object
@@ -711,6 +744,7 @@ module.exports = {
   getCurrentEpisode,
   getEpisodeAppointments,
   getReadingCase,
+  getReadingCaseById,
   getEpisodeReadingCases,
   getEpisodeReadingCase,
   getEpisodeReadingOutcome,

--- a/app/lib/utils/reading-case-list.js
+++ b/app/lib/utils/reading-case-list.js
@@ -1,0 +1,204 @@
+// app/lib/utils/reading-case-list.js
+//
+// Listing reading cases across every episode - the backlog behind
+// /reading/cases.
+//
+// Separate from reading.js because it works on a different axis: reading.js is
+// the appointment/session layer (one reader working through a list of
+// appointments), this is every case in the service regardless of who is reading
+// it. Separate from reading-cases.js because that file is deliberately pure and
+// this needs session data to reach episodes, appointments and participants.
+
+const dataStore = require('../data-store')
+const { getAppointment } = require('./appointment-data')
+const { getParticipant, getFullName } = require('./participants')
+const { getClinic, getClinicLocationName } = require('./clinics')
+const {
+  getReadingCases,
+  getReadsAsArray,
+  getReadingCaseState,
+  getReadingCaseOutcome,
+  isCaseDeferred
+} = require('./reading-cases')
+
+// How the list is scoped. Historic episodes are seeded summaries of past rounds
+// and outnumber live ones roughly five to one, so they stay out of the way
+// unless asked for.
+//
+// Every non-historic closed episode was closed within the last month, so
+// 'recently-closed' needs no date cutoff - not historic is the same set.
+const CASE_SCOPES = ['open', 'recently-closed', 'all']
+
+// Rows beyond this aren't rendered. The unfiltered open list is ~550 cases;
+// most filtered views are far smaller. The route reports what was dropped.
+const MAX_ROWS = 200
+
+/**
+ * Every episode the list could draw on, session changes included.
+ *
+ * @param {object} data - Session data
+ * @returns {Array} Episodes
+ */
+const getAllEpisodes = (data) => {
+  const changed = data._changes?.episodes || {}
+  const changedIds = new Set(Object.keys(changed))
+
+  return [
+    ...dataStore.state.episodes.filter((episode) => !changedIds.has(episode.id)),
+    ...Object.values(changed)
+  ]
+}
+
+/**
+ * Whether an episode is in scope for the list
+ *
+ * @param {object} episode - Episode object
+ * @param {string} scope - One of CASE_SCOPES
+ * @returns {boolean}
+ */
+const episodeInScope = (episode, scope) => {
+  if (scope === 'all') return true
+
+  if (scope === 'recently-closed') {
+    return episode.stage === 'closed' && !episode.isHistoric
+  }
+
+  return episode.stage !== 'closed'
+}
+
+/**
+ * Build one row for a case - everything the list and its filters need.
+ *
+ * @param {object} data - Session data
+ * @param {object} episode - The episode holding the case
+ * @param {object} readingCase - The case
+ * @returns {object} Row
+ */
+const buildRow = (data, episode, readingCase) => {
+  const appointment = getAppointment(data, readingCase.appointmentId)
+  const participant = getParticipant(data, episode.participantId)
+  const clinic = appointment ? getClinic(data, appointment.clinicId) : null
+
+  return {
+    readingCase,
+    episode,
+    appointment,
+    participant,
+    clinic,
+    clinicLocationName: getClinicLocationName(data, clinic),
+    state: getReadingCaseState(readingCase, data.settings),
+    outcome: getReadingCaseOutcome(readingCase, data.settings),
+    readCount: getReadsAsArray(readingCase).length,
+    isDeferred: isCaseDeferred(readingCase),
+    imagesTakenDate: readingCase.openedDate
+  }
+}
+
+/**
+ * Whether a row matches a free-text search of the participant's name or NHS
+ * number
+ *
+ * @param {object} row - A row from buildRow
+ * @param {string} query - Search text
+ * @returns {boolean}
+ */
+const rowMatchesQuery = (row, query) => {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return true
+
+  const name = row.participant ? getFullName(row.participant) : ''
+  const nhsNumber =
+    row.participant?.medicalInformation?.nhsNumber?.replace(/\s/g, '') || ''
+
+  return (
+    name.toLowerCase().includes(needle) ||
+    nhsNumber.includes(needle.replace(/\s/g, ''))
+  )
+}
+
+/**
+ * Every matching row, uncapped and sorted oldest images first.
+ *
+ * @param {object} data - Session data
+ * @param {object} filters - Filters, as getReadingCaseList documents
+ * @returns {Array} Rows
+ */
+const collectRows = (data, filters) => {
+  const { scope = 'open', state = null, deferred = false, query = '' } = filters
+
+  const rows = []
+
+  for (const episode of getAllEpisodes(data)) {
+    if (!episodeInScope(episode, scope)) continue
+
+    for (const readingCase of getReadingCases(episode)) {
+      const row = buildRow(data, episode, readingCase)
+
+      if (state && row.state !== state) continue
+      if (deferred && !row.isDeferred) continue
+      if (query && !rowMatchesQuery(row, query)) continue
+
+      rows.push(row)
+    }
+  }
+
+  return rows.sort(
+    (a, b) => new Date(a.imagesTakenDate) - new Date(b.imagesTakenDate)
+  )
+}
+
+/**
+ * The reading case backlog, filtered and sorted oldest images first.
+ *
+ * @param {object} data - Session data
+ * @param {object} [filters] - Filters
+ * @param {string} [filters.scope] - One of CASE_SCOPES, default 'open'
+ * @param {string} [filters.state] - A single reading case state
+ * @param {boolean} [filters.deferred] - Only deferred cases
+ * @param {string} [filters.query] - Participant name or NHS number
+ * @returns {object} `{ rows, totalCount, truncated }` - rows capped at MAX_ROWS
+ */
+const getReadingCaseList = (data, filters = {}) => {
+  const rows = collectRows(data, filters)
+
+  return {
+    rows: rows.slice(0, MAX_ROWS),
+    totalCount: rows.length,
+    truncated: rows.length > MAX_ROWS
+  }
+}
+
+/**
+ * How many cases sit in each state, for the filter links.
+ *
+ * Counted within the current scope but ignoring the state and deferred filters,
+ * so the counts don't collapse to whichever filter is active. Uncapped - a
+ * count that stopped at MAX_ROWS would be a lie.
+ *
+ * @param {object} data - Session data
+ * @param {object} [filters] - Same filters as getReadingCaseList
+ * @returns {object} State value -> count, plus `all` and `deferred`
+ */
+const getReadingCaseStateCounts = (data, filters = {}) => {
+  const rows = collectRows(data, {
+    ...filters,
+    state: null,
+    deferred: false
+  })
+
+  const counts = { all: rows.length, deferred: 0 }
+
+  for (const row of rows) {
+    counts[row.state] = (counts[row.state] || 0) + 1
+    if (row.isDeferred) counts.deferred += 1
+  }
+
+  return counts
+}
+
+module.exports = {
+  CASE_SCOPES,
+  MAX_ROWS,
+  getReadingCaseList,
+  getReadingCaseStateCounts
+}

--- a/app/lib/utils/status.js
+++ b/app/lib/utils/status.js
@@ -230,6 +230,14 @@ const STATUS_TAGS = {
   },
   // Reading journey state - mostly derived, reached via snake-cased tag text
   readingState: {
+    // Reading case states (READING_CASE_STATES in reading-cases.js) - where one
+    // set of images has got to. The entries below them are the older
+    // appointment- and group-level vocabulary.
+    'awaiting_first_read': { label: 'Awaiting 1st read', colour: 'grey' },
+    'awaiting_second_read': { label: 'Awaiting 2nd read', colour: 'blue' },
+    'arbitration_required': { label: 'Arbitration required', colour: 'orange' },
+    'in_arbitration': { label: 'In arbitration', colour: 'purple' },
+    'concluded': { label: 'Concluded', colour: 'green' },
     'waiting_for_1st_read': { colour: 'grey' },
     'waiting_for_2nd_read': { colour: 'grey' },
     'not_started': { colour: 'grey' },

--- a/app/routes.js
+++ b/app/routes.js
@@ -314,6 +314,7 @@ require('./routes/participants')(router)
 require('./routes/episodes')(router)
 require('./routes/appointments')(router)
 require('./routes/reading')(router)
+require('./routes/reading-cases')(router)
 require('./routes/reports')(router)
 
 router.get('/modal-examples', (req, res) => {

--- a/app/routes/reading-cases.js
+++ b/app/routes/reading-cases.js
@@ -1,0 +1,143 @@
+// app/routes/reading-cases.js
+//
+// The reading lens's "seeing" surface: a backlog of every reading case and a
+// view of one case with its reads. Separate from routes/reading.js, which owns
+// the "doing" surface - one reader working through a session.
+//
+// Registered after routes/reading.js so its `/reading` middleware (nav state)
+// has already run.
+
+const {
+  getReadingCaseList,
+  getReadingCaseStateCounts,
+  CASE_SCOPES
+} = require('../lib/utils/reading-case-list')
+const { getReadingCaseById } = require('../lib/utils/episodes')
+const { getAppointment } = require('../lib/utils/appointment-data')
+const { getParticipant } = require('../lib/utils/participants')
+const { getClinic, getClinicLocationName } = require('../lib/utils/clinics')
+const {
+  READING_CASE_STATES,
+  getReadingCases,
+  getReadsAsArray,
+  getReadingCaseState,
+  getReadingCaseOutcome,
+  getReadingMetadata,
+  getArbitrationRead,
+  isCaseDeferred,
+  canUserReadCase
+} = require('../lib/utils/reading-cases')
+
+module.exports = (router) => {
+  // Reading case backlog. Filters are query params rather than path segments
+  // because this list has several facets at once (state, scope, deferred,
+  // search) where the other reading lists have one - and it keeps the URL
+  // shareable.
+  router.get('/reading/cases', (req, res) => {
+    const data = req.session.data
+
+    const scope = CASE_SCOPES.includes(req.query.scope)
+      ? req.query.scope
+      : 'open'
+
+    const state = READING_CASE_STATES.includes(req.query.state)
+      ? req.query.state
+      : null
+
+    const deferred = req.query.deferred === 'true'
+    const query = req.query.q || ''
+
+    const filters = { scope, state, deferred, query }
+
+    const { rows, totalCount, truncated } = getReadingCaseList(data, filters)
+    const counts = getReadingCaseStateCounts(data, filters)
+
+    res.render('reading/cases', {
+      rows,
+      totalCount,
+      truncated,
+      shownCount: rows.length,
+      counts,
+      filters,
+      scopes: CASE_SCOPES,
+      states: READING_CASE_STATES
+    })
+  })
+
+  // One reading case, in tabs. Summary is the default; the tab is a path
+  // segment so each is linkable, the same way the other reading views do views
+  // and filters.
+  //
+  // Registered as two paths rather than an optional `:tab?` - Express 5's
+  // path-to-regexp rejects that syntax.
+  const CASE_TABS = ['summary', 'reads', 'annotations']
+
+  const caseViewPaths = [
+    '/reading/cases/:caseId',
+    '/reading/cases/:caseId/:tab'
+  ]
+
+  router.get(caseViewPaths, (req, res) => {
+    const data = req.session.data
+
+    const tab = CASE_TABS.includes(req.params.tab) ? req.params.tab : 'summary'
+
+    const found = getReadingCaseById(data, req.params.caseId)
+    if (!found) {
+      return res.redirect('/reading/cases')
+    }
+
+    const { readingCase, episode } = found
+
+    const appointment = getAppointment(data, readingCase.appointmentId)
+    const participant = getParticipant(data, episode.participantId)
+    const clinic = appointment ? getClinic(data, appointment.clinicId) : null
+
+    // Which set of images this is, when a round has more than one. A technical
+    // recall produces a second case, so the earlier one is superseded rather
+    // than wrong - worth saying which you are looking at.
+    const casesOnEpisode = getReadingCases(episode)
+    const casePosition =
+      casesOnEpisode.findIndex((candidate) => candidate.id === readingCase.id) + 1
+
+    // Blind reading: someone who could still read this case must not see what
+    // the other reader said. Once they have read it - or it is no longer theirs
+    // to read - the reads are theirs to see.
+    const blindReading = data.settings?.reading?.blindReading === 'true'
+    const readsHidden =
+      blindReading && canUserReadCase(readingCase, data.currentUser?.id)
+
+    const allReads = getReadsAsArray(readingCase)
+    const caseOutcome = getReadingCaseOutcome(readingCase, data.settings)
+
+    // The read the outcome came from - arbitration where there was one, else
+    // either of the two agreeing reads. Its per-breast assessment is what the
+    // summary reports, since that is what the case concluded.
+    const decidingRead = caseOutcome
+      ? getArbitrationRead(readingCase) || allReads[0]
+      : null
+
+    res.render('reading/case', {
+      tab,
+      // Not `tabs` - that name is taken by the NHS frontend tabs macro, which
+      // is imported globally and silently shadows a template variable
+      caseTabs: CASE_TABS,
+      readingCase,
+      episode,
+      appointment,
+      participant,
+      clinic,
+      clinicLocationName: getClinicLocationName(data, clinic),
+      reads: readsHidden ? [] : allReads,
+      readsHidden,
+      readCount: allReads.length,
+      caseState: getReadingCaseState(readingCase, data.settings),
+      caseOutcome,
+      decidingRead: readsHidden ? null : decidingRead,
+      readingMetadata: getReadingMetadata(readingCase, data.settings),
+      isDeferred: isCaseDeferred(readingCase),
+      casePosition,
+      caseTotal: casesOnEpisode.length
+    })
+  })
+}

--- a/app/views/_includes/episodes/reading-cases-table.njk
+++ b/app/views/_includes/episodes/reading-cases-table.njk
@@ -29,7 +29,7 @@
           {{ (readingCase | getReadsAsArray) | length }}
         </td>
         <td class="nhsuk-table__cell">
-          {{ caseState | formatWords | sentenceCase }}
+          {{ caseState | toTag({ vocabulary: "readingState" }) }}
         </td>
         <td class="nhsuk-table__cell">
           {% if caseOutcome %}
@@ -39,9 +39,7 @@
           {% endif %}
         </td>
         <td class="nhsuk-table__cell">
-          {# Alludes to the reading case view, which the reading backlog work
-             will build. Nothing serves it yet, so it goes nowhere. #}
-          <a href="#">View case</a>
+          <a href="/reading/cases/{{ readingCase.id }}">View case</a>
         </td>
       </tr>
     {% endfor %}

--- a/app/views/reading/case.html
+++ b/app/views/reading/case.html
@@ -1,0 +1,268 @@
+{# app/views/reading/case.html
+
+   One reading case in reading chrome, in tabs: what the case concluded, what
+   each reader said, and every mark they made on the images.
+
+   The casework lens on the same content is the episode page's reading section.
+   When that grows a tab of its own, the panels below should move into shared
+   includes rather than being written twice.
+
+   Read panels reuse _includes/summary-lists/read-summary.njk, the same include
+   the workflow's review and compare pages use, so a read looks the same
+   wherever it is shown. #}
+
+{% extends 'layout-app.html' %}
+
+{% from '_components/annotation-images/macro.njk' import appAnnotationImages %}
+{% from '_components/annotation-list/macro.njk' import appAnnotationList %}
+{% from '_components/details/macro.njk' import appDetails %}
+
+{% set pageHeading = participant | getFullName %}
+{% set gridColumn = "nhsuk-grid-column-full" %}
+
+{% set back = {
+  href: "/reading/cases",
+  text: "Back to reading cases"
+} %}
+
+{% set tabLabels = {
+  "summary": "Summary",
+  "reads": "Reads",
+  "annotations": "Annotations"
+} %}
+
+{% block pageContent %}
+
+  <span class="nhsuk-caption-l">Image reading case</span>
+  <h1 class="nhsuk-heading-l">{{ pageHeading }}</h1>
+
+  {% set tabNavItems = [] %}
+  {% for tabName in caseTabs %}
+    {% set tabHref %}/reading/cases/{{ readingCase.id }}{{ "/" + tabName if tabName != "summary" }}{% endset %}
+    {% set tabNavItems = tabNavItems | push({
+      text: tabLabels[tabName],
+      href: tabHref | trim,
+      current: true if tabName == tab
+    }) %}
+  {% endfor %}
+
+  {{ appSecondaryNavigation({
+    visuallyHiddenTitle: "Reading case views",
+    items: tabNavItems
+  }) }}
+
+  {# Image paths drive the annotation markers. Resolved once here rather than
+     per read, since the annotations tab pools every read onto one set. #}
+  {% set withImages = data.settings.reading.annotationsMode != 'without-images' %}
+  {% if withImages and appointment %}
+    {% set mammogramImages = getImagesForAppointment(appointment.id, "diagrams", { appointment: appointment }) %}
+    {% set allPaths = mammogramImages.allPaths if mammogramImages else {} %}
+  {% endif %}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% if tab == "summary" %}
+
+        {% set caseRows = [
+          {
+            key: { text: "Images taken" },
+            value: { html: (readingCase.openedDate | formatDate) + ' <span class="nhsuk-u-secondary-text-colour">(' + (readingCase.openedDate | formatRelativeDate) + ')</span>' }
+          },
+          {
+            key: { text: "Screened at" },
+            value: { text: clinicLocationName or "Unknown" }
+          },
+          {
+            key: { text: "State" },
+            value: { html: caseState | toTag({ vocabulary: "readingState" }) }
+          },
+          {
+            key: { text: "Reads" },
+            value: { text: readCount }
+          }
+        ] %}
+
+        {% if caseOutcome %}
+          {% set caseRows = caseRows | push({
+            key: { text: "Outcome" },
+            value: { html: caseOutcome | toTag }
+          }) %}
+        {% endif %}
+
+        {# What the case concluded per breast, from the deciding read #}
+        {% if decidingRead %}
+          {% for side in ["right", "left"] %}
+            {% set breast = decidingRead[side] %}
+            {% if breast and breast.breastAssessment %}
+              {% set assessmentKey = breast.breastAssessment | lower %}
+              {% set tagStatusMap = {
+                "normal": "normal",
+                "clinical": "clinical_recall",
+                "abnormal": "abnormal",
+                "technical": "technical_recall"
+              } %}
+              {% set caseRows = caseRows | push({
+                key: { text: side | sentenceCase + " breast" },
+                value: { html: (tagStatusMap[assessmentKey] or breast.breastAssessment) | toTag }
+              }) %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        {% if caseTotal > 1 %}
+          {# A technical recall opens a further case, covering the new images as
+             well as the originals - so say which of the round's cases this is #}
+          {% set caseRows = caseRows | push({
+            key: { text: "Case" },
+            value: { text: casePosition + " of " + caseTotal + " this round" }
+          }) %}
+        {% endif %}
+
+        {{ appSummaryList({ rows: caseRows }) }}
+
+        {% if isDeferred %}
+          {{ warningCallout({
+            heading: "Deferred",
+            html: "<p>This case has been deferred from reading and needs review before it returns to the reading queue.</p>"
+          }) }}
+        {% endif %}
+
+        <h2 class="nhsuk-heading-m">Elsewhere</h2>
+        <ul class="nhsuk-list nhsuk-list--bullet">
+          <li>
+            <a href="/participants/{{ episode.participantId }}/episodes/{{ episode.id }}">
+              Episode this case belongs to
+            </a>
+          </li>
+          {% if appointment %}
+            <li>
+              <a href="/clinics/{{ appointment.clinicId }}/appointments/{{ appointment.id }}">
+                Appointment the images were taken at
+              </a>
+            </li>
+          {% endif %}
+        </ul>
+
+      {% elseif tab == "reads" %}
+
+        {% if readsHidden %}
+          <p>Reads on this case are hidden because it is still yours to read. They become visible once you have given your opinion.</p>
+        {% elseif readCount == 0 %}
+          <p>This case has not been read yet.</p>
+        {% else %}
+
+          {% for thisRead in reads %}
+            {# Opinion up front; the rest behind a disclosure, since the
+               question most of the time is just who said what #}
+            {% set readDetailHtml %}
+              {% set read = thisRead %}
+              {% set allowEdits = false %}
+              {% set hideEmptyRows = true %}
+              {% set hideOpinionRow = true %}
+              {% set showAnnotationImages = false %}
+              {% include "_includes/summary-lists/read-summary.njk" %}
+            {% endset %}
+
+            <div class="nhsuk-summary-card">
+              <div class="nhsuk-summary-card__title-wrapper">
+                <h2 class="nhsuk-summary-card__title">
+                  {{ thisRead.readType | formatWords | sentenceCase }} read
+                </h2>
+                <div class="nhsuk-summary-card__actions">
+                  <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+                    {{ thisRead.readerId | getUsername({ format: "short", identifyCurrentUser: true }) }},
+                    {{ thisRead.timestamp | formatDate }}
+                  </span>
+                </div>
+              </div>
+              <div class="nhsuk-summary-card__content">
+                <p class="nhsuk-u-margin-bottom-2">
+                  {{ thisRead.opinion | toTag if thisRead.opinion else "Opinion not recorded" }}
+                </p>
+
+                {{ appDetails({
+                  summaryText: "Show full read",
+                  html: readDetailHtml
+                }) }}
+              </div>
+            </div>
+          {% endfor %}
+
+        {% endif %}
+
+      {% endif %}
+
+    </div>
+  </div>
+
+  {# Annotations get the full width - two sides of images side by side #}
+  {% if tab == "annotations" %}
+
+    {% if readsHidden %}
+      <p>Annotations on this case are hidden because it is still yours to read.</p>
+    {% elseif readCount == 0 %}
+      <p>This case has not been read yet, so nothing has been annotated.</p>
+    {% else %}
+
+      <div class="nhsuk-grid-row">
+        {% for side in ["right", "left"] %}
+
+          {# Pool every read's marks for this side onto one set of images, and
+             keep the numbering running so the lists beneath match the markers #}
+          {% set pooled = [] %}
+          {% for thisRead in reads %}
+            {% for annotation in (thisRead[side].annotations or []) %}
+              {% set pooled = pooled | push(annotation) %}
+            {% endfor %}
+          {% endfor %}
+
+          <div class="nhsuk-grid-column-one-half">
+            <h2 class="nhsuk-heading-m">{{ side | sentenceCase }} breast</h2>
+
+            {% if pooled | length == 0 %}
+              <p class="nhsuk-u-secondary-text-colour">No annotations on this side.</p>
+            {% else %}
+
+              {% if withImages and allPaths %}
+                {{ appAnnotationImages({
+                  side: side,
+                  imagePaths: allPaths,
+                  viewOrder: data.settings.mammogramViewOrder or "cc-first",
+                  annotations: pooled,
+                  mode: "readonly",
+                  size: "thumbnail",
+                  showLabels: true
+                }) }}
+              {% endif %}
+
+              {# Attribute the marks: same numbering, grouped by who made them #}
+              {% set runningNumber = 1 %}
+              {% for thisRead in reads %}
+                {% set sideAnnotations = thisRead[side].annotations or [] %}
+                {% if sideAnnotations | length %}
+                  <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1 nhsuk-u-margin-top-3">
+                    {{ thisRead.readerId | getUsername({ format: "short", identifyCurrentUser: true }) }}
+                    <span class="nhsuk-u-secondary-text-colour nhsuk-u-font-weight-normal">
+                      ({{ thisRead.readType | formatWords }} read)
+                    </span>
+                  </h3>
+                  {{ appAnnotationList({
+                    annotations: sideAnnotations,
+                    startNumber: runningNumber,
+                    editable: false
+                  }) }}
+                  {% set runningNumber = runningNumber + (sideAnnotations | length) %}
+                {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+
+    {% endif %}
+
+  {% endif %}
+
+{% endblock %}

--- a/app/views/reading/cases.html
+++ b/app/views/reading/cases.html
@@ -1,0 +1,152 @@
+{# app/views/reading/cases.html
+
+   The reading backlog - every reading case, whatever stage it has reached.
+   Filters are query params so several can apply at once and the URL stays
+   shareable. #}
+
+{% extends 'layout-app.html' %}
+
+{% set pageHeading = "Reading cases" %}
+{% set gridColumn = "nhsuk-grid-column-full" %}
+
+{% set back = {
+  href: "/reading",
+  text: "Back to reading"
+} %}
+
+{# Build a filtered URL, carrying the filters that aren't being changed #}
+{%- macro casesUrl(scope, state, deferred, query) -%}
+  /reading/cases?scope={{ scope }}
+  {%- if state %}&state={{ state }}{% endif -%}
+  {%- if deferred %}&deferred=true{% endif -%}
+  {%- if query %}&q={{ query | urlencode }}{% endif -%}
+{%- endmacro -%}
+
+{% set scopeLabels = {
+  "open": "Open rounds",
+  "recently-closed": "Recently closed",
+  "all": "All, including history"
+} %}
+
+{% block pageContent %}
+
+  <span class="nhsuk-caption-l">Image reading</span>
+  <h1 class="nhsuk-heading-l">{{ pageHeading }}</h1>
+
+  {# Search first - the fastest way to a known case, before any browsing #}
+  <form action="/reading/cases" method="get" class="nhsuk-u-margin-bottom-4">
+    <input type="hidden" name="scope" value="{{ filters.scope }}">
+    {% if filters.state %}<input type="hidden" name="state" value="{{ filters.state }}">{% endif %}
+    {% if filters.deferred %}<input type="hidden" name="deferred" value="true">{% endif %}
+
+    {{ searchInput({
+      id: "case-search",
+      name: "q",
+      value: filters.query,
+      label: { text: "Search by name or NHS number" },
+      width: 20,
+      button: { variant: "secondary" }
+    }) }}
+  </form>
+
+  {# Scope next - it decides which population the state counts describe #}
+  {% set scopeNavItems = [] %}
+  {% for scope in scopes %}
+    {% set scopeNavItems = scopeNavItems | push({
+      text: scopeLabels[scope],
+      href: casesUrl(scope, filters.state, filters.deferred, filters.query) | trim,
+      current: true if scope == filters.scope
+    }) %}
+  {% endfor %}
+
+  {{ appSecondaryNavigation({
+    visuallyHiddenTitle: "Which rounds to show",
+    items: scopeNavItems
+  }) }}
+
+  {# State filters, with counts from the current scope #}
+  <p class="nhsuk-u-margin-bottom-2">
+    <strong>State:</strong>
+    <a href="{{ casesUrl(filters.scope, null, filters.deferred, filters.query) | trim }}"
+       class="nhsuk-link--no-visited-state {{ 'nhsuk-u-font-weight-bold' if not filters.state }}">
+      All ({{ counts.all }})
+    </a>
+    {% for state in states %}
+      {% if counts[state] %}
+        &nbsp;·&nbsp;
+        <a href="{{ casesUrl(filters.scope, state, filters.deferred, filters.query) | trim }}"
+           class="nhsuk-link--no-visited-state {{ 'nhsuk-u-font-weight-bold' if filters.state == state }}">
+          {{ state | getStatusText("readingState") or (state | formatWords | sentenceCase) }} ({{ counts[state] }})
+        </a>
+      {% endif %}
+    {% endfor %}
+    &nbsp;·&nbsp;
+    <a href="{{ casesUrl(filters.scope, filters.state, (not filters.deferred), filters.query) | trim }}"
+       class="nhsuk-link--no-visited-state {{ 'nhsuk-u-font-weight-bold' if filters.deferred }}">
+      Deferred ({{ counts.deferred }})
+    </a>
+  </p>
+
+  {% if totalCount == 0 %}
+    <p>No reading cases match these filters.</p>
+  {% else %}
+
+    <p class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+      {% if truncated %}
+        Showing the {{ shownCount }} oldest of {{ totalCount }} cases. Filter or search to narrow this down.
+      {% else %}
+        {{ totalCount }} {{ "case" | pluralise(totalCount) }}.
+      {% endif %}
+    </p>
+
+    <table class="nhsuk-table">
+      <thead class="nhsuk-table__head">
+        <tr>
+          <th scope="col">Participant</th>
+          <th scope="col">Images taken</th>
+          <th scope="col">Screened at</th>
+          <th scope="col">Reads</th>
+          <th scope="col">State</th>
+          <th scope="col">Outcome</th>
+        </tr>
+      </thead>
+      <tbody class="nhsuk-table__body">
+        {% for row in rows %}
+          <tr class="nhsuk-table__row">
+            <td class="nhsuk-table__cell">
+              <a href="/reading/cases/{{ row.readingCase.id }}" class="nhsuk-link--no-visited-state">
+                {{ row.participant | getFullName }}
+              </a>
+              {% if row.isDeferred %}
+                <br>{{ "Deferred" | toTag }}
+              {% endif %}
+            </td>
+            <td class="nhsuk-table__cell">
+              {{ row.imagesTakenDate | formatDate }}
+              <br>
+              <span class="nhsuk-u-secondary-text-colour nhsuk-body-s">
+                {{ row.imagesTakenDate | formatRelativeDate }}
+              </span>
+            </td>
+            <td class="nhsuk-table__cell">
+              {{ row.clinicLocationName or "Unknown" }}
+            </td>
+            <td class="nhsuk-table__cell">{{ row.readCount }}</td>
+            <td class="nhsuk-table__cell">
+              {{ row.state | toTag({ vocabulary: "readingState" }) }}
+            </td>
+            <td class="nhsuk-table__cell">
+              {% if row.outcome %}
+                {{ row.outcome | toTag }}
+              {% else %}
+                <span class="nhsuk-u-secondary-text-colour">Not yet</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+  {% endif %}
+
+{% endblock %}

--- a/scripts/route-sweep.js
+++ b/scripts/route-sweep.js
@@ -139,6 +139,7 @@ const collectParams = async (sessionFetch) => {
   const appointments = require(
     path.join(generatedPath, 'appointments.json')
   ).appointments
+  const episodes = require(path.join(generatedPath, 'episodes.json')).episodes
 
   const today = dayjs().format('YYYY-MM-DD')
   const clinic = clinics.find((item) => item.date === today) ?? clinics[0]
@@ -148,15 +149,28 @@ const collectParams = async (sessionFetch) => {
     throw new Error(`No appointments found on clinic ${clinic.id}`)
   }
 
+  // Reading cases live inside episodes, so the case views need an id from one
+  // that actually has a case rather than one derived from the appointment above
+  const episodeWithReadingCase = episodes.find(
+    (item) => item.readingCases?.length
+  )
+
+  if (!episodeWithReadingCase) {
+    throw new Error('No episodes with reading cases found')
+  }
+
   const params = {
     clinicId: clinic.id,
     id: clinic.id,
     appointmentId: appointment.id,
     participantId: appointment.participantId,
     episodeId: appointment.episodeId,
+    caseId: episodeWithReadingCase.readingCases[0].id,
     // Filters and views are named tabs; "all" exists on every set of them
     filter: 'all',
     view: 'all',
+    // The reading case view's tabs - "reads" exercises more than the default
+    tab: 'reads',
     // A medical history type, by slug
     type: 'breast-cancer'
   }


### PR DESCRIPTION
Phase 0 of the arbitration work. Adds `/reading/cases`, a backlog listing cases across every state with filters (scope, state, deferred) and search, and `/reading/cases/:caseId`, a case view with summary/reads/annotations tabs. Wired from the episode page's reading table. Works against today's state vocabulary, no confirmation step yet.

- Reads are collapsed behind a disclosure, reusing `read-summary.njk`
- Annotations are pooled across reads onto shared images with continuous numbering, so two readers' marks on the same spot are visible together
- Adds `getClinicLocationName` to `clinics.js` and reading-case states to the `readingState` tag vocabulary
