### PR TITLE
Add read finalisation and the arbitration backlog

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -116,7 +116,7 @@ const defaultSettings = {
     secondReaderComparison: 'off', // 'early' | 'late' | 'off'
     compareWhen: 'non_normal', // 'non_normal' | 'discordant_only'
     arbitrationPolicy: 'discordant_only', // 'discordant_only' | 'all_recalls' | 'all_non_normal'
-    confirmationDelay: '60', // minutes before reads auto-confirm; '0' immediate | 'never' manual only
+    finalisationDelay: '60', // minutes before reads auto-finalise; '0' immediate | 'never' manual only
     lazySessions: 'true',
     defaultSessionSize: '25'
   }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -115,7 +115,7 @@ const defaultSettings = {
     annotationsMode: 'with-images-simple', // 'without-images' | 'with-images-simple' | 'with-images' | 'with-images-progressive'
     secondReaderComparison: 'off', // 'early' | 'late' | 'off'
     compareWhen: 'non_normal', // 'non_normal' | 'discordant_only'
-    arbitrationPolicy: 'discordant_only', // 'discordant_only' | 'all_non_normal'
+    arbitrationPolicy: 'discordant_only', // 'discordant_only' | 'all_recalls' | 'all_non_normal'
     confirmationDelay: '60', // minutes before reads auto-confirm; '0' immediate | 'never' manual only
     lazySessions: 'true',
     defaultSessionSize: '25'

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -116,6 +116,7 @@ const defaultSettings = {
     secondReaderComparison: 'off', // 'early' | 'late' | 'off'
     compareWhen: 'non_normal', // 'non_normal' | 'discordant_only'
     arbitrationPolicy: 'discordant_only', // 'discordant_only' | 'all_non_normal'
+    confirmationDelay: '60', // minutes before reads auto-confirm; '0' immediate | 'never' manual only
     lazySessions: 'true',
     defaultSessionSize: '25'
   }

--- a/app/lib/generate-seed-data.js
+++ b/app/lib/generate-seed-data.js
@@ -453,13 +453,20 @@ const seedTechnicalRecallRescreen = ({
     // rather than adding to them - buildRead types a read from where the case
     // had got to, and against the existing reads this would come out as an
     // arbitration read
-    const firstRead = buildRead(
-      { ...readingCase, reads: [] },
-      firstReader.id,
-      firstReader.role,
-      generatedRead,
-      { timestamp: readAt.add(1, 'day').toISOString() }
-    )
+    const firstRead = {
+      ...buildRead(
+        { ...readingCase, reads: [] },
+        firstReader.id,
+        firstReader.role,
+        generatedRead,
+        { timestamp: readAt.add(1, 'day').toISOString() }
+      ),
+      // Confirmed explicitly: these reads can be dated ahead of now, so the
+      // technical-recall outcome (and the re-screen owed on it) must not
+      // depend on the confirmation delay having passed
+      confirmedAt: readAt.add(1, 'day').toISOString(),
+      confirmedBy: firstReader.id
+    }
 
     // The second read has to agree with the first, down to which views need
     // retaking - two technical recalls flagging different views count as
@@ -470,7 +477,9 @@ const seedTechnicalRecallRescreen = ({
       readerType: secondReader.role,
       readType: 'second',
       readNumber: 2,
-      timestamp: readAt.add(2, 'day').toISOString()
+      timestamp: readAt.add(2, 'day').toISOString(),
+      confirmedAt: readAt.add(2, 'day').toISOString(),
+      confirmedBy: secondReader.id
     }
 
     readingCase.reads = [firstRead, secondRead]

--- a/app/lib/generate-seed-data.js
+++ b/app/lib/generate-seed-data.js
@@ -461,11 +461,11 @@ const seedTechnicalRecallRescreen = ({
         generatedRead,
         { timestamp: readAt.add(1, 'day').toISOString() }
       ),
-      // Confirmed explicitly: these reads can be dated ahead of now, so the
+      // Finalised explicitly: these reads can be dated ahead of now, so the
       // technical-recall outcome (and the re-screen owed on it) must not
-      // depend on the confirmation delay having passed
-      confirmedAt: readAt.add(1, 'day').toISOString(),
-      confirmedBy: firstReader.id
+      // depend on the finalisation delay having passed
+      finalisedAt: readAt.add(1, 'day').toISOString(),
+      finalisedBy: firstReader.id
     }
 
     // The second read has to agree with the first, down to which views need
@@ -478,8 +478,8 @@ const seedTechnicalRecallRescreen = ({
       readType: 'second',
       readNumber: 2,
       timestamp: readAt.add(2, 'day').toISOString(),
-      confirmedAt: readAt.add(2, 'day').toISOString(),
-      confirmedBy: secondReader.id
+      finalisedAt: readAt.add(2, 'day').toISOString(),
+      finalisedBy: secondReader.id
     }
 
     readingCase.reads = [firstRead, secondRead]

--- a/app/lib/generators/episode-generator.js
+++ b/app/lib/generators/episode-generator.js
@@ -209,7 +209,10 @@ const buildHistoricReadingCase = ({
     readerType: reader.role,
     readType,
     readNumber,
-    timestamp: timestamp.toISOString()
+    timestamp: timestamp.toISOString(),
+    // A settled past round's reads were confirmed at the time
+    confirmedAt: timestamp.add(30, 'minute').toISOString(),
+    confirmedBy: reader.id
   })
 
   // When it went to arbitration the two readers disagreed, so one of them said
@@ -684,6 +687,14 @@ const checkEpisodes = (episodes, appointmentsById) => {
             `historic episode ${episode.id} ended in treatment but was read as "${readingOutcome}"`
           )
         }
+        // A settled past round's reads were all confirmed at the time
+        getReadsAsArray(readingCase).forEach((read) => {
+          if (!read.confirmedAt) {
+            problems.push(
+              `historic reading case ${readingCase.id} has an unconfirmed read`
+            )
+          }
+        })
         // Two readers, or three where they disagreed and one arbitrated
         const historicReadCount = getReadsAsArray(readingCase).length
         if (historicReadCount !== 2 && historicReadCount !== 3) {
@@ -756,6 +767,20 @@ const checkEpisodes = (episodes, appointmentsById) => {
           `reading case ${readingCase.id} has an arbitration read without two prior reads`
         )
       }
+      // Confirmation coherence: a confirmation is one act with two halves,
+      // and nothing confirms a read before it was made
+      reads.forEach((read) => {
+        if (Boolean(read.confirmedAt) !== Boolean(read.confirmedBy)) {
+          problems.push(
+            `read by ${read.readerId} on case ${readingCase.id} has half a confirmation record`
+          )
+        }
+        if (read.confirmedAt && read.confirmedAt < read.timestamp) {
+          problems.push(
+            `read by ${read.readerId} on case ${readingCase.id} was confirmed before it was read`
+          )
+        }
+      })
       if (new Set(reads.map((read) => read.readerId)).size !== reads.length) {
         problems.push(
           `reading case ${readingCase.id} has the same reader twice`

--- a/app/lib/generators/episode-generator.js
+++ b/app/lib/generators/episode-generator.js
@@ -210,9 +210,9 @@ const buildHistoricReadingCase = ({
     readType,
     readNumber,
     timestamp: timestamp.toISOString(),
-    // A settled past round's reads were confirmed at the time
-    confirmedAt: timestamp.add(30, 'minute').toISOString(),
-    confirmedBy: reader.id
+    // A settled past round's reads were finalised at the time
+    finalisedAt: timestamp.add(30, 'minute').toISOString(),
+    finalisedBy: reader.id
   })
 
   // When it went to arbitration the two readers disagreed, so one of them said
@@ -687,11 +687,11 @@ const checkEpisodes = (episodes, appointmentsById) => {
             `historic episode ${episode.id} ended in treatment but was read as "${readingOutcome}"`
           )
         }
-        // A settled past round's reads were all confirmed at the time
+        // A settled past round's reads were all finalised at the time
         getReadsAsArray(readingCase).forEach((read) => {
-          if (!read.confirmedAt) {
+          if (!read.finalisedAt) {
             problems.push(
-              `historic reading case ${readingCase.id} has an unconfirmed read`
+              `historic reading case ${readingCase.id} has an unfinalised read`
             )
           }
         })
@@ -767,17 +767,17 @@ const checkEpisodes = (episodes, appointmentsById) => {
           `reading case ${readingCase.id} has an arbitration read without two prior reads`
         )
       }
-      // Confirmation coherence: a confirmation is one act with two halves,
-      // and nothing confirms a read before it was made
+      // Finalisation coherence: a finalisation is one act with two halves,
+      // and nothing finalises a read before it was made
       reads.forEach((read) => {
-        if (Boolean(read.confirmedAt) !== Boolean(read.confirmedBy)) {
+        if (Boolean(read.finalisedAt) !== Boolean(read.finalisedBy)) {
           problems.push(
-            `read by ${read.readerId} on case ${readingCase.id} has half a confirmation record`
+            `read by ${read.readerId} on case ${readingCase.id} has half a finalisation record`
           )
         }
-        if (read.confirmedAt && read.confirmedAt < read.timestamp) {
+        if (read.finalisedAt && read.finalisedAt < read.timestamp) {
           problems.push(
-            `read by ${read.readerId} on case ${readingCase.id} was confirmed before it was read`
+            `read by ${read.readerId} on case ${readingCase.id} was finalised before it was read`
           )
         }
       })

--- a/app/lib/generators/reading-generator.js
+++ b/app/lib/generators/reading-generator.js
@@ -363,6 +363,16 @@ const addRead = (readingCase, appointment, reader, timestamp, options = {}) => {
     timestamp
   })
 
+  // A read old enough would have been confirmed by now, so record it as such.
+  // Recent reads stay unconfirmed - they are what the confirmation flow (and
+  // the awaiting_confirmation state) has to work on.
+  if (dayjs(timestamp).isBefore(dayjs().subtract(24, 'hour'))) {
+    read.confirmedAt = dayjs(timestamp)
+      .add(faker.number.int({ min: 15, max: 45 }), 'minute')
+      .toISOString()
+    read.confirmedBy = reader.id
+  }
+
   const existingIndex = readingCase.reads.findIndex(
     (candidate) => candidate.readerId === reader.id
   )

--- a/app/lib/generators/reading-generator.js
+++ b/app/lib/generators/reading-generator.js
@@ -363,14 +363,14 @@ const addRead = (readingCase, appointment, reader, timestamp, options = {}) => {
     timestamp
   })
 
-  // A read old enough would have been confirmed by now, so record it as such.
-  // Recent reads stay unconfirmed - they are what the confirmation flow (and
-  // the awaiting_confirmation state) has to work on.
+  // A read old enough would have been finalised by now, so record it as such.
+  // Recent reads stay unfinalised - they are what the finalisation flow (and
+  // the awaiting_finalisation state) has to work on.
   if (dayjs(timestamp).isBefore(dayjs().subtract(24, 'hour'))) {
-    read.confirmedAt = dayjs(timestamp)
+    read.finalisedAt = dayjs(timestamp)
       .add(faker.number.int({ min: 15, max: 45 }), 'minute')
       .toISOString()
-    read.confirmedBy = reader.id
+    read.finalisedBy = reader.id
   }
 
   const existingIndex = readingCase.reads.findIndex(

--- a/app/lib/utils/episodes.js
+++ b/app/lib/utils/episodes.js
@@ -709,12 +709,12 @@ const advanceEpisodeForAppointmentStatus = (data, appointment) => {
  * Move an appointment's episode to wherever its reading outcome leaves it.
  *
  * Deliberately NOT called when a read is saved. Two opinions and a computed
- * outcome is not a confirmed result: there is no confirmation step in the
+ * outcome is not a finalised result: there is no finalisation step in the
  * app yet, so writing a read leaves the episode in `reading`. This is what
- * that confirmation step should call once it exists.
+ * that finalisation step should call once it exists.
  *
  * The seed generator uses the same map to settle rounds read long enough ago
- * that they would have been confirmed by now.
+ * that they would have been finalised by now.
  *
  * @param {object} data - Session data
  * @param {object} appointment - The appointment that was read

--- a/app/lib/utils/reading-cases.js
+++ b/app/lib/utils/reading-cases.js
@@ -29,14 +29,20 @@ const READ_TYPES = ['first', 'second', 'arbitration']
 // Where a case has got to. Derived from its reads plus the acts recorded on it
 // - never stored, so it can't drift from the reads it describes.
 //
-// `arbitration_required` and `in_arbitration` are deliberately different
-// states: reads disagreeing is what makes arbitration *necessary*, but a case
-// only becomes arbitratable once someone releases it. Nothing performs that
-// release yet, so no case reaches `in_arbitration` today.
+// Two reads are not a result by themselves: the result becomes real once the
+// reads are confirmed - explicitly by the reader, or automatically when the
+// confirmation delay passes. `awaiting_confirmation` is that gap. A case whose
+// destination is arbitration is still `awaiting_confirmation` until then - the
+// destination is a fact about the case (see getReadingCaseStatus), not a
+// separate state.
+//
+// `in_arbitration` is reserved for a future claim/lock - a case being actively
+// worked in an arbitration session. Nothing sets it yet.
 const READING_CASE_STATES = [
   'awaiting_first_read',
   'awaiting_second_read',
-  'arbitration_required',
+  'awaiting_confirmation',
+  'awaiting_arbitration',
   'in_arbitration',
   'concluded'
 ]
@@ -303,6 +309,50 @@ const willGoToArbitration = (readA, readB, settings = {}) => {
 }
 
 /**
+ * Whether a read is confirmed.
+ *
+ * Confirmation happens two ways: the reader confirms it (confirmedAt is
+ * written), or the confirmation delay passes and it confirms itself. The
+ * delay comes from settings.reading.confirmationDelay - minutes as a string,
+ * '0' meaning immediately, 'never' meaning only ever manually.
+ *
+ * @param {object} read - The read
+ * @param {object} [settings] - Site settings object (data.settings)
+ * @param {Date | string} [now] - The time to judge auto-confirmation against;
+ *   defaults to the real now
+ * @returns {boolean}
+ */
+const isReadConfirmed = (read, settings = {}, now = null) => {
+  if (!read) return false
+  if (read.confirmedAt) return true
+
+  const delay = settings?.reading?.confirmationDelay ?? '60'
+  if (delay === 'never') return false
+  if (!read.timestamp) return false
+
+  const delayMinutes = parseInt(delay, 10)
+  if (Number.isNaN(delayMinutes)) return false
+
+  const confirmsAt = new Date(read.timestamp).getTime() + delayMinutes * 60000
+  const judgedAt = now ? new Date(now).getTime() : Date.now()
+  return judgedAt >= confirmsAt
+}
+
+/**
+ * Whether every read on a case is confirmed
+ *
+ * @param {object} readingCase - Reading case
+ * @param {object} [settings] - Site settings object (data.settings)
+ * @param {Date | string} [now] - The time to judge auto-confirmation against
+ * @returns {boolean}
+ */
+const areAllReadsConfirmed = (readingCase, settings = {}, now = null) => {
+  return getReadsAsArray(readingCase).every((read) =>
+    isReadConfirmed(read, settings, now)
+  )
+}
+
+/**
  * Where a case has got to.
  *
  * Deferral and outstanding priors are not states here - both hold a case up
@@ -311,9 +361,10 @@ const willGoToArbitration = (readA, readB, settings = {}) => {
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
+ * @param {Date | string} [now] - The time to judge auto-confirmation against
  * @returns {string} One of READING_CASE_STATES
  */
-const getReadingCaseState = (readingCase, settings = {}) => {
+const getReadingCaseState = (readingCase, settings = {}, now = null) => {
   const reads = getReadsAsArray(readingCase)
 
   if (reads.length === 0) return 'awaiting_first_read'
@@ -322,12 +373,15 @@ const getReadingCaseState = (readingCase, settings = {}) => {
   // An arbitration read settles the case whatever the first two said
   if (getArbitrationRead(readingCase)) return 'concluded'
 
+  // Two opinions are not a result until they are confirmed
+  if (!areAllReadsConfirmed(readingCase, settings, now)) {
+    return 'awaiting_confirmation'
+  }
+
   const [firstRead, secondRead] = reads
 
   if (willGoToArbitration(firstRead, secondRead, settings)) {
-    return isCaseInArbitration(readingCase)
-      ? 'in_arbitration'
-      : 'arbitration_required'
+    return 'awaiting_arbitration'
   }
 
   return 'concluded'
@@ -341,10 +395,13 @@ const getReadingCaseState = (readingCase, settings = {}) => {
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
+ * @param {Date | string} [now] - The time to judge auto-confirmation against
  * @returns {string | null} One of READING_CASE_OUTCOMES, or null
  */
-const getReadingCaseOutcome = (readingCase, settings = {}) => {
-  if (getReadingCaseState(readingCase, settings) !== 'concluded') return null
+const getReadingCaseOutcome = (readingCase, settings = {}, now = null) => {
+  if (getReadingCaseState(readingCase, settings, now) !== 'concluded') {
+    return null
+  }
 
   // Arbitration, where it happened, is the deciding read
   const arbitrationRead = getArbitrationRead(readingCase)
@@ -352,6 +409,46 @@ const getReadingCaseOutcome = (readingCase, settings = {}) => {
 
   // Otherwise the two reads agreed, so either one gives the answer
   return getReadsAsArray(readingCase)[0]?.opinion || null
+}
+
+/**
+ * The facts about where a case stands, for composing status displays.
+ *
+ * Facts rather than labels, so "awaiting confirmation, then arbitration" is
+ * one state with a destination instead of a fourth state - willArbitrate is
+ * just willGoToArbitration asked as soon as two reads exist, rather than at
+ * confirmation.
+ *
+ * getReadingCaseOutcome stays strict (null until concluded);
+ * provisionalOutcome is what the outcome will be once the reads confirm,
+ * where that can already be said.
+ *
+ * @param {object} readingCase - Reading case
+ * @param {object} [settings] - Site settings object (data.settings)
+ * @param {Date | string} [now] - The time to judge auto-confirmation against
+ * @returns {{state: string, confirmed: boolean, willArbitrate: boolean, provisionalOutcome: string | null}}
+ */
+const getReadingCaseStatus = (readingCase, settings = {}, now = null) => {
+  const reads = getReadsAsArray(readingCase)
+  const arbitrationRead = getArbitrationRead(readingCase)
+
+  const willArbitrate = Boolean(
+    reads.length >= 2 &&
+      !arbitrationRead &&
+      willGoToArbitration(reads[0], reads[1], settings)
+  )
+
+  const provisionalOutcome =
+    arbitrationRead?.opinion ||
+    (reads.length >= 2 && !willArbitrate ? reads[0]?.opinion || null : null)
+
+  return {
+    state: getReadingCaseState(readingCase, settings, now),
+    confirmed:
+      reads.length >= 2 && areAllReadsConfirmed(readingCase, settings, now),
+    willArbitrate,
+    provisionalOutcome
+  }
 }
 
 /**
@@ -406,14 +503,15 @@ const caseNeedsSecondRead = (readingCase) => {
 }
 
 /**
- * Whether a case needs arbitrating but hasn't been released into it
+ * Whether a case sits in the arbitration backlog - confirmed reads whose
+ * result the rules send to arbitration, not yet claimed by anyone
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
  * @returns {boolean}
  */
 const caseNeedsArbitration = (readingCase, settings = {}) => {
-  return getReadingCaseState(readingCase, settings) === 'arbitration_required'
+  return getReadingCaseState(readingCase, settings) === 'awaiting_arbitration'
 }
 
 /**
@@ -631,8 +729,11 @@ module.exports = {
   willGoToArbitration,
   getComparisonInfo,
   shouldShowComparePage,
+  isReadConfirmed,
+  areAllReadsConfirmed,
   getReadingCaseState,
   getReadingCaseOutcome,
+  getReadingCaseStatus,
   getReadingMetadata,
   caseNeedsFirstRead,
   caseNeedsSecondRead,

--- a/app/lib/utils/reading-cases.js
+++ b/app/lib/utils/reading-cases.js
@@ -286,6 +286,7 @@ const areReadsDiscordant = (readA, readB) => {
  *
  * Policies (from settings.reading.arbitrationPolicy):
  * - 'discordant_only' (default): only discordant reads need arbitration
+ * - 'all_recalls': concordant recalls for assessment do too
  * - 'all_non_normal': any concordant non-normal outcome does too
  *
  * @param {object} readA - First read
@@ -303,6 +304,9 @@ const willGoToArbitration = (readA, readB, settings = {}) => {
   const policy = settings?.reading?.arbitrationPolicy || 'discordant_only'
   if (policy === 'all_non_normal') {
     return readA.opinion !== 'normal'
+  }
+  if (policy === 'all_recalls') {
+    return readA.opinion === 'recall_for_assessment'
   }
 
   return false

--- a/app/lib/utils/reading-cases.js
+++ b/app/lib/utils/reading-cases.js
@@ -691,6 +691,33 @@ const withRead = (readingCase, read) => {
 }
 
 /**
+ * Mark a user's read on a case as confirmed, returning a new case record.
+ *
+ * Already-confirmed reads are left alone, so the original confirmation
+ * record survives a repeat call.
+ *
+ * @param {object} readingCase - The case
+ * @param {string} userId - Whose read to confirm
+ * @param {object} [options] - Options
+ * @param {string} [options.confirmedAt] - When; defaults to now
+ * @param {string} [options.confirmedBy] - Who confirmed it; defaults to the reader
+ * @returns {object} A new case record with the confirmation applied
+ */
+const withReadConfirmed = (readingCase, userId, options = {}) => {
+  const reads = getReadsAsArray(readingCase).map((read) =>
+    read.readerId === userId && !read.confirmedAt
+      ? {
+          ...read,
+          confirmedAt: options.confirmedAt || new Date().toISOString(),
+          confirmedBy: options.confirmedBy || userId
+        }
+      : read
+  )
+
+  return { ...readingCase, reads }
+}
+
+/**
  * Remove a user's read from a case, returning a new case record.
  *
  * Deferring after giving an opinion withdraws that opinion - the reader is
@@ -741,5 +768,6 @@ module.exports = {
   canUserReadCase,
   buildRead,
   withRead,
+  withReadConfirmed,
   withoutRead
 }

--- a/app/lib/utils/reading-cases.js
+++ b/app/lib/utils/reading-cases.js
@@ -30,9 +30,9 @@ const READ_TYPES = ['first', 'second', 'arbitration']
 // - never stored, so it can't drift from the reads it describes.
 //
 // Two reads are not a result by themselves: the result becomes real once the
-// reads are confirmed - explicitly by the reader, or automatically when the
-// confirmation delay passes. `awaiting_confirmation` is that gap. A case whose
-// destination is arbitration is still `awaiting_confirmation` until then - the
+// reads are finalised - explicitly by the reader, or automatically when the
+// finalisation delay passes. `awaiting_finalisation` is that gap. A case whose
+// destination is arbitration is still `awaiting_finalisation` until then - the
 // destination is a fact about the case (see getReadingCaseStatus), not a
 // separate state.
 //
@@ -41,7 +41,7 @@ const READ_TYPES = ['first', 'second', 'arbitration']
 const READING_CASE_STATES = [
   'awaiting_first_read',
   'awaiting_second_read',
-  'awaiting_confirmation',
+  'awaiting_finalisation',
   'awaiting_arbitration',
   'in_arbitration',
   'concluded'
@@ -313,46 +313,46 @@ const willGoToArbitration = (readA, readB, settings = {}) => {
 }
 
 /**
- * Whether a read is confirmed.
+ * Whether a read is finalised.
  *
- * Confirmation happens two ways: the reader confirms it (confirmedAt is
- * written), or the confirmation delay passes and it confirms itself. The
- * delay comes from settings.reading.confirmationDelay - minutes as a string,
+ * Finalisation happens two ways: the reader finalises it (finalisedAt is
+ * written), or the finalisation delay passes and it finalises itself. The
+ * delay comes from settings.reading.finalisationDelay - minutes as a string,
  * '0' meaning immediately, 'never' meaning only ever manually.
  *
  * @param {object} read - The read
  * @param {object} [settings] - Site settings object (data.settings)
- * @param {Date | string} [now] - The time to judge auto-confirmation against;
+ * @param {Date | string} [now] - The time to judge auto-finalisation against;
  *   defaults to the real now
  * @returns {boolean}
  */
-const isReadConfirmed = (read, settings = {}, now = null) => {
+const isReadFinalised = (read, settings = {}, now = null) => {
   if (!read) return false
-  if (read.confirmedAt) return true
+  if (read.finalisedAt) return true
 
-  const delay = settings?.reading?.confirmationDelay ?? '60'
+  const delay = settings?.reading?.finalisationDelay ?? '60'
   if (delay === 'never') return false
   if (!read.timestamp) return false
 
   const delayMinutes = parseInt(delay, 10)
   if (Number.isNaN(delayMinutes)) return false
 
-  const confirmsAt = new Date(read.timestamp).getTime() + delayMinutes * 60000
+  const finalisesAt = new Date(read.timestamp).getTime() + delayMinutes * 60000
   const judgedAt = now ? new Date(now).getTime() : Date.now()
-  return judgedAt >= confirmsAt
+  return judgedAt >= finalisesAt
 }
 
 /**
- * Whether every read on a case is confirmed
+ * Whether every read on a case is finalised
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
- * @param {Date | string} [now] - The time to judge auto-confirmation against
+ * @param {Date | string} [now] - The time to judge auto-finalisation against
  * @returns {boolean}
  */
-const areAllReadsConfirmed = (readingCase, settings = {}, now = null) => {
+const areAllReadsFinalised = (readingCase, settings = {}, now = null) => {
   return getReadsAsArray(readingCase).every((read) =>
-    isReadConfirmed(read, settings, now)
+    isReadFinalised(read, settings, now)
   )
 }
 
@@ -365,7 +365,7 @@ const areAllReadsConfirmed = (readingCase, settings = {}, now = null) => {
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
- * @param {Date | string} [now] - The time to judge auto-confirmation against
+ * @param {Date | string} [now] - The time to judge auto-finalisation against
  * @returns {string} One of READING_CASE_STATES
  */
 const getReadingCaseState = (readingCase, settings = {}, now = null) => {
@@ -377,9 +377,9 @@ const getReadingCaseState = (readingCase, settings = {}, now = null) => {
   // An arbitration read settles the case whatever the first two said
   if (getArbitrationRead(readingCase)) return 'concluded'
 
-  // Two opinions are not a result until they are confirmed
-  if (!areAllReadsConfirmed(readingCase, settings, now)) {
-    return 'awaiting_confirmation'
+  // Two opinions are not a result until they are finalised
+  if (!areAllReadsFinalised(readingCase, settings, now)) {
+    return 'awaiting_finalisation'
   }
 
   const [firstRead, secondRead] = reads
@@ -399,7 +399,7 @@ const getReadingCaseState = (readingCase, settings = {}, now = null) => {
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
- * @param {Date | string} [now] - The time to judge auto-confirmation against
+ * @param {Date | string} [now] - The time to judge auto-finalisation against
  * @returns {string | null} One of READING_CASE_OUTCOMES, or null
  */
 const getReadingCaseOutcome = (readingCase, settings = {}, now = null) => {
@@ -418,19 +418,19 @@ const getReadingCaseOutcome = (readingCase, settings = {}, now = null) => {
 /**
  * The facts about where a case stands, for composing status displays.
  *
- * Facts rather than labels, so "awaiting confirmation, then arbitration" is
+ * Facts rather than labels, so "awaiting finalisation, then arbitration" is
  * one state with a destination instead of a fourth state - willArbitrate is
  * just willGoToArbitration asked as soon as two reads exist, rather than at
- * confirmation.
+ * finalisation.
  *
  * getReadingCaseOutcome stays strict (null until concluded);
- * provisionalOutcome is what the outcome will be once the reads confirm,
+ * provisionalOutcome is what the outcome will be once the reads finalise,
  * where that can already be said.
  *
  * @param {object} readingCase - Reading case
  * @param {object} [settings] - Site settings object (data.settings)
- * @param {Date | string} [now] - The time to judge auto-confirmation against
- * @returns {{state: string, confirmed: boolean, willArbitrate: boolean, provisionalOutcome: string | null}}
+ * @param {Date | string} [now] - The time to judge auto-finalisation against
+ * @returns {{state: string, finalised: boolean, willArbitrate: boolean, provisionalOutcome: string | null}}
  */
 const getReadingCaseStatus = (readingCase, settings = {}, now = null) => {
   const reads = getReadsAsArray(readingCase)
@@ -448,8 +448,8 @@ const getReadingCaseStatus = (readingCase, settings = {}, now = null) => {
 
   return {
     state: getReadingCaseState(readingCase, settings, now),
-    confirmed:
-      reads.length >= 2 && areAllReadsConfirmed(readingCase, settings, now),
+    finalised:
+      reads.length >= 2 && areAllReadsFinalised(readingCase, settings, now),
     willArbitrate,
     provisionalOutcome
   }
@@ -507,7 +507,7 @@ const caseNeedsSecondRead = (readingCase) => {
 }
 
 /**
- * Whether a case sits in the arbitration backlog - confirmed reads whose
+ * Whether a case sits in the arbitration backlog - finalised reads whose
  * result the rules send to arbitration, not yet claimed by anyone
  *
  * @param {object} readingCase - Reading case
@@ -695,25 +695,25 @@ const withRead = (readingCase, read) => {
 }
 
 /**
- * Mark a user's read on a case as confirmed, returning a new case record.
+ * Mark a user's read on a case as finalised, returning a new case record.
  *
- * Already-confirmed reads are left alone, so the original confirmation
+ * Already-finalised reads are left alone, so the original finalisation
  * record survives a repeat call.
  *
  * @param {object} readingCase - The case
- * @param {string} userId - Whose read to confirm
+ * @param {string} userId - Whose read to finalise
  * @param {object} [options] - Options
- * @param {string} [options.confirmedAt] - When; defaults to now
- * @param {string} [options.confirmedBy] - Who confirmed it; defaults to the reader
- * @returns {object} A new case record with the confirmation applied
+ * @param {string} [options.finalisedAt] - When; defaults to now
+ * @param {string} [options.finalisedBy] - Who finalised it; defaults to the reader
+ * @returns {object} A new case record with the finalisation applied
  */
-const withReadConfirmed = (readingCase, userId, options = {}) => {
+const withReadFinalised = (readingCase, userId, options = {}) => {
   const reads = getReadsAsArray(readingCase).map((read) =>
-    read.readerId === userId && !read.confirmedAt
+    read.readerId === userId && !read.finalisedAt
       ? {
           ...read,
-          confirmedAt: options.confirmedAt || new Date().toISOString(),
-          confirmedBy: options.confirmedBy || userId
+          finalisedAt: options.finalisedAt || new Date().toISOString(),
+          finalisedBy: options.finalisedBy || userId
         }
       : read
   )
@@ -760,8 +760,8 @@ module.exports = {
   willGoToArbitration,
   getComparisonInfo,
   shouldShowComparePage,
-  isReadConfirmed,
-  areAllReadsConfirmed,
+  isReadFinalised,
+  areAllReadsFinalised,
   getReadingCaseState,
   getReadingCaseOutcome,
   getReadingCaseStatus,
@@ -772,6 +772,6 @@ module.exports = {
   canUserReadCase,
   buildRead,
   withRead,
-  withReadConfirmed,
+  withReadFinalised,
   withoutRead
 }

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -302,10 +302,10 @@ const calculateReadingMetrics = function (
   // Count cases that are ready for second read (have first read but not second)
   const secondReadReady = cases.filter(caseNeedsSecondRead).length
 
-  // Count cases needing arbitration (policy-aware via the case state)
+  // Count cases in the arbitration backlog (policy-aware via the case state)
   const arbitrationCount = cases.filter(
     (readingCase) =>
-      getReadingCaseState(readingCase, settings) === 'arbitration_required'
+      getReadingCaseState(readingCase, settings) === 'awaiting_arbitration'
   ).length
 
   // Global awaiting priors count (appointments with any outstanding prior request)

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -26,7 +26,7 @@ const {
   getReadingMetadata,
   getReadingCaseState,
   getReadingCaseOutcome,
-  isReadConfirmed,
+  isReadFinalised,
   isCaseDeferred,
   caseHasReads,
   caseNeedsFirstRead,
@@ -35,7 +35,7 @@ const {
   userHasReadCase,
   buildRead,
   withRead,
-  withReadConfirmed
+  withReadFinalised
 } = require('./reading-cases')
 
 /************************************************************************
@@ -87,8 +87,8 @@ const writeReading = (data, appointment, userId, reading, sessionId = null) => {
   updateReadingCase(data, appointment.episodeId, updatedCase)
 
   // Note the episode deliberately stays in `reading`. Two opinions and a
-  // computed outcome is not a confirmed result - the episode moves on when
-  // the reads are confirmed (see confirmUserReadsForSession below).
+  // computed outcome is not a finalised result - the episode moves on when
+  // the reads are finalised (see finaliseUserReadsForSession below).
 
   // If we have session context, remove this appointment from skipped appointments
   // (readingSessions is per-session working data, so in-place edits are fine)
@@ -106,19 +106,19 @@ const writeReading = (data, appointment, userId, reading, sessionId = null) => {
 }
 
 /**
- * The user's not-yet-confirmed reads in a session, each with the appointment
- * and case it belongs to. The session-complete panel's count and the confirm
+ * The user's not-yet-finalised reads in a session, each with the appointment
+ * and case it belongs to. The session-complete panel's count and the finalise
  * action both work from this.
  *
- * "Not yet confirmed" means not confirmed either way: no explicit confirmedAt,
- * and the auto-confirmation delay hasn't passed.
+ * "Not yet finalised" means not finalised either way: no explicit finalisedAt,
+ * and the auto-finalisation delay hasn't passed.
  *
  * @param {object} data - Session data
  * @param {string} sessionId - Reading session ID
  * @param {string} userId - User ID
  * @returns {Array<{appointment: object, readingCase: object, read: object}>}
  */
-const getUnconfirmedUserReadsForSession = (data, sessionId, userId) => {
+const getUnfinalisedUserReadsForSession = (data, sessionId, userId) => {
   const session = data.readingSessions?.[sessionId]
   if (!session || !userId) return []
 
@@ -133,7 +133,7 @@ const getUnconfirmedUserReadsForSession = (data, sessionId, userId) => {
     const readingCase = getReadingCase(data, appointment)
     const read = getReadForUser(readingCase, userId)
     if (!read) continue
-    if (isReadConfirmed(read, data.settings)) continue
+    if (isReadFinalised(read, data.settings)) continue
 
     results.push({ appointment, readingCase, read })
   }
@@ -142,12 +142,12 @@ const getUnconfirmedUserReadsForSession = (data, sessionId, userId) => {
 }
 
 /**
- * Confirm the user's outstanding reads from a session, and settle what each
- * confirmation makes true: a case whose confirmed reads the rules send to
+ * Finalise the user's outstanding reads from a session, and settle what each
+ * finalisation makes true: a case whose finalised reads the rules send to
  * arbitration gets its release recorded, and a case that concludes moves its
  * episode on.
  *
- * Auto-confirmation (the delay passing) has no moment like this - a case can
+ * Auto-finalisation (the delay passing) has no moment like this - a case can
  * conclude by time alone without anything recording the release or advancing
  * the episode. The state stays honest because it is derived; the acts are only
  * recorded where there is an act to record.
@@ -155,24 +155,24 @@ const getUnconfirmedUserReadsForSession = (data, sessionId, userId) => {
  * @param {object} data - Session data
  * @param {string} sessionId - Reading session ID
  * @param {string} userId - User ID
- * @returns {{confirmedCount: number, releasedCount: number, concludedCount: number}}
+ * @returns {{finalisedCount: number, releasedCount: number, concludedCount: number}}
  */
-const confirmUserReadsForSession = (data, sessionId, userId) => {
-  const unconfirmed = getUnconfirmedUserReadsForSession(data, sessionId, userId)
-  const confirmedAt = new Date().toISOString()
+const finaliseUserReadsForSession = (data, sessionId, userId) => {
+  const unfinalised = getUnfinalisedUserReadsForSession(data, sessionId, userId)
+  const finalisedAt = new Date().toISOString()
 
   let releasedCount = 0
   let concludedCount = 0
 
-  for (const { appointment, readingCase } of unconfirmed) {
-    let updatedCase = withReadConfirmed(readingCase, userId, {
-      confirmedAt,
-      confirmedBy: userId
+  for (const { appointment, readingCase } of unfinalised) {
+    let updatedCase = withReadFinalised(readingCase, userId, {
+      finalisedAt,
+      finalisedBy: userId
     })
 
     const state = getReadingCaseState(updatedCase, data.settings)
 
-    // Both reads confirmed and the rules send it to arbitration: record the
+    // Both reads finalised and the rules send it to arbitration: record the
     // release into the backlog (see isCaseInArbitration)
     if (
       state === 'awaiting_arbitration' &&
@@ -180,14 +180,14 @@ const confirmUserReadsForSession = (data, sessionId, userId) => {
     ) {
       updatedCase = {
         ...updatedCase,
-        arbitration: { releasedAt: confirmedAt, releasedBy: userId }
+        arbitration: { releasedAt: finalisedAt, releasedBy: userId }
       }
       releasedCount++
     }
 
     updateReadingCase(data, appointment.episodeId, updatedCase)
 
-    // A confirmed conclusion is a real result, so the episode moves on
+    // A finalised conclusion is a real result, so the episode moves on
     if (state === 'concluded') {
       advanceEpisodeForReadingOutcome(
         data,
@@ -198,7 +198,7 @@ const confirmUserReadsForSession = (data, sessionId, userId) => {
     }
   }
 
-  return { confirmedCount: unconfirmed.length, releasedCount, concludedCount }
+  return { finalisedCount: unfinalised.length, releasedCount, concludedCount }
 }
 
 /**
@@ -1567,8 +1567,8 @@ module.exports = {
   // Single appointment
   getAppointmentReadingMetadata,
   writeReading,
-  getUnconfirmedUserReadsForSession,
-  confirmUserReadsForSession,
+  getUnfinalisedUserReadsForSession,
+  finaliseUserReadsForSession,
   getEpisodeReadingStatus,
   getDeferredCases,
   getResolvedDeferrals,

--- a/app/lib/utils/reading.js
+++ b/app/lib/utils/reading.js
@@ -17,13 +17,16 @@ const { awaitingPriors, userRequestedPriors } = require('./prior-mammograms')
 const {
   getReadingCase,
   getEpisodeAppointments,
-  updateReadingCase
+  updateReadingCase,
+  advanceEpisodeForReadingOutcome
 } = require('./episodes')
 const {
   getReadsAsArray,
   getReadForUser,
   getReadingMetadata,
   getReadingCaseState,
+  getReadingCaseOutcome,
+  isReadConfirmed,
   isCaseDeferred,
   caseHasReads,
   caseNeedsFirstRead,
@@ -31,7 +34,8 @@ const {
   canUserReadCase,
   userHasReadCase,
   buildRead,
-  withRead
+  withRead,
+  withReadConfirmed
 } = require('./reading-cases')
 
 /************************************************************************
@@ -83,9 +87,8 @@ const writeReading = (data, appointment, userId, reading, sessionId = null) => {
   updateReadingCase(data, appointment.episodeId, updatedCase)
 
   // Note the episode deliberately stays in `reading`. Two opinions and a
-  // computed outcome is not a confirmed result, and there is no step in the
-  // app that confirms one yet - see advanceEpisodeForReadingOutcome in
-  // app/lib/utils/episodes.js, which is what that step should call.
+  // computed outcome is not a confirmed result - the episode moves on when
+  // the reads are confirmed (see confirmUserReadsForSession below).
 
   // If we have session context, remove this appointment from skipped appointments
   // (readingSessions is per-session working data, so in-place edits are fine)
@@ -100,6 +103,102 @@ const writeReading = (data, appointment, userId, reading, sessionId = null) => {
   }
 
   return updatedCase
+}
+
+/**
+ * The user's not-yet-confirmed reads in a session, each with the appointment
+ * and case it belongs to. The session-complete panel's count and the confirm
+ * action both work from this.
+ *
+ * "Not yet confirmed" means not confirmed either way: no explicit confirmedAt,
+ * and the auto-confirmation delay hasn't passed.
+ *
+ * @param {object} data - Session data
+ * @param {string} sessionId - Reading session ID
+ * @param {string} userId - User ID
+ * @returns {Array<{appointment: object, readingCase: object, read: object}>}
+ */
+const getUnconfirmedUserReadsForSession = (data, sessionId, userId) => {
+  const session = data.readingSessions?.[sessionId]
+  if (!session || !userId) return []
+
+  const results = []
+
+  for (const appointmentId of session.appointmentIds || []) {
+    const appointment = data.appointments.find(
+      (candidate) => candidate.id === appointmentId
+    )
+    if (!appointment) continue
+
+    const readingCase = getReadingCase(data, appointment)
+    const read = getReadForUser(readingCase, userId)
+    if (!read) continue
+    if (isReadConfirmed(read, data.settings)) continue
+
+    results.push({ appointment, readingCase, read })
+  }
+
+  return results
+}
+
+/**
+ * Confirm the user's outstanding reads from a session, and settle what each
+ * confirmation makes true: a case whose confirmed reads the rules send to
+ * arbitration gets its release recorded, and a case that concludes moves its
+ * episode on.
+ *
+ * Auto-confirmation (the delay passing) has no moment like this - a case can
+ * conclude by time alone without anything recording the release or advancing
+ * the episode. The state stays honest because it is derived; the acts are only
+ * recorded where there is an act to record.
+ *
+ * @param {object} data - Session data
+ * @param {string} sessionId - Reading session ID
+ * @param {string} userId - User ID
+ * @returns {{confirmedCount: number, releasedCount: number, concludedCount: number}}
+ */
+const confirmUserReadsForSession = (data, sessionId, userId) => {
+  const unconfirmed = getUnconfirmedUserReadsForSession(data, sessionId, userId)
+  const confirmedAt = new Date().toISOString()
+
+  let releasedCount = 0
+  let concludedCount = 0
+
+  for (const { appointment, readingCase } of unconfirmed) {
+    let updatedCase = withReadConfirmed(readingCase, userId, {
+      confirmedAt,
+      confirmedBy: userId
+    })
+
+    const state = getReadingCaseState(updatedCase, data.settings)
+
+    // Both reads confirmed and the rules send it to arbitration: record the
+    // release into the backlog (see isCaseInArbitration)
+    if (
+      state === 'awaiting_arbitration' &&
+      !updatedCase.arbitration?.releasedAt
+    ) {
+      updatedCase = {
+        ...updatedCase,
+        arbitration: { releasedAt: confirmedAt, releasedBy: userId }
+      }
+      releasedCount++
+    }
+
+    updateReadingCase(data, appointment.episodeId, updatedCase)
+
+    // A confirmed conclusion is a real result, so the episode moves on
+    if (state === 'concluded') {
+      advanceEpisodeForReadingOutcome(
+        data,
+        appointment,
+        getReadingCaseOutcome(updatedCase, data.settings)
+      )
+      concludedCount++
+    }
+  }
+
+  return { confirmedCount: unconfirmed.length, releasedCount, concludedCount }
 }
 
 /**
@@ -1468,6 +1567,8 @@ module.exports = {
   // Single appointment
   getAppointmentReadingMetadata,
   writeReading,
+  getUnconfirmedUserReadsForSession,
+  confirmUserReadsForSession,
   getEpisodeReadingStatus,
   getDeferredCases,
   getResolvedDeferrals,

--- a/app/lib/utils/status.js
+++ b/app/lib/utils/status.js
@@ -235,7 +235,7 @@ const STATUS_TAGS = {
     // appointment- and group-level vocabulary.
     'awaiting_first_read': { label: 'Awaiting 1st read', colour: 'grey' },
     'awaiting_second_read': { label: 'Awaiting 2nd read', colour: 'blue' },
-    'awaiting_confirmation': { label: 'Awaiting confirmation', colour: 'yellow' },
+    'awaiting_finalisation': { label: 'Awaiting finalisation', colour: 'yellow' },
     'awaiting_arbitration': { label: 'Awaiting arbitration', colour: 'orange' },
     'in_arbitration': { label: 'In arbitration', colour: 'purple' },
     'concluded': { label: 'Concluded', colour: 'green' },

--- a/app/lib/utils/status.js
+++ b/app/lib/utils/status.js
@@ -235,7 +235,8 @@ const STATUS_TAGS = {
     // appointment- and group-level vocabulary.
     'awaiting_first_read': { label: 'Awaiting 1st read', colour: 'grey' },
     'awaiting_second_read': { label: 'Awaiting 2nd read', colour: 'blue' },
-    'arbitration_required': { label: 'Arbitration required', colour: 'orange' },
+    'awaiting_confirmation': { label: 'Awaiting confirmation', colour: 'yellow' },
+    'awaiting_arbitration': { label: 'Awaiting arbitration', colour: 'orange' },
     'in_arbitration': { label: 'In arbitration', colour: 'purple' },
     'concluded': { label: 'Concluded', colour: 'green' },
     'waiting_for_1st_read': { colour: 'grey' },

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -16,6 +16,8 @@ const {
   canUserReadAppointment,
   userHasReadAppointment,
   writeReading,
+  getUnconfirmedUserReadsForSession,
+  confirmUserReadsForSession,
   getEligibleCandidatesForSession,
   createReadingSession,
   getFirstReadableAppointmentInSession,
@@ -451,8 +453,42 @@ module.exports = (router) => {
       return res.redirect('/reading')
     }
     res.render('reading/no-more-cases', {
-      sessionId
+      sessionId,
+      unconfirmedReadCount: getUnconfirmedUserReadsForSession(
+        data,
+        sessionId,
+        data.currentUser?.id
+      ).length
     })
+  })
+
+  // Confirm the user's reads from this session. Confirmation is what makes a
+  // result real - it releases discordant cases into the arbitration backlog
+  // and moves concluded episodes on.
+  router.post('/reading/session/:sessionId/confirm-reads', (req, res) => {
+    const data = req.session.data
+    const { sessionId } = req.params
+    const session = getReadingSession(data, sessionId)
+    if (!session) {
+      return res.redirect('/reading')
+    }
+
+    const { confirmedCount } = confirmUserReadsForSession(
+      data,
+      sessionId,
+      data.currentUser?.id
+    )
+
+    if (confirmedCount > 0) {
+      req.flash(
+        'success',
+        confirmedCount === 1
+          ? '1 read confirmed'
+          : `${confirmedCount} reads confirmed`
+      )
+    }
+
+    res.redirect(`/reading/session/${sessionId}/no-more-cases`)
   })
 
   // Route for viewing a session with specific view

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -462,10 +462,11 @@ module.exports = (router) => {
     })
   })
 
-  // Confirm the user's reads from this session. Confirmation is what makes a
-  // result real - it releases discordant cases into the arbitration backlog
-  // and moves concluded episodes on.
-  router.post('/reading/session/:sessionId/confirm-reads', (req, res) => {
+  // Confirm the user's reads from this session - linked from the session
+  // overview's session-complete panel, so a plain link can reach it.
+  // Confirmation is what makes a result real: it releases discordant cases
+  // into the arbitration backlog and moves concluded episodes on.
+  router.all('/reading/session/:sessionId/confirm-reads', (req, res) => {
     const data = req.session.data
     const { sessionId } = req.params
     const session = getReadingSession(data, sessionId)
@@ -488,14 +489,13 @@ module.exports = (router) => {
       )
     }
 
-    res.redirect(`/reading/session/${sessionId}/no-more-cases`)
+    res.redirect(`/reading/session/${sessionId}`)
   })
 
   // Route for viewing a session with specific view
   router.get('/reading/session/:sessionId/:view', (req, res) => {
     const data = req.session.data
     const { sessionId, view } = req.params
-    const autoFinaliseWindowMinutes = 30
     const validViews = ['your-reads', 'all-reads']
 
     // Validate view parameter
@@ -552,21 +552,26 @@ module.exports = (router) => {
       session.skippedAppointments || []
     )
 
-    // Countdown starts when the current user records their first opinion in this session
-    const firstUserReadTimestamp = enhancedAppointments
-      .map(
-        (appointment) =>
-          getReadForUser(appointment.readingCase, data.currentUser.id)
-            ?.timestamp
-      )
-      .filter(Boolean)
-      .sort((a, b) => new Date(a) - new Date(b))[0]
-
-    const autoFinaliseAt = firstUserReadTimestamp
-      ? dayjs(firstUserReadTimestamp)
-          .add(autoFinaliseWindowMinutes, 'minute')
-          .toISOString()
-      : dayjs().add(autoFinaliseWindowMinutes, 'minute').toISOString()
+    // The user's reads still awaiting confirmation, and when the first will
+    // confirm itself - drives the session-complete panel's confirm prompt
+    const unconfirmedReads = getUnconfirmedUserReadsForSession(
+      data,
+      sessionId,
+      data.currentUser.id
+    )
+    const confirmationDelayMinutes = parseInt(
+      data.settings?.reading?.confirmationDelay,
+      10
+    )
+    const firstUnconfirmedTimestamp = unconfirmedReads
+      .map(({ read }) => read.timestamp)
+      .sort()[0]
+    const autoConfirmAt =
+      firstUnconfirmedTimestamp && !Number.isNaN(confirmationDelayMinutes)
+        ? dayjs(firstUnconfirmedTimestamp)
+            .add(confirmationDelayMinutes, 'minute')
+            .toISOString()
+        : null
 
     // Clear any lingering opinion banner from a previous session
     delete data.readingOpinionBanner
@@ -592,7 +597,8 @@ module.exports = (router) => {
       readingStatus,
       sessionProgress,
       resumeAppointment,
-      autoFinaliseAt,
+      autoConfirmAt,
+      unconfirmedReadCount: unconfirmedReads.length,
       clinic,
       backlogTotal,
       view: selectedView

--- a/app/routes/reading.js
+++ b/app/routes/reading.js
@@ -16,8 +16,8 @@ const {
   canUserReadAppointment,
   userHasReadAppointment,
   writeReading,
-  getUnconfirmedUserReadsForSession,
-  confirmUserReadsForSession,
+  getUnfinalisedUserReadsForSession,
+  finaliseUserReadsForSession,
   getEligibleCandidatesForSession,
   createReadingSession,
   getFirstReadableAppointmentInSession,
@@ -454,7 +454,7 @@ module.exports = (router) => {
     }
     res.render('reading/no-more-cases', {
       sessionId,
-      unconfirmedReadCount: getUnconfirmedUserReadsForSession(
+      unfinalisedReadCount: getUnfinalisedUserReadsForSession(
         data,
         sessionId,
         data.currentUser?.id
@@ -462,11 +462,11 @@ module.exports = (router) => {
     })
   })
 
-  // Confirm the user's reads from this session - linked from the session
+  // Finalise the user's reads from this session - linked from the session
   // overview's session-complete panel, so a plain link can reach it.
-  // Confirmation is what makes a result real: it releases discordant cases
+  // Finalisation is what makes a result real: it releases discordant cases
   // into the arbitration backlog and moves concluded episodes on.
-  router.all('/reading/session/:sessionId/confirm-reads', (req, res) => {
+  router.all('/reading/session/:sessionId/finalise-reads', (req, res) => {
     const data = req.session.data
     const { sessionId } = req.params
     const session = getReadingSession(data, sessionId)
@@ -474,18 +474,18 @@ module.exports = (router) => {
       return res.redirect('/reading')
     }
 
-    const { confirmedCount } = confirmUserReadsForSession(
+    const { finalisedCount } = finaliseUserReadsForSession(
       data,
       sessionId,
       data.currentUser?.id
     )
 
-    if (confirmedCount > 0) {
+    if (finalisedCount > 0) {
       req.flash(
         'success',
-        confirmedCount === 1
-          ? '1 read confirmed'
-          : `${confirmedCount} reads confirmed`
+        finalisedCount === 1
+          ? '1 read finalised'
+          : `${finalisedCount} reads finalised`
       )
     }
 
@@ -552,24 +552,24 @@ module.exports = (router) => {
       session.skippedAppointments || []
     )
 
-    // The user's reads still awaiting confirmation, and when the first will
-    // confirm itself - drives the session-complete panel's confirm prompt
-    const unconfirmedReads = getUnconfirmedUserReadsForSession(
+    // The user's reads still awaiting finalisation, and when the first will
+    // finalise itself - drives the session-complete panel's finalise prompt
+    const unconfirmedReads = getUnfinalisedUserReadsForSession(
       data,
       sessionId,
       data.currentUser.id
     )
-    const confirmationDelayMinutes = parseInt(
-      data.settings?.reading?.confirmationDelay,
+    const finalisationDelayMinutes = parseInt(
+      data.settings?.reading?.finalisationDelay,
       10
     )
     const firstUnconfirmedTimestamp = unconfirmedReads
       .map(({ read }) => read.timestamp)
       .sort()[0]
-    const autoConfirmAt =
-      firstUnconfirmedTimestamp && !Number.isNaN(confirmationDelayMinutes)
+    const autoFinaliseAt =
+      firstUnconfirmedTimestamp && !Number.isNaN(finalisationDelayMinutes)
         ? dayjs(firstUnconfirmedTimestamp)
-            .add(confirmationDelayMinutes, 'minute')
+            .add(finalisationDelayMinutes, 'minute')
             .toISOString()
         : null
 
@@ -597,8 +597,8 @@ module.exports = (router) => {
       readingStatus,
       sessionProgress,
       resumeAppointment,
-      autoConfirmAt,
-      unconfirmedReadCount: unconfirmedReads.length,
+      autoFinaliseAt,
+      unfinalisedReadCount: unconfirmedReads.length,
       clinic,
       backlogTotal,
       view: selectedView

--- a/app/views/reading/history.html
+++ b/app/views/reading/history.html
@@ -175,8 +175,8 @@
                 {{ "Waiting for 1st read" | toTag }}
               {% elseif caseState == 'awaiting_second_read' %}
                 {{ "Waiting for 2nd read" | toTag }}
-              {% elseif caseState == 'awaiting_confirmation' %}
-                {{ "Awaiting confirmation" | toTag }}
+              {% elseif caseState == 'awaiting_finalisation' %}
+                {{ "Awaiting finalisation" | toTag }}
               {% elseif caseState == 'awaiting_arbitration' or caseState == 'in_arbitration' %}
                 {{ "Arbitration" | toTag }}
               {% else %}

--- a/app/views/reading/history.html
+++ b/app/views/reading/history.html
@@ -175,7 +175,9 @@
                 {{ "Waiting for 1st read" | toTag }}
               {% elseif caseState == 'awaiting_second_read' %}
                 {{ "Waiting for 2nd read" | toTag }}
-              {% elseif caseState == 'arbitration_required' or caseState == 'in_arbitration' %}
+              {% elseif caseState == 'awaiting_confirmation' %}
+                {{ "Awaiting confirmation" | toTag }}
+              {% elseif caseState == 'awaiting_arbitration' or caseState == 'in_arbitration' %}
                 {{ "Arbitration" | toTag }}
               {% else %}
                 {{ (thisCase | getReadingCaseOutcome(data.settings)) | toTag }}

--- a/app/views/reading/no-more-cases.html
+++ b/app/views/reading/no-more-cases.html
@@ -18,13 +18,44 @@
 
     <p>You have given an opinion on all available cases.</p>
 
-    <div class="nhsuk-button-group">
-      {{ button({
-        text: "See session overview",
-        href: "/reading/session/" + sessionId
-      }) }}
-      <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
-    </div>
+    {% if unconfirmedReadCount > 0 %}
+
+      {# Confirmation is what makes a result real - until then a case sits in
+         awaiting_confirmation rather than concluding or going to arbitration #}
+      <p>
+        {% if unconfirmedReadCount == 1 %}
+          Your read from this session is not yet confirmed.
+        {% else %}
+          Your {{ unconfirmedReadCount }} reads from this session are not yet confirmed.
+        {% endif %}
+        Each case moves on – to its result, or to arbitration – once its reads are confirmed.
+      </p>
+
+      <form action="/reading/session/{{ sessionId }}/confirm-reads" method="post">
+        <div class="nhsuk-button-group">
+          {{ button({
+            text: "Confirm read" if unconfirmedReadCount == 1 else "Confirm reads"
+          }) }}
+          {{ button({
+            text: "See session overview",
+            href: "/reading/session/" + sessionId,
+            classes: "nhsuk-button--secondary"
+          }) }}
+          <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
+        </div>
+      </form>
+
+    {% else %}
+
+      <div class="nhsuk-button-group">
+        {{ button({
+          text: "See session overview",
+          href: "/reading/session/" + sessionId
+        }) }}
+        <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
+      </div>
+
+    {% endif %}
 
   </div>
 </div>

--- a/app/views/reading/no-more-cases.html
+++ b/app/views/reading/no-more-cases.html
@@ -19,43 +19,25 @@
     <p>You have given an opinion on all available cases.</p>
 
     {% if unconfirmedReadCount > 0 %}
-
-      {# Confirmation is what makes a result real - until then a case sits in
-         awaiting_confirmation rather than concluding or going to arbitration #}
+      {# Confirmation itself lives on the session overview, behind a chance to
+         review what was read - this page only points there #}
       <p>
         {% if unconfirmedReadCount == 1 %}
           Your read from this session is not yet confirmed.
         {% else %}
           Your {{ unconfirmedReadCount }} reads from this session are not yet confirmed.
         {% endif %}
-        Each case moves on – to its result, or to arbitration – once its reads are confirmed.
+        Review and confirm them from the session overview.
       </p>
-
-      <form action="/reading/session/{{ sessionId }}/confirm-reads" method="post">
-        <div class="nhsuk-button-group">
-          {{ button({
-            text: "Confirm read" if unconfirmedReadCount == 1 else "Confirm reads"
-          }) }}
-          {{ button({
-            text: "See session overview",
-            href: "/reading/session/" + sessionId,
-            classes: "nhsuk-button--secondary"
-          }) }}
-          <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
-        </div>
-      </form>
-
-    {% else %}
-
-      <div class="nhsuk-button-group">
-        {{ button({
-          text: "See session overview",
-          href: "/reading/session/" + sessionId
-        }) }}
-        <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
-      </div>
-
     {% endif %}
+
+    <div class="nhsuk-button-group">
+      {{ button({
+        text: "See session overview",
+        href: "/reading/session/" + sessionId
+      }) }}
+      <a href="/reading" class="nhsuk-link nhsuk-link--no-visited-state">Exit session</a>
+    </div>
 
   </div>
 </div>

--- a/app/views/reading/no-more-cases.html
+++ b/app/views/reading/no-more-cases.html
@@ -18,16 +18,16 @@
 
     <p>You have given an opinion on all available cases.</p>
 
-    {% if unconfirmedReadCount > 0 %}
-      {# Confirmation itself lives on the session overview, behind a chance to
+    {% if unfinalisedReadCount > 0 %}
+      {# Finalisation itself lives on the session overview, behind a chance to
          review what was read - this page only points there #}
       <p>
-        {% if unconfirmedReadCount == 1 %}
-          Your read from this session is not yet confirmed.
+        {% if unfinalisedReadCount == 1 %}
+          Your read from this session is not yet finalised.
         {% else %}
-          Your {{ unconfirmedReadCount }} reads from this session are not yet confirmed.
+          Your {{ unfinalisedReadCount }} reads from this session are not yet finalised.
         {% endif %}
-        Review and confirm them from the session overview.
+        Review and finalise them from the session overview.
       </p>
     {% endif %}
 

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -56,7 +56,11 @@
       </a>
     {% else %}
       {% set sessionCompletePanelHtml %}
-        <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}. The first opinion will be automatically finalised at {{ autoFinaliseAt | formatTime("h:mma") }}. <a href="/reading/clinics" class="nhsuk-link nhsuk-link--reverse">Finalise opinions now</a></p>
+        {% if unconfirmedReadCount > 0 %}
+          <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}.{% if autoConfirmAt %} The first opinion will be confirmed automatically at {{ autoConfirmAt | formatTime("h:mma") }}.{% endif %} <a href="/reading/session/{{ session.id }}/confirm-reads" class="nhsuk-link nhsuk-link--reverse">Confirm opinions now</a></p>
+        {% else %}
+          <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}. All opinions are confirmed.</p>
+        {% endif %}
         <div class="nhsuk-button-group nhsuk-u-margin-bottom-0">
           {% if backlogTotal > 0 %}
             {{ button({

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -355,7 +355,7 @@
           {% set allViewTechnicalRecallAppointments = allViewTechnicalRecallAppointments | push(appointment) %}
         {% elseif appointmentOutcome == 'recall_for_assessment' %}
           {% set allViewRecallForAssessmentAppointments = allViewRecallForAssessmentAppointments | push(appointment) %}
-        {% elseif appointmentState == 'arbitration_required' or appointmentState == 'in_arbitration' %}
+        {% elseif appointmentState == 'awaiting_arbitration' or appointmentState == 'in_arbitration' %}
           {% set allViewArbitrationAppointments = allViewArbitrationAppointments | push(appointment) %}
         {% endif %}
       {% endfor %}
@@ -542,7 +542,9 @@
                   {{ "Waiting for 1st read" | toTag }}
                 {% elseif caseState == 'awaiting_second_read' %}
                   {{ "Waiting for 2nd read" | toTag }}
-                {% elseif caseState == 'arbitration_required' or caseState == 'in_arbitration' %}
+                {% elseif caseState == 'awaiting_confirmation' %}
+                  {{ "Awaiting confirmation" | toTag }}
+                {% elseif caseState == 'awaiting_arbitration' or caseState == 'in_arbitration' %}
                   {{ "Arbitration" | toTag }}
                 {% else %}
                   {{ (appointment.readingCase | getReadingCaseOutcome(data.settings)) | toTag }}

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -56,10 +56,10 @@
       </a>
     {% else %}
       {% set sessionCompletePanelHtml %}
-        {% if unconfirmedReadCount > 0 %}
-          <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}.{% if autoConfirmAt %} The first opinion will be confirmed automatically at {{ autoConfirmAt | formatTime("h:mma") }}.{% endif %} <a href="/reading/session/{{ session.id }}/confirm-reads" class="nhsuk-link nhsuk-link--reverse">Confirm opinions now</a></p>
+        {% if unfinalisedReadCount > 0 %}
+          <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}.{% if autoFinaliseAt %} The first opinion will be finalised automatically at {{ autoFinaliseAt | formatTime("h:mma") }}.{% endif %} <a href="/reading/session/{{ session.id }}/finalise-reads" class="nhsuk-link nhsuk-link--reverse">Finalise opinions now</a></p>
         {% else %}
-          <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}. All opinions are confirmed.</p>
+          <p class="nhsuk-body-m">An opinion has been provided for {{ readingStatus.userReadCount }} {{ "case" | pluralise(readingStatus.userReadCount) }}. All opinions are finalised.</p>
         {% endif %}
         <div class="nhsuk-button-group nhsuk-u-margin-bottom-0">
           {% if backlogTotal > 0 %}
@@ -546,8 +546,8 @@
                   {{ "Waiting for 1st read" | toTag }}
                 {% elseif caseState == 'awaiting_second_read' %}
                   {{ "Waiting for 2nd read" | toTag }}
-                {% elseif caseState == 'awaiting_confirmation' %}
-                  {{ "Awaiting confirmation" | toTag }}
+                {% elseif caseState == 'awaiting_finalisation' %}
+                  {{ "Awaiting finalisation" | toTag }}
                 {% elseif caseState == 'awaiting_arbitration' or caseState == 'in_arbitration' %}
                   {{ "Arbitration" | toTag }}
                 {% else %}

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -193,6 +193,7 @@
     {# Arbitration policy #}
     {{ settingToggle("Arbitration policy", "settings[reading][arbitrationPolicy]", [
       {value: "discordant_only", label: "Discordant reads only"},
+      {value: "all_recalls", label: "All recalls for assessment"},
       {value: "all_non_normal", label: "All non-normal outcomes"}
     ], data.settings.reading.arbitrationPolicy, "discordant_only") }}
 

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -182,13 +182,13 @@
     {% endif %}
     
 
-    {# Read confirmation delay #}
-    {{ settingToggle("Read confirmation", "settings[reading][confirmationDelay]", [
+    {# Read finalisation delay #}
+    {{ settingToggle("Read finalisation", "settings[reading][finalisationDelay]", [
       {value: "0", label: "Immediate"},
       {value: "60", label: "After 1 hour"},
       {value: "1440", label: "After 24 hours"},
       {value: "never", label: "Manual only"}
-    ], data.settings.reading.confirmationDelay, "60") }}
+    ], data.settings.reading.finalisationDelay, "60") }}
 
     {# Arbitration policy #}
     {{ settingToggle("Arbitration policy", "settings[reading][arbitrationPolicy]", [

--- a/app/views/settings.html
+++ b/app/views/settings.html
@@ -182,6 +182,14 @@
     {% endif %}
     
 
+    {# Read confirmation delay #}
+    {{ settingToggle("Read confirmation", "settings[reading][confirmationDelay]", [
+      {value: "0", label: "Immediate"},
+      {value: "60", label: "After 1 hour"},
+      {value: "1440", label: "After 24 hours"},
+      {value: "never", label: "Manual only"}
+    ], data.settings.reading.confirmationDelay, "60") }}
+
     {# Arbitration policy #}
     {{ settingToggle("Arbitration policy", "settings[reading][arbitrationPolicy]", [
       {value: "discordant_only", label: "Discordant reads only"},

--- a/docs/IMAGE-READING-TECHNICAL-SUMMARY.md
+++ b/docs/IMAGE-READING-TECHNICAL-SUMMARY.md
@@ -423,10 +423,10 @@ Templates receive via `res.locals`:
 - `writeReading(data, appointment, userId, reading, sessionId)` - Saves a read onto the appointment's case, settles readNumber and readType, removes from skipped list
 - `areReadsDiscordant(readA, readB)` - Compares opinions, TR views, and RFA breast assessments
 - `willGoToArbitration(readA, readB, settings)` - Policy-aware: always true if discordant; may be true for concordant non-normal depending on `arbitrationPolicy`
-- `getReadingCaseState(readingCase, settings, now)` - Where the case has got to: `awaiting_first_read` | `awaiting_second_read` | `awaiting_confirmation` | `awaiting_arbitration` | `in_arbitration` | `concluded`
+- `getReadingCaseState(readingCase, settings, now)` - Where the case has got to: `awaiting_first_read` | `awaiting_second_read` | `awaiting_finalisation` | `awaiting_arbitration` | `in_arbitration` | `concluded`
 - `getReadingCaseOutcome(readingCase, settings, now)` - What it found: `normal` | `technical_recall` | `recall_for_assessment`, or `null` while reading is still under way. The arbitration read, where there is one, is the deciding read.
-- `isReadConfirmed(read, settings, now)` - Whether a read is confirmed: explicitly (`confirmedAt`) or automatically once `settings.reading.confirmationDelay` minutes have passed since the read (`'0'` immediate, `'never'` manual only)
-- `getReadingCaseStatus(readingCase, settings, now)` - The facts for status displays: `{ state, confirmed, willArbitrate, provisionalOutcome }` - `willArbitrate` is `willGoToArbitration` asked as soon as two reads exist, so "awaiting confirmation, then arbitration" is one state with a destination
+- `isReadFinalised(read, settings, now)` - Whether a read is finalised: explicitly (`finalisedAt`) or automatically once `settings.reading.finalisationDelay` minutes have passed since the read (`'0'` immediate, `'never'` manual only)
+- `getReadingCaseStatus(readingCase, settings, now)` - The facts for status displays: `{ state, finalised, willArbitrate, provisionalOutcome }` - `willArbitrate` is `willGoToArbitration` asked as soon as two reads exist, so "awaiting finalisation, then arbitration" is one state with a destination
 - `getComparisonInfo(appointment, secondReadData, userId, settings)` - Returns comparison data for second reader, or `false` if not applicable
 - `shouldShowComparePage(appointment, secondReadData, userId, settings)` - Boolean: whether to show compare page given timing/filter settings
 

--- a/docs/IMAGE-READING-TECHNICAL-SUMMARY.md
+++ b/docs/IMAGE-READING-TECHNICAL-SUMMARY.md
@@ -423,8 +423,10 @@ Templates receive via `res.locals`:
 - `writeReading(data, appointment, userId, reading, sessionId)` - Saves a read onto the appointment's case, settles readNumber and readType, removes from skipped list
 - `areReadsDiscordant(readA, readB)` - Compares opinions, TR views, and RFA breast assessments
 - `willGoToArbitration(readA, readB, settings)` - Policy-aware: always true if discordant; may be true for concordant non-normal depending on `arbitrationPolicy`
-- `getReadingCaseState(readingCase, settings)` - Where the case has got to: `awaiting_first_read` | `awaiting_second_read` | `arbitration_required` | `in_arbitration` | `concluded`
-- `getReadingCaseOutcome(readingCase, settings)` - What it found: `normal` | `technical_recall` | `recall_for_assessment`, or `null` while reading is still under way. The arbitration read, where there is one, is the deciding read.
+- `getReadingCaseState(readingCase, settings, now)` - Where the case has got to: `awaiting_first_read` | `awaiting_second_read` | `awaiting_confirmation` | `awaiting_arbitration` | `in_arbitration` | `concluded`
+- `getReadingCaseOutcome(readingCase, settings, now)` - What it found: `normal` | `technical_recall` | `recall_for_assessment`, or `null` while reading is still under way. The arbitration read, where there is one, is the deciding read.
+- `isReadConfirmed(read, settings, now)` - Whether a read is confirmed: explicitly (`confirmedAt`) or automatically once `settings.reading.confirmationDelay` minutes have passed since the read (`'0'` immediate, `'never'` manual only)
+- `getReadingCaseStatus(readingCase, settings, now)` - The facts for status displays: `{ state, confirmed, willArbitrate, provisionalOutcome }` - `willArbitrate` is `willGoToArbitration` asked as soon as two reads exist, so "awaiting confirmation, then arbitration" is one state with a destination
 - `getComparisonInfo(appointment, secondReadData, userId, settings)` - Returns comparison data for second reader, or `false` if not applicable
 - `shouldShowComparePage(appointment, secondReadData, userId, settings)` - Boolean: whether to show compare page given timing/filter settings
 

--- a/docs/data-conventions.md
+++ b/docs/data-conventions.md
@@ -194,21 +194,21 @@ Two functions answer the two different questions, and the split matters:
 
 | | |
 |---|---|
-| `getReadingCaseState(case, settings, now)` | where the case has got to: `awaiting_first_read`, `awaiting_second_read`, `awaiting_confirmation`, `awaiting_arbitration`, `in_arbitration`, `concluded` |
+| `getReadingCaseState(case, settings, now)` | where the case has got to: `awaiting_first_read`, `awaiting_second_read`, `awaiting_finalisation`, `awaiting_arbitration`, `in_arbitration`, `concluded` |
 | `getReadingCaseOutcome(case, settings, now)` | what it found — `normal` / `technical_recall` / `recall_for_assessment`, or **null** while reading is still under way |
 
 Two reads are not a result by themselves — the result becomes real once the
-reads are confirmed, explicitly (`read.confirmedAt` / `confirmedBy`) or
-automatically when the confirmation delay passes
-(`settings.reading.confirmationDelay`, minutes as a string, `'0'` immediate,
-`'never'` manual only — see `isReadConfirmed`). Until then the case sits in
-`awaiting_confirmation`. Whether it is heading for arbitration is a **fact
+reads are finalised, explicitly (`read.finalisedAt` / `finalisedBy`) or
+automatically when the finalisation delay passes
+(`settings.reading.finalisationDelay`, minutes as a string, `'0'` immediate,
+`'never'` manual only — see `isReadFinalised`). Until then the case sits in
+`awaiting_finalisation`. Whether it is heading for arbitration is a **fact
 about the case, not a separate state**: `getReadingCaseStatus(case, settings,
-now)` returns `{ state, confirmed, willArbitrate, provisionalOutcome }`, so
-"awaiting confirmation, then arbitration" is one state with a destination.
+now)` returns `{ state, finalised, willArbitrate, provisionalOutcome }`, so
+"awaiting finalisation, then arbitration" is one state with a destination.
 
 `awaiting_arbitration` and `in_arbitration` are deliberately different:
-confirmed discordant reads put a case in the arbitration backlog, but
+finalised discordant reads put a case in the arbitration backlog, but
 `in_arbitration` is reserved for a future claim/lock while someone actively
 arbitrates it — nothing sets it yet. The state exists so the vocabulary is
 whole rather than growing a value later across every call site. Deferral works

--- a/docs/data-conventions.md
+++ b/docs/data-conventions.md
@@ -194,15 +194,25 @@ Two functions answer the two different questions, and the split matters:
 
 | | |
 |---|---|
-| `getReadingCaseState(case, settings)` | where the case has got to: `awaiting_first_read`, `awaiting_second_read`, `arbitration_required`, `in_arbitration`, `concluded` |
-| `getReadingCaseOutcome(case, settings)` | what it found — `normal` / `technical_recall` / `recall_for_assessment`, or **null** while reading is still under way |
+| `getReadingCaseState(case, settings, now)` | where the case has got to: `awaiting_first_read`, `awaiting_second_read`, `awaiting_confirmation`, `awaiting_arbitration`, `in_arbitration`, `concluded` |
+| `getReadingCaseOutcome(case, settings, now)` | what it found — `normal` / `technical_recall` / `recall_for_assessment`, or **null** while reading is still under way |
 
-`arbitration_required` and `in_arbitration` are deliberately different. Reads
-disagreeing is what makes arbitration *necessary*; a case only becomes
-arbitratable once someone releases it into arbitration. Nothing performs that
-release yet, so no case reaches `in_arbitration` today — the state exists so the
-vocabulary is whole rather than growing a value later across every call site.
-Deferral works the same way already: the act is recorded
+Two reads are not a result by themselves — the result becomes real once the
+reads are confirmed, explicitly (`read.confirmedAt` / `confirmedBy`) or
+automatically when the confirmation delay passes
+(`settings.reading.confirmationDelay`, minutes as a string, `'0'` immediate,
+`'never'` manual only — see `isReadConfirmed`). Until then the case sits in
+`awaiting_confirmation`. Whether it is heading for arbitration is a **fact
+about the case, not a separate state**: `getReadingCaseStatus(case, settings,
+now)` returns `{ state, confirmed, willArbitrate, provisionalOutcome }`, so
+"awaiting confirmation, then arbitration" is one state with a destination.
+
+`awaiting_arbitration` and `in_arbitration` are deliberately different:
+confirmed discordant reads put a case in the arbitration backlog, but
+`in_arbitration` is reserved for a future claim/lock while someone actively
+arbitrates it — nothing sets it yet. The state exists so the vocabulary is
+whole rather than growing a value later across every call site. Deferral works
+the same way already: the act is recorded
 (`deferral: { deferredAt, deferredBy, reason }`) and `isCaseDeferred` reads the
 state back from its presence.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,7 +38,7 @@ name, and the skip list is printed on every run so it stays visible.
 
 **Journeys** (`tests/e2e/`) drive real flows in Chromium via Playwright. This is
 the only layer that exercises POST handlers, session state and the client-side
-JavaScript. Seven journeys:
+JavaScript. Eight journeys:
 
 - a screening appointment recording medical history and a symptom, from
   check-in to completion
@@ -48,6 +48,8 @@ JavaScript. Seven journeys:
 - a technical recall, through its views-to-retake form and the review step
 - deferring a case, then unflagging it from the deferred cases page
 - a second reader reaching the comparison page and keeping their opinion
+- a concordant second read taking a case to its concluded outcome, checked on
+  the case view
 - a lazy session staying lazy across leaving and resuming it
 
 Between them the reading journeys cover all four ways a reader can leave a case

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,7 +38,7 @@ name, and the skip list is printed on every run so it stays visible.
 
 **Journeys** (`tests/e2e/`) drive real flows in Chromium via Playwright. This is
 the only layer that exercises POST handlers, session state and the client-side
-JavaScript. Eight journeys:
+JavaScript. Nine journeys:
 
 - a screening appointment recording medical history and a symptom, from
   check-in to completion
@@ -50,6 +50,8 @@ JavaScript. Eight journeys:
 - a second reader reaching the comparison page and keeping their opinion
 - a concordant second read taking a case to its concluded outcome, checked on
   the case view
+- confirming a read from the session-complete panel, settling a case that was
+  awaiting confirmation
 - a lazy session staying lazy across leaving and resuming it
 
 Between them the reading journeys cover all four ways a reader can leave a case

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,7 +50,7 @@ JavaScript. Nine journeys:
 - a second reader reaching the comparison page and keeping their opinion
 - a concordant second read taking a case to its concluded outcome, checked on
   the case view
-- confirming a read from the session-complete panel, settling a case that was
+- confirming a read from the session overview, settling a case that was
   awaiting confirmation
 - a lazy session staying lazy across leaving and resuming it
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,8 +50,8 @@ JavaScript. Nine journeys:
 - a second reader reaching the comparison page and keeping their opinion
 - a concordant second read taking a case to its concluded outcome, checked on
   the case view
-- confirming a read from the session overview, settling a case that was
-  awaiting confirmation
+- finalising a read from the session overview, settling a case that was
+  awaiting finalisation
 - a lazy session staying lazy across leaving and resuming it
 
 Between them the reading journeys cover all four ways a reader can leave a case

--- a/scripts/route-sweep.js
+++ b/scripts/route-sweep.js
@@ -40,6 +40,7 @@ const skippedPaths = [
   { pattern: /\/undo-check-in$/, reason: 'reverses a check-in' },
   { pattern: /\/complete$/, reason: 'completes an appointment' },
   { pattern: /\/save-opinion$/, reason: 'saves a reading opinion' },
+  { pattern: /\/confirm-reads$/, reason: 'confirms reading opinions' },
   {
     pattern: /^\/reading\/create-session/,
     reason: 'creates a reading session'

--- a/scripts/route-sweep.js
+++ b/scripts/route-sweep.js
@@ -40,7 +40,7 @@ const skippedPaths = [
   { pattern: /\/undo-check-in$/, reason: 'reverses a check-in' },
   { pattern: /\/complete$/, reason: 'completes an appointment' },
   { pattern: /\/save-opinion$/, reason: 'saves a reading opinion' },
-  { pattern: /\/confirm-reads$/, reason: 'confirms reading opinions' },
+  { pattern: /\/finalise-reads$/, reason: 'finalises reading opinions' },
   {
     pattern: /^\/reading\/create-session/,
     reason: 'creates a reading session'

--- a/tests/e2e/appointment.spec.js
+++ b/tests/e2e/appointment.spec.js
@@ -93,13 +93,15 @@ test.describe('Screening appointment', () => {
     await openSection(page, 'Medical history')
 
     const historyModal = await clickToOpenModal(page, 'Breast cancer')
-    // The checkbox can sit below the fold of the modal, and check() won't
-    // scroll a covered NHS-styled input into view by itself
+    // Under a loaded full-suite run Playwright intermittently reports this
+    // checkbox "outside of the viewport" inside the transformed dialog and
+    // retries forever (see revealInModal's note). A DOM-level click sidesteps
+    // the geometry, and the assertion keeps it honest.
     const cancerLocation = historyModal.locator(
       'input[name="appointment[medicalHistoryTemp][cancerLocation]"][value="Right breast"]'
     )
-    await revealInModal(cancerLocation)
-    await cancerLocation.check()
+    await cancerLocation.evaluate((element) => element.click())
+    await expect(cancerLocation).toBeChecked()
     await historyModal.getByRole('button', { name: 'Save' }).click()
     await expectModalClosed(historyModal)
 

--- a/tests/e2e/appointment.spec.js
+++ b/tests/e2e/appointment.spec.js
@@ -93,11 +93,13 @@ test.describe('Screening appointment', () => {
     await openSection(page, 'Medical history')
 
     const historyModal = await clickToOpenModal(page, 'Breast cancer')
-    await historyModal
-      .locator(
-        'input[name="appointment[medicalHistoryTemp][cancerLocation]"][value="Right breast"]'
-      )
-      .check()
+    // The checkbox can sit below the fold of the modal, and check() won't
+    // scroll a covered NHS-styled input into view by itself
+    const cancerLocation = historyModal.locator(
+      'input[name="appointment[medicalHistoryTemp][cancerLocation]"][value="Right breast"]'
+    )
+    await revealInModal(cancerLocation)
+    await cancerLocation.check()
     await historyModal.getByRole('button', { name: 'Save' }).click()
     await expectModalClosed(historyModal)
 

--- a/tests/e2e/helpers/seed-data.js
+++ b/tests/e2e/helpers/seed-data.js
@@ -76,7 +76,60 @@ const findTodayAppointment = ({ status = 'scheduled', index = 0 } = {}) => {
   }
 }
 
+/**
+ * Find a reading case holding exactly one seeded read, ready for the current
+ * user to give the second.
+ *
+ * The first read must be someone else's (nobody reads the same case twice) and
+ * carry the requested opinion, so a test can mirror it and land a concordant
+ * pair. Skips deferred cases and appointments awaiting priors, which the
+ * reading routes would bounce to the existing-read page.
+ *
+ * @param {object} [options] - Options
+ * @param {string} [options.firstOpinion] - Opinion the seeded read must carry
+ * @returns {{episode: object, readingCase: object, appointment: object}} The subject
+ */
+const findCaseAwaitingSecondRead = ({ firstOpinion = 'normal' } = {}) => {
+  // The journeys run as the default user, users[0] - the same pick
+  // session-data-defaults.js makes for currentUser
+  const users = require('../../../app/data/users')
+  const currentUserId = users[0].id
+
+  const episodes = readCollection('episodes.json', 'episodes')
+  const appointments = readCollection('appointments.json', 'appointments')
+
+  for (const episode of episodes) {
+    for (const readingCase of episode.readingCases || []) {
+      const reads = readingCase.reads || []
+      if (reads.length !== 1) continue
+      if (reads[0].opinion !== firstOpinion) continue
+      if (reads[0].readerId === currentUserId) continue
+      if (readingCase.deferral) continue
+
+      const appointment = appointments.find(
+        (item) => item.id === readingCase.appointmentId
+      )
+      if (!appointment) continue
+
+      const priorsPending = (appointment.previousMammograms || []).some(
+        (mammogram) =>
+          mammogram.requestStatus === 'pending' ||
+          mammogram.requestStatus === 'requested'
+      )
+      if (priorsPending) continue
+
+      return { episode, readingCase, appointment }
+    }
+  }
+
+  throw new Error(
+    `Seed data has no case awaiting a second read with a "${firstOpinion}" ` +
+      'first read from another reader. Regenerate the data with "npm run generate".'
+  )
+}
+
 module.exports = {
   readCollection,
-  findTodayAppointment
+  findTodayAppointment,
+  findCaseAwaitingSecondRead
 }

--- a/tests/e2e/helpers/settings.js
+++ b/tests/e2e/helpers/settings.js
@@ -41,9 +41,9 @@ const readingSettings = {
   // more than a smoke test should take on - see notes in reading.spec.js.
   'settings[reading][annotationsMode]': 'without-images',
   'settings[reading][secondReaderComparison]': 'off',
-  // Reads confirm as soon as they are saved, so journeys see settled states
-  // rather than cases waiting out the confirmation delay
-  'settings[reading][confirmationDelay]': '0'
+  // Reads finalise as soon as they are saved, so journeys see settled states
+  // rather than cases waiting out the finalisation delay
+  'settings[reading][finalisationDelay]': '0'
 }
 
 /**

--- a/tests/e2e/helpers/settings.js
+++ b/tests/e2e/helpers/settings.js
@@ -40,7 +40,10 @@ const readingSettings = {
   // The image-marking modes need pixel-accurate clicks on a canvas, which is
   // more than a smoke test should take on - see notes in reading.spec.js.
   'settings[reading][annotationsMode]': 'without-images',
-  'settings[reading][secondReaderComparison]': 'off'
+  'settings[reading][secondReaderComparison]': 'off',
+  // Reads confirm as soon as they are saved, so journeys see settled states
+  // rather than cases waiting out the confirmation delay
+  'settings[reading][confirmationDelay]': '0'
 }
 
 /**

--- a/tests/e2e/reading.spec.js
+++ b/tests/e2e/reading.spec.js
@@ -318,10 +318,12 @@ test.describe('Image reading', () => {
     await expect(summaryRow('Outcome')).toContainText('Normal')
   })
 
-  test('confirms reads from the session-complete panel', async ({ page }) => {
-    // With a confirmation delay, a fresh read sits unconfirmed and the
-    // session-complete panel offers to confirm it. The seeded first read is
-    // hours old, so it has auto-confirmed - confirming ours settles the case.
+  test('confirms reads from the session overview', async ({ page }) => {
+    // With a confirmation delay, a fresh read sits unconfirmed. Confirmation
+    // deliberately lives on the session overview - behind a chance to review
+    // what was read - not on the session-complete page, which only points
+    // there. The seeded first read is hours old, so it has auto-confirmed -
+    // confirming ours settles the case.
     await pinSettings(page, {
       ...readingSettings,
       'settings[reading][confirmationDelay]': '60'
@@ -337,15 +339,19 @@ test.describe('Image reading', () => {
 
     await recordNormal(page)
 
-    // The only case is read, so the session is complete - with the read
-    // unconfirmed, the panel says so and offers to confirm
+    // The only case is read, so the session is complete - the page notes the
+    // unconfirmed read but sends the reader to the overview to confirm it
     await expect(page).toHaveURL(/\/no-more-cases/)
     await expect(page.getByText('not yet confirmed')).toBeVisible()
-    await page.getByRole('button', { name: 'Confirm read' }).click()
+    await page.getByRole('button', { name: 'See session overview' }).click()
 
-    // Confirmed: the panel reverts to the plain session-complete state
-    await expect(page).toHaveURL(/\/no-more-cases/)
-    await expect(page.getByText('not yet confirmed')).toBeHidden()
+    // The session-complete panel carries the auto-confirmation time and the
+    // confirm action
+    await expect(page.getByText('confirmed automatically')).toBeVisible()
+    await page.getByRole('link', { name: 'Confirm opinions now' }).click()
+
+    // Confirmed: the prompt gives way to the settled state
+    await expect(page.getByText('All opinions are confirmed')).toBeVisible()
 
     // Both reads now confirmed, so the case has settled - concluded if the
     // reads agreed, awaiting arbitration if not

--- a/tests/e2e/reading.spec.js
+++ b/tests/e2e/reading.spec.js
@@ -318,15 +318,15 @@ test.describe('Image reading', () => {
     await expect(summaryRow('Outcome')).toContainText('Normal')
   })
 
-  test('confirms reads from the session overview', async ({ page }) => {
-    // With a confirmation delay, a fresh read sits unconfirmed. Confirmation
+  test('finalises reads from the session overview', async ({ page }) => {
+    // With a finalisation delay, a fresh read sits unfinalised. Finalisation
     // deliberately lives on the session overview - behind a chance to review
     // what was read - not on the session-complete page, which only points
-    // there. The seeded first read is hours old, so it has auto-confirmed -
-    // confirming ours settles the case.
+    // there. The seeded first read is hours old, so it has auto-finalised -
+    // finalising ours settles the case.
     await pinSettings(page, {
       ...readingSettings,
-      'settings[reading][confirmationDelay]': '60'
+      'settings[reading][finalisationDelay]': '60'
     })
 
     await page.goto(
@@ -340,20 +340,20 @@ test.describe('Image reading', () => {
     await recordNormal(page)
 
     // The only case is read, so the session is complete - the page notes the
-    // unconfirmed read but sends the reader to the overview to confirm it
+    // unfinalised read but sends the reader to the overview to finalise it
     await expect(page).toHaveURL(/\/no-more-cases/)
-    await expect(page.getByText('not yet confirmed')).toBeVisible()
+    await expect(page.getByText('not yet finalised')).toBeVisible()
     await page.getByRole('button', { name: 'See session overview' }).click()
 
-    // The session-complete panel carries the auto-confirmation time and the
-    // confirm action
-    await expect(page.getByText('confirmed automatically')).toBeVisible()
-    await page.getByRole('link', { name: 'Confirm opinions now' }).click()
+    // The session-complete panel carries the auto-finalisation time and the
+    // finalise action
+    await expect(page.getByText('finalised automatically')).toBeVisible()
+    await page.getByRole('link', { name: 'Finalise opinions now' }).click()
 
-    // Confirmed: the prompt gives way to the settled state
-    await expect(page.getByText('All opinions are confirmed')).toBeVisible()
+    // Finalised: the prompt gives way to the settled state
+    await expect(page.getByText('All opinions are finalised')).toBeVisible()
 
-    // Both reads now confirmed, so the case has settled - concluded if the
+    // Both reads now finalised, so the case has settled - concluded if the
     // reads agreed, awaiting arbitration if not
     const episodes = readCollection('episodes.json', 'episodes')
     const readingCase = episodes

--- a/tests/e2e/reading.spec.js
+++ b/tests/e2e/reading.spec.js
@@ -14,7 +14,10 @@
 
 const { test, expect } = require('./helpers/fixtures')
 const { pinSettings, readingSettings } = require('./helpers/settings')
-const { findCaseAwaitingSecondRead } = require('./helpers/seed-data')
+const {
+  findCaseAwaitingSecondRead,
+  readCollection
+} = require('./helpers/seed-data')
 const {
   clickToOpenModal,
   clickLinkToOpenModal,
@@ -313,6 +316,49 @@ test.describe('Image reading', () => {
     await expect(summaryRow('State')).toContainText('Concluded')
     await expect(summaryRow('Reads')).toContainText('2')
     await expect(summaryRow('Outcome')).toContainText('Normal')
+  })
+
+  test('confirms reads from the session-complete panel', async ({ page }) => {
+    // With a confirmation delay, a fresh read sits unconfirmed and the
+    // session-complete panel offers to confirm it. The seeded first read is
+    // hours old, so it has auto-confirmed - confirming ours settles the case.
+    await pinSettings(page, {
+      ...readingSettings,
+      'settings[reading][confirmationDelay]': '60'
+    })
+
+    await page.goto(
+      '/reading/create-session?type=second_reads&limit=1&lazy=false'
+    )
+    await expect(page).toHaveURL(/\/reading\/session\/[^/]+\/appointments\//)
+
+    // The case in hand, for finding its case view afterwards
+    const appointmentId = page.url().split('/appointments/')[1].split('/')[0]
+
+    await recordNormal(page)
+
+    // The only case is read, so the session is complete - with the read
+    // unconfirmed, the panel says so and offers to confirm
+    await expect(page).toHaveURL(/\/no-more-cases/)
+    await expect(page.getByText('not yet confirmed')).toBeVisible()
+    await page.getByRole('button', { name: 'Confirm read' }).click()
+
+    // Confirmed: the panel reverts to the plain session-complete state
+    await expect(page).toHaveURL(/\/no-more-cases/)
+    await expect(page.getByText('not yet confirmed')).toBeHidden()
+
+    // Both reads now confirmed, so the case has settled - concluded if the
+    // reads agreed, awaiting arbitration if not
+    const episodes = readCollection('episodes.json', 'episodes')
+    const readingCase = episodes
+      .flatMap((episode) => episode.readingCases || [])
+      .find((candidate) => candidate.appointmentId === appointmentId)
+
+    await page.goto(`/reading/cases/${readingCase.id}`)
+    const stateRow = page.locator('.nhsuk-summary-list__row', {
+      hasText: 'State'
+    })
+    await expect(stateRow).toContainText(/Concluded|Awaiting arbitration/)
   })
 
   test('shows the second reader the first read before saving', async ({

--- a/tests/e2e/reading.spec.js
+++ b/tests/e2e/reading.spec.js
@@ -2,7 +2,8 @@
 //
 // Journeys through image reading. Between them they cover the four ways a
 // reader can leave a case - normal, recall for assessment, technical recall,
-// and deferral - plus the second reader's comparison step.
+// and deferral - plus the second reader's comparison step, and a concordant
+// second read taking a case to its concluded outcome.
 //
 // Sessions are created with an explicit limit so each test reads a known,
 // small number of cases rather than working through a default-sized session.
@@ -13,6 +14,7 @@
 
 const { test, expect } = require('./helpers/fixtures')
 const { pinSettings, readingSettings } = require('./helpers/settings')
+const { findCaseAwaitingSecondRead } = require('./helpers/seed-data')
 const {
   clickToOpenModal,
   clickLinkToOpenModal,
@@ -268,6 +270,49 @@ test.describe('Image reading', () => {
 
     await page.goto(`/reading/session/${sessionId}/all-reads`)
     await expect(caseRows).toHaveCount(rowsBefore)
+  })
+
+  test('concludes a case after a concordant second read', async ({ page }) => {
+    // The safety net under the reading state derivation: a case with one
+    // seeded normal read gets a matching second read, and the case view then
+    // shows it concluded with a normal outcome. Anything that breaks
+    // getReadingCaseState or getReadingCaseOutcome shows up here first.
+    await pinSettings(page, {
+      ...readingSettings,
+      // Concordant reads conclude without arbitration
+      'settings[reading][arbitrationPolicy]': 'discordant_only'
+    })
+
+    // Picked from the seed data so the first read's opinion is known - the
+    // second read mirrors it, making the pair concordant
+    const { readingCase, appointment } = findCaseAwaitingSecondRead({
+      firstOpinion: 'normal'
+    })
+
+    await page.goto(
+      '/reading/create-session?type=second_reads&limit=100&lazy=false'
+    )
+    await expect(page).toHaveURL(/\/reading\/session\/[^/]+\/appointments\//)
+    const sessionId = page.url().split('/session/')[1].split('/')[0]
+
+    // Go straight to the chosen case rather than whichever the session leads
+    // with - the appointment routes resolve any readable case by id
+    await page.goto(`/reading/session/${sessionId}/appointments/${appointment.id}`)
+    await recordNormal(page)
+
+    // Saving moves on to another case (or session complete) - wait for that
+    // before leaving, so the save has landed
+    await expect(page).not.toHaveURL(new RegExp(appointment.id))
+
+    // The case view derives state and outcome from the reads
+    await page.goto(`/reading/cases/${readingCase.id}`)
+
+    const summaryRow = (label) =>
+      page.locator('.nhsuk-summary-list__row', { hasText: label })
+
+    await expect(summaryRow('State')).toContainText('Concluded')
+    await expect(summaryRow('Reads')).toContainText('2')
+    await expect(summaryRow('Outcome')).toContainText('Normal')
   })
 
   test('shows the second reader the first read before saving', async ({


### PR DESCRIPTION
First part of arbitration - after reading cases have an hour before they get auto-finalised. Users can also finalise early from the session overview once they have completed their session.
