### PR TITLE
Use reversed name more selectively

### DIFF
--- a/app/lib/utils/participants.js
+++ b/app/lib/utils/participants.js
@@ -35,7 +35,7 @@ const getFullName = (participant) => {
   if (!participant?.demographicInformation) return ''
   const { firstName, middleName, lastName } = participant.demographicInformation
   return nunjucksSafe(
-    [`${lastName.toUpperCase()},`, firstName, middleName].filter(Boolean).join(' ')
+    [firstName, middleName, lastName].filter(Boolean).join(' ')
   )
 }
 
@@ -62,7 +62,9 @@ const getFirstNames = (participant) => {
 const getFullNameReversed = (participant) => {
   if (!participant?.demographicInformation) return ''
   const { firstName, middleName, lastName } = participant.demographicInformation
-  return [`${lastName.toUpperCase()},`, firstName, middleName].filter(Boolean).join(' ')
+  return nunjucksSafe(
+    [`${lastName.toUpperCase()},`, firstName, middleName].filter(Boolean).join(' ')
+  )
 }
 
 /**
@@ -74,7 +76,7 @@ const getFullNameReversed = (participant) => {
 const getShortName = (participant) => {
   if (!participant?.demographicInformation) return ''
   const { firstName, lastName } = participant.demographicInformation
-  return nunjucksSafe(`${lastName.toUpperCase()}, ${firstName}`)
+  return nunjucksSafe(`${firstName} ${lastName}`)
 }
 
 /**

--- a/app/views/_includes/appointment-status-bar.njk
+++ b/app/views/_includes/appointment-status-bar.njk
@@ -79,7 +79,7 @@
 
 {# Full name with age #}
 {% set nameWithAge %}
-  {{ participant | getFullName }}
+  {{ participant | getFullNameReversed }}
 
 {% endset %}
 {% set participantRowItems = participantRowItems | push({

--- a/app/views/_includes/appointment/appointment-header.njk
+++ b/app/views/_includes/appointment/appointment-header.njk
@@ -36,7 +36,7 @@
     <span class="nhsuk-caption-l">
       {{ clinic.clinicType | sentenceCase }} appointment
     </span>
-    {{ participant | getFullName | safe }}
+    {{ participant | getFullNameReversed }}
   </h1>
 
   <div class="app-header-with-status__status-tag">

--- a/app/views/_includes/reading/reading-status-bar.njk
+++ b/app/views/_includes/reading/reading-status-bar.njk
@@ -65,7 +65,7 @@
 
   {# Full name #}
   {% set nameWithAge %}
-    {{ participant | getFullName }}
+    {{ participant | getFullNameReversed }}
   {% endset %}
   {% set participantRowItems = participantRowItems | push({
     html: "<strong>" + nameWithAge + "</strong>"

--- a/app/views/_includes/summary-lists/rows/full-name.njk
+++ b/app/views/_includes/summary-lists/rows/full-name.njk
@@ -5,7 +5,7 @@
     text: "Full name"
   },
   value: {
-    text: participant | getFullName
+    text: participant | getFullNameReversed
   },
   anyRowHasActions: allowEdits
 } | handleSummaryListMissingInformation(showNotProvidedText) %}

--- a/app/views/_templates/layout-reading.html
+++ b/app/views/_templates/layout-reading.html
@@ -158,7 +158,7 @@
   {% if isReadingWorkflow and participant %}
     {% set mammogramImages = getImagesForAppointment(appointmentId, "diagrams", { appointment: appointment }) %}
     <meta name="mammogram-appointment-id" content="{{ appointmentId }}">
-    <meta name="mammogram-participant-name" content="{{ participant | getFullName }}">
+    <meta name="mammogram-participant-name" content="{{ participant | getFullNameReversed }}">
     <meta name="mammogram-nhs-number" content="{{ participant.medicalInformation.nhsNumber | formatNhsNumber }}">
     <meta name="mammogram-sx-number" content="{{ participant.sxNumber }}">
     <meta name="mammogram-date-of-birth" content="{{ participant.demographicInformation.dateOfBirth | formatDate }} ({{ participant | getAge }} years)">

--- a/app/views/clinics/show.html
+++ b/app/views/clinics/show.html
@@ -162,9 +162,9 @@
             <p class="nhsuk-u-margin-bottom-1 nhsuk-u-font-weight-bold">
               {# <a href="/clinics/{{ clinicId }}/appointments/{{ appointment.id }}/start" class="nhsuk-link"> #}
                 {# <a href="{{ participantHref }}" class="nhsuk-link">
-                  {{ participant | getFullName }}
+                  {{ participant | getFullNameReversed }}
                 </a> #}
-                {{ participant | getFullName }}
+                {{ participant | getFullNameReversed }}
             </p>
             <p class="nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-0">
               {# DOB: {{ participant.demographicInformation.dateOfBirth | formatDate }} ({{

--- a/app/views/episodes/index.html
+++ b/app/views/episodes/index.html
@@ -57,7 +57,7 @@
           <tr class="nhsuk-table__row">
             <td class="nhsuk-table__cell">
               <a href="/participants/{{ row.episode.participantId }}">
-                {{ row.participant | getFullName }}
+                {{ row.participant | getFullNameReversed }}
               </a>
             </td>
             <td class="nhsuk-table__cell">

--- a/app/views/episodes/show.html
+++ b/app/views/episodes/show.html
@@ -13,7 +13,7 @@
       },
       {
         href: participantUrl,
-        text: participant | getFullName
+        text: participant | getFullNameReversed
       }
     ]
   }) }}

--- a/app/views/participants/index.html
+++ b/app/views/participants/index.html
@@ -67,8 +67,7 @@
                 {{ participant.demographicInformation.dateOfBirth | formatRelativeDate(true) }} old
               {% endset %}
               <a href="/participants/{{ participant.id }}" class="nhsuk-link">
-                {# {{ participant | getFullNameReversed }} #}
-                {{ participant | getFullName }}
+                {{ participant | getFullNameReversed }}
               </a><br>
               {{ dob | asHint }}
             </td>

--- a/app/views/reading/cases.html
+++ b/app/views/reading/cases.html
@@ -115,7 +115,7 @@
           <tr class="nhsuk-table__row">
             <td class="nhsuk-table__cell">
               <a href="/reading/cases/{{ row.readingCase.id }}" class="nhsuk-link--no-visited-state">
-                {{ row.participant | getFullName }}
+                {{ row.participant | getFullNameReversed }}
               </a>
               {% if row.isDeferred %}
                 <br>{{ "Deferred" | toTag }}

--- a/app/views/reading/history.html
+++ b/app/views/reading/history.html
@@ -137,10 +137,10 @@
             <td>
               {% if reading.sessionId %}
               <a href="/reading/session/{{ reading.sessionId or 'clinic' }}/appointments/{{ reading.appointmentId }}">
-                {{ reading.participant | getFullName }}
+                {{ reading.participant | getFullNameReversed }}
               </a>
               {% else %}
-                {{ reading.participant | getFullName }}
+                {{ reading.participant | getFullNameReversed }}
               {% endif %}
 
 

--- a/app/views/reading/priors.html
+++ b/app/views/reading/priors.html
@@ -108,7 +108,7 @@
                 {% set thisParticipant = data | getParticipant(thisAppointment.participantId) %}
                 <td>
                   <a href="/clinics/{{ thisAppointment.clinicId }}/appointments/{{ thisAppointment.id }}">
-                    {{ thisParticipant | getFullName }}
+                    {{ thisParticipant | getFullNameReversed }}
                   </a>
                 </td>
 

--- a/app/views/reading/session.html
+++ b/app/views/reading/session.html
@@ -254,7 +254,7 @@
                 {% if appointment.medicalInformation.symptoms | length %}
                   <span class="app-reading-case-tag">{{ "Has symptoms" | toTag }}</span>
                 {% endif %}
-                <a href="{{ readingHref }}">{{ appointment.participant | getFullName }}</a>
+                <a href="{{ readingHref }}">{{ appointment.participant | getFullNameReversed }}</a>
 
                 <br>
                 <span class="nhsuk-u-secondary-text-colour app-nowrap nhsuk-body-s">
@@ -451,7 +451,7 @@
                 {% if appointment.medicalInformation.symptoms | length %}
                   <span class="app-reading-case-tag">{{ "Has symptoms" | toTag }}</span>
                 {% endif %}
-                <a href="{{ readingHref }}">{{ appointment.participant | getFullName }}</a>
+                <a href="{{ readingHref }}">{{ appointment.participant | getFullNameReversed }}</a>
 
                 {% if appointment | awaitingPriors %}
                 <br>


### PR DESCRIPTION
## Description

Quick patch on #395. The app uses the user's full name in body copy often in question legends, and surname first there looks weird. This reverts the prior change and selectively applies where the full name is used on its own - data display, headings, summary lists, tables.